### PR TITLE
Add EventManager system with worker

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -9,7 +9,7 @@
             margin: 0;
             overflow: hidden;
             display: flex;
-            flex-direction: column; /* 세로 방향 정렬 */
+            flex-direction: column;
             justify-content: center;
             align-items: center;
             min-height: 100vh;
@@ -24,19 +24,32 @@
             background-color: rgba(0, 0, 0, 0.7);
             padding: 10px;
             border-radius: 5px;
-            z-index: 1000; /* 캔버스 위에 표시되도록 */
+            z-index: 1000;
+            display: flex;
+            flex-direction: column;
+            gap: 5px; /* 버튼과 섹션 사이 간격 */
+        }
+        #debugInfo h4 {
+            margin: 10px 0 5px 0;
+            color: #ccc;
         }
         #debugInfo button {
-            background-color: #f44336; /* 빨간색 버튼 */
+            background-color: #4CAF50; /* 초록색 버튼 */
             color: white;
             padding: 8px 12px;
             border: none;
             border-radius: 4px;
             cursor: pointer;
-            margin-top: 5px;
             font-size: 0.9em;
+            transition: background-color 0.2s;
         }
         #debugInfo button:hover {
+            background-color: #45a049;
+        }
+        #debugInfo button.fault-btn {
+            background-color: #f44336; /* 빨간색 버튼 */
+        }
+        #debugInfo button.fault-btn:hover {
             background-color: #d32f2f;
         }
         canvas {
@@ -49,33 +62,63 @@
     <div id="debugInfo">
         <h3>디버그 정보</h3>
         <p>FPS: <span id="fpsCounter">--</span></p>
-        <h4>결함 주입 테스트</h4>
-        <button id="injectRendererFaultBtn">렌더러 결함 주입</button>
-        <button id="injectUpdateFaultBtn">Update 함수 결함 주입</button>
-        <button id="injectDrawFaultBtn">Draw 함수 결함 주입</button>
+        
+        <h4>엔진 기본 테스트</h4>
+        <button id="runAllEngineTestsBtn">모든 엔진 테스트 실행</button>
+
+        <h4>엔진 결함 주입 테스트</h4>
+        <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
+        <button id="injectUpdateFaultBtn" class="fault-btn">Update 함수 결함 주입</button>
+        <button id="injectDrawFaultBtn" class="fault-btn">Draw 함수 결함 주입</button>
+        <button id="injectEventManagerFaultsBtn" class="fault-btn">이벤트 매니저 결함 주입</button>
+        <h4>이벤트 발생 시뮬레이션</h4>
+        <button id="simulateEventsBtn">이벤트 시뮬레이션 시작/정지</button>
     </div>
     <canvas id="gameCanvas"></canvas>
     <script type="module">
-        // Debug 페이지에서는 main.js의 일부 기능을 확장하여 사용합니다.
-        // GameLoop와 Renderer 모듈을 불러옵니다.
         import { Renderer } from './js/Renderer.js';
         import { GameLoop } from './js/GameLoop.js';
+        import { EventManager } from './js/managers/EventManager.js'; // EventManager 불러오기
         // 엔진 테스트 모듈과 결함 주입 테스트 함수들을 불러옵니다.
-        import { runEngineTests, injectRendererFault, injectGameLoopFault, getFaultFlags, setFaultFlag } from './js/tests/engineTests.js';
+        import { 
+            runEngineTests, 
+            injectRendererFault, 
+            injectGameLoopFault, 
+            getFaultFlags, 
+            setFaultFlag,
+            runEventManagerTests, // 추가
+            injectEventManagerFaults // 추가
+        } from './js/tests/engineTests.js'; 
 
         document.addEventListener('DOMContentLoaded', () => {
             const renderer = new Renderer('gameCanvas');
             if (!renderer.canvas) {
-                console.error("Failed to initialize Renderer. Game cannot start.");
+                console.error('Failed to initialize Renderer. Game cannot start.');
                 return;
             }
             const ctx = renderer.ctx;
+
+            const eventManager = new EventManager(); // EventManager 인스턴스 생성
+
+            // 테스트용 EventManager 구독 (debug.html에서만 필요)
+            eventManager.subscribe('unitDeath', (data) => {
+                console.log(`[Debug Main] Unit ${data.unitId} (${data.unitName}) has died!`);
+            });
+            eventManager.subscribe('skillExecuted', (data) => {
+                console.log(`[Debug Main] Skill '${data.skillName}' was executed.`);
+            });
+
 
             let frameCount = 0;
             let lastFpsTime = 0;
             const fpsCounterElement = document.getElementById('fpsCounter');
 
-            // 결함 주입 버튼 이벤트 리스너 설정
+            // --- 버튼 이벤트 리스너 설정 ---
+            document.getElementById('runAllEngineTestsBtn').addEventListener('click', () => {
+                runEngineTests(renderer, gameLoop);
+                runEventManagerTests(eventManager); // EventManager 테스트 실행
+            });
+
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
                 injectRendererFault(renderer);
             });
@@ -85,14 +128,39 @@
             document.getElementById('injectDrawFaultBtn').addEventListener('click', () => {
                 injectGameLoopFault('draw', setFaultFlag);
             });
+            document.getElementById('injectEventManagerFaultsBtn').addEventListener('click', () => { // 추가
+                injectEventManagerFaults(eventManager);
+            });
+
+            let isSimulatingEvents = false; // 이벤트 시뮬레이션 플래그 추가
+            let lastEmittedSecond = -1; // 이벤트 시뮬레이션 타이머
+            document.getElementById('simulateEventsBtn').addEventListener('click', (e) => { // 추가
+                isSimulatingEvents = !isSimulatingEvents;
+                e.target.textContent = isSimulatingEvents ? '이벤트 시뮬레이션 정지' : '이벤트 시뮬레이션 시작';
+                if (!isSimulatingEvents) {
+                    console.log('Event simulation stopped.');
+                } else {
+                    console.log('Event simulation started. Check console.');
+                }
+            });
+
 
             // 게임 업데이트 함수 정의
             const update = (deltaTime) => {
-                // 이곳에서 게임의 논리를 업데이트합니다.
                 const faultFlags = getFaultFlags();
                 if (faultFlags.update) {
-                    setFaultFlag('update', false); // 한 번만 오류 발생
-                    throw new Error("Simulated Error: Something went wrong in update()!");
+                    setFaultFlag('update', false);
+                    throw new Error('Simulated Error: Something went wrong in update()!');
+                }
+
+                // 이벤트 시뮬레이션 로직 (debug.html에서만)
+                if (isSimulatingEvents) {
+                    if (Math.floor(performance.now() / 1000) % 5 === 0 && Math.floor(performance.now() / 1000) !== lastEmittedSecond) {
+                        eventManager.emit('unitAttack', { attackerId: 'DebugHero', targetId: 'DebugGoblin', damageDealt: 15 });
+                        eventManager.emit('unitDeath', { unitId: 'DebugGoblin', unitName: '디버그 고블린', unitType: 'normal' });
+                        eventManager.emit('unitDeath', { unitId: 'DebugOgreBoss', unitName: '디버그 오우거 보스', unitType: 'elite' });
+                        lastEmittedSecond = Math.floor(performance.now() / 1000);
+                    }
                 }
             };
 
@@ -100,8 +168,8 @@
             const draw = () => {
                 const faultFlags = getFaultFlags();
                 if (faultFlags.draw) {
-                    setFaultFlag('draw', false); // 한 번만 오류 발생
-                    throw new Error("Simulated Error: Drawing failed in draw()!");
+                    setFaultFlag('draw', false);
+                    throw new Error('Simulated Error: Drawing failed in draw()!');
                 }
 
                 renderer.clear();
@@ -112,12 +180,12 @@
                 ctx.textAlign = 'center';
                 ctx.fillText('Muscle & Blood', renderer.canvas.width / 2, renderer.canvas.height / 2);
                 ctx.font = '24px Arial';
-                ctx.fillText('디버그 모드', renderer.canvas.width / 2, renderer.canvas.height / 2 + 50);
+                ctx.fillText('디버그 모드 (이벤트 매니저 테스트)', renderer.canvas.width / 2, renderer.canvas.height / 2 + 50);
 
                 // FPS 카운터 업데이트
                 frameCount++;
                 const currentTime = performance.now();
-                if (currentTime - lastFpsTime >= 1000) { // 1초마다 업데이트
+                if (currentTime - lastFpsTime >= 1000) {
                     const fps = frameCount / ((currentTime - lastFpsTime) / 1000);
                     fpsCounterElement.textContent = fps.toFixed(0);
                     frameCount = 0;
@@ -128,8 +196,9 @@
             const gameLoop = new GameLoop(update, draw);
             gameLoop.start();
 
-            // 엔진 테스트 실행 (렌더러와 게임 루프 인스턴스를 전달합니다.)
+            // 페이지 로드 시 기본 엔진 테스트 자동 실행
             runEngineTests(renderer, gameLoop);
+            // EventManager 테스트는 이제 버튼으로 실행됩니다.
         });
     </script>
 </body>

--- a/js/managers/EventManager.js
+++ b/js/managers/EventManager.js
@@ -1,0 +1,90 @@
+// js/managers/EventManager.js
+
+export class EventManager {
+    constructor() {
+        // Web Worker 인스턴스 생성
+        // '../workers/eventWorker.js' 경로는 이 파일(EventManager.js) 기준으로 workers 폴더 안의 eventWorker.js를 의미합니다.
+        this.worker = new Worker('./js/workers/eventWorker.js'); // main.js에서 EventManager를 불러올 때의 상대 경로
+        this.subscribers = new Map(); // 메인 스레드에서 이벤트 구독자를 관리할 Map
+
+        // Web Worker로부터 메시지를 받을 때 실행될 콜백 설정
+        this.worker.onmessage = this.handleWorkerMessage.bind(this);
+        // 에러 발생 시 처리
+        this.worker.onerror = (e) => {
+            console.error("[EventManager] Worker Error:", e);
+        };
+
+        console.log("[EventManager] Initialized with Web Worker.");
+    }
+
+    /**
+     * Web Worker로부터 메시지를 처리합니다.
+     * @param {MessageEvent} event
+     */
+    handleWorkerMessage(event) {
+        const { type, eventName, data, skillName, targetUnitId, amount, sourceUnitId, radius } = event.data;
+
+        if (type === 'EVENT_DISPATCHED') {
+            // Worker가 이벤트를 받았다고 알림 -> 메인 스레드의 구독자들에게 전파
+            this.dispatch(eventName, data);
+        } else if (type === 'SKILL_TRIGGERED') {
+            // Worker의 '작은 엔진'이 스킬 발동을 요청함
+            console.log(`[EventManager] Worker requested skill: ${skillName}`);
+            // TODO: 실제 게임에서는 이 요청을 CombatEngine이나 StatSystem 등으로 전달하여
+            // 해당 스킬의 효과를 적용해야 합니다.
+            // 임시로 콘솔에 출력
+            if (skillName === '흡혈') {
+                console.log(`[EventManager] Unit ${targetUnitId} 흡혈 ${amount} 만큼 발동!`);
+            } else if (skillName === '광역 공포') {
+                console.log(`[EventManager] ${sourceUnitId} 사망으로 인한 광역 공포(${radius} 범위) 발동!`);
+            }
+            // 이 시점에서 다시 이벤트(예: 'skillExecuted')를 발생시킬 수도 있습니다.
+            this.emit('skillExecuted', { skillName, targetUnitId, amount, sourceUnitId, radius });
+        }
+    }
+
+    /**
+     * 이벤트를 발생시켜 Web Worker로 보냅니다.
+     * @param {string} eventName - 발생시킬 이벤트의 이름
+     * @param {object} data - 이벤트와 함께 전달할 데이터
+     */
+    emit(eventName, data) {
+        // Worker에게 이벤트를 처리하도록 요청
+        this.worker.postMessage({ type: 'EMIT_EVENT', eventName, data });
+    }
+
+    /**
+     * 메인 스레드에서 이벤트를 구독합니다.
+     * (Worker로부터 받은 'EVENT_DISPATCHED' 메시지를 처리하기 위함)
+     * @param {string} eventName - 구독할 이벤트의 이름
+     * @param {function} callback - 이벤트 발생 시 호출될 콜백 함수
+     */
+    subscribe(eventName, callback) {
+        if (!this.subscribers.has(eventName)) {
+            this.subscribers.set(eventName, []);
+        }
+        this.subscribers.get(eventName).push(callback);
+        console.log(`[EventManager] Subscribed to event: ${eventName}`);
+    }
+
+    /**
+     * 메인 스레드에서 이벤트를 전파합니다 (Worker로부터 받은 후).
+     * @param {string} eventName - 전파할 이벤트의 이름
+     * @param {object} data - 이벤트와 함께 전달할 데이터
+     */
+    dispatch(eventName, data) {
+        if (this.subscribers.has(eventName)) {
+            this.subscribers.get(eventName).forEach(callback => callback(data));
+        }
+    }
+
+    /**
+     * Web Worker를 종료합니다. (선택 사항)
+     */
+    terminateWorker() {
+        if (this.worker) {
+            this.worker.terminate();
+            console.log("[EventManager] Web Worker terminated.");
+        }
+    }
+}

--- a/js/workers/eventWorker.js
+++ b/js/workers/eventWorker.js
@@ -1,0 +1,70 @@
+// js/workers/eventWorker.js
+
+// 이벤트 리스너(구독자)를 저장할 맵 (key: 이벤트 이름, value: 리스너 함수 배열)
+const listeners = new Map();
+
+// '작은 엔진' - 트리거 스킬 정의 (간단한 예시)
+// 실제 게임에서는 더 복잡한 스킬 로직이 여기에 포함될 수 있습니다.
+const triggerSkills = {
+    // 'unitAttack' 이벤트에 반응하는 가상의 트리거 스킬
+    'unitAttack': [
+        {
+            name: '공격 시 흡혈',
+            condition: (eventData) => eventData.damageDealt > 10, // 10 이상의 피해를 입혔을 때
+            action: (eventData) => {
+                // 메인 스레드에 '흡혈' 효과 적용을 요청
+                self.postMessage({
+                    type: 'SKILL_TRIGGERED',
+                    skillName: '흡혈',
+                    targetUnitId: eventData.attackerId,
+                    amount: Math.floor(eventData.damageDealt * 0.1) // 피해량의 10%만큼 흡혈
+                });
+            }
+        }
+    ],
+    // 'unitDeath' 이벤트에 반응하는 가상의 트리거 스킬
+    'unitDeath': [
+        {
+            name: '죽음의 메아리',
+            condition: (eventData) => eventData.unitType === 'elite', // 엘리트 유닛이 죽었을 때
+            action: (eventData) => {
+                // 메인 스레드에 '광역 공포' 효과 적용을 요청
+                self.postMessage({
+                    type: 'SKILL_TRIGGERED',
+                    skillName: '광역 공포',
+                    sourceUnitId: eventData.unitId, // 죽은 유닛을 스킬의 원천으로
+                    radius: 3 // 특정 반경 내 적들에게 적용
+                });
+            }
+        }
+    ]
+};
+
+
+// 메인 스레드로부터 메시지를 받을 때 실행되는 함수
+self.onmessage = (event) => {
+    const { type, eventName, data } = event.data;
+
+    if (type === 'EMIT_EVENT') {
+        // 1. 등록된 리스너들에게 이벤트 전파 (메인 스레드에 다시 전달)
+        // worker는 직접 DOM 조작이나 게임 상태를 변경할 수 없으므로,
+        // 이벤트를 수신한 메인 스레드의 EventManager가 다시 구독자들에게 전파해야 합니다.
+        self.postMessage({
+            type: 'EVENT_DISPATCHED',
+            eventName: eventName,
+            data: data
+        });
+
+        // 2. '작은 엔진' - 트리거 스킬 조건 검사 및 실행
+        if (triggerSkills[eventName]) {
+            triggerSkills[eventName].forEach(skill => {
+                if (skill.condition(data)) {
+                    console.log(`[Worker] Trigger Skill '${skill.name}' activated by event: ${eventName}`);
+                    skill.action(data); // 해당 스킬의 액션 실행
+                }
+            });
+        }
+    }
+};
+
+console.log("[Worker] EventWorker initialized and small engine ready.");


### PR DESCRIPTION
## Summary
- implement `EventManager` and event worker
- wire `EventManager` into `main.js`
- extend debug page with buttons for testing events and faults
- expand engine test suite with `runEventManagerTests` and fault injection

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687142f68050832790d30f297c75b3c7