### PR TITLE
Add fault injection helpers

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -26,6 +26,19 @@
             border-radius: 5px;
             z-index: 1000; /* 캔버스 위에 표시되도록 */
         }
+        #debugInfo button {
+            background-color: #f44336; /* 빨간색 버튼 */
+            color: white;
+            padding: 8px 12px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 5px;
+            font-size: 0.9em;
+        }
+        #debugInfo button:hover {
+            background-color: #d32f2f;
+        }
         canvas {
             border: 2px solid #fff;
             background-color: #000;
@@ -36,15 +49,19 @@
     <div id="debugInfo">
         <h3>디버그 정보</h3>
         <p>FPS: <span id="fpsCounter">--</span></p>
-        </div>
+        <h4>결함 주입 테스트</h4>
+        <button id="injectRendererFaultBtn">렌더러 결함 주입</button>
+        <button id="injectUpdateFaultBtn">Update 함수 결함 주입</button>
+        <button id="injectDrawFaultBtn">Draw 함수 결함 주입</button>
+    </div>
     <canvas id="gameCanvas"></canvas>
     <script type="module">
         // Debug 페이지에서는 main.js의 일부 기능을 확장하여 사용합니다.
         // GameLoop와 Renderer 모듈을 불러옵니다.
         import { Renderer } from './js/Renderer.js';
         import { GameLoop } from './js/GameLoop.js';
-        // 새로 만든 엔진 테스트 모듈을 불러옵니다.
-        import { runEngineTests } from './js/tests/engineTests.js';
+        // 엔진 테스트 모듈과 결함 주입 테스트 함수들을 불러옵니다.
+        import { runEngineTests, injectRendererFault, injectGameLoopFault, getFaultFlags, setFaultFlag } from './js/tests/engineTests.js';
 
         document.addEventListener('DOMContentLoaded', () => {
             const renderer = new Renderer('gameCanvas');
@@ -58,13 +75,35 @@
             let lastFpsTime = 0;
             const fpsCounterElement = document.getElementById('fpsCounter');
 
+            // 결함 주입 버튼 이벤트 리스너 설정
+            document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
+                injectRendererFault(renderer);
+            });
+            document.getElementById('injectUpdateFaultBtn').addEventListener('click', () => {
+                injectGameLoopFault('update', setFaultFlag);
+            });
+            document.getElementById('injectDrawFaultBtn').addEventListener('click', () => {
+                injectGameLoopFault('draw', setFaultFlag);
+            });
+
             // 게임 업데이트 함수 정의
             const update = (deltaTime) => {
                 // 이곳에서 게임의 논리를 업데이트합니다.
+                const faultFlags = getFaultFlags();
+                if (faultFlags.update) {
+                    setFaultFlag('update', false); // 한 번만 오류 발생
+                    throw new Error("Simulated Error: Something went wrong in update()!");
+                }
             };
 
             // 게임 그리기 함수 정의
             const draw = () => {
+                const faultFlags = getFaultFlags();
+                if (faultFlags.draw) {
+                    setFaultFlag('draw', false); // 한 번만 오류 발생
+                    throw new Error("Simulated Error: Drawing failed in draw()!");
+                }
+
                 renderer.clear();
                 renderer.drawBackground();
 

--- a/js/tests/engineTests.js
+++ b/js/tests/engineTests.js
@@ -28,3 +28,65 @@ export function runEngineTests(renderer, gameLoop) {
 
     console.log("--- Engine Test End ---");
 }
+
+/**
+ * 렌더러 엔진에 결함을 주입하는 테스트입니다.
+ * 캔버스 컨텍스트를 임의로 null로 만들어서 그리기가 실패하는지 확인합니다.
+ * @param {Renderer} renderer - Renderer 인스턴스.
+ */
+export function injectRendererFault(renderer) {
+    console.warn("--- Injecting Renderer Fault (Simulating missing context) ---");
+    const originalCtx = renderer.ctx; // 원래 컨텍스트 저장
+
+    try {
+        renderer.ctx = null; // 컨텍스트를 null로 강제 설정
+        console.log("Attempting to draw with null context...");
+        renderer.clear(); // 오류 발생 예상
+        renderer.drawBackground(); // 오류 발생 예상
+        console.error("Renderer Fault Test: Failed to throw error as expected. [FAIL]");
+    } catch (e) {
+        console.log("Renderer Fault Test: Successfully caught expected error when drawing with null context. [PASS]");
+        console.error("Error details:", e);
+    } finally {
+        renderer.ctx = originalCtx; // 원래 컨텍스트로 복구
+        console.log("Renderer context restored.");
+    }
+    console.warn("--- Renderer Fault Injection End ---");
+}
+
+/**
+ * 게임 루프의 콜백 함수에 결함을 주입하는 테스트입니다.
+ * update 또는 draw 함수 내에서 강제로 에러를 발생시킵니다.
+ * 이 함수는 실제 콜백 함수가 에러를 발생시킬 수 있도록 플래그를 설정합니다.
+ * @param {string} faultType - 'update' 또는 'draw' 중 어떤 함수에서 에러를 발생시킬지 지정.
+ * @param {function} setFaultFlag - 외부에서 결함 플래그를 설정하는 함수.
+ */
+export function injectGameLoopFault(faultType, setFaultFlag) {
+    console.warn(`--- Injecting GameLoop Fault in ${faultType} function ---`);
+    if (setFaultFlag && typeof setFaultFlag === 'function') {
+        setFaultFlag(faultType, true);
+        console.log(`Fault flag set for ${faultType} function. Check console for errors in game loop.`);
+    } else {
+        console.error("GameLoop Fault Test: setFaultFlag function is missing or invalid. [FAIL]");
+    }
+    console.warn("--- GameLoop Fault Injection End ---");
+}
+
+// 이 함수는 외부에서 호출되어 게임 루프 콜백 내에서 사용할 플래그를 관리합니다.
+let updateShouldThrow = false;
+let drawShouldThrow = false;
+
+export function getFaultFlags() {
+    return {
+        update: updateShouldThrow,
+        draw: drawShouldThrow
+    };
+}
+
+export function setFaultFlag(type, value) {
+    if (type === 'update') {
+        updateShouldThrow = value;
+    } else if (type === 'draw') {
+        drawShouldThrow = value;
+    }
+}


### PR DESCRIPTION
## Summary
- extend engine tests to support fault injection for Renderer and GameLoop
- add buttons in `debug.html` to trigger fault injection
- simulate update/draw errors via flags during debug

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68713f84fab48327bee0e31dd2b86424