### PR TITLE
Add GuardianManager and tests

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -71,6 +71,7 @@
         <button id="injectUpdateFaultBtn" class="fault-btn">Update 함수 결함 주입</button>
         <button id="injectDrawFaultBtn" class="fault-btn">Draw 함수 결함 주입</button>
         <button id="injectEventManagerFaultsBtn" class="fault-btn">이벤트 매니저 결함 주입</button>
+        <button id="injectGuardianManagerFaultsBtn" class="fault-btn">가디언 매니저 결함 주입</button>
         <h4>이벤트 발생 시뮬레이션</h4>
         <button id="simulateEventsBtn">이벤트 시뮬레이션 시작/정지</button>
     </div>
@@ -79,16 +80,19 @@
         import { Renderer } from './js/Renderer.js';
         import { GameLoop } from './js/GameLoop.js';
         import { EventManager } from './js/managers/EventManager.js'; // EventManager 불러오기
+        import { GuardianManager } from './js/managers/GuardianManager.js'; // GuardianManager 불러오기
         // 엔진 테스트 모듈과 결함 주입 테스트 함수들을 불러옵니다.
-        import { 
-            runEngineTests, 
-            injectRendererFault, 
-            injectGameLoopFault, 
-            getFaultFlags, 
+        import {
+            runEngineTests,
+            injectRendererFault,
+            injectGameLoopFault,
+            getFaultFlags,
             setFaultFlag,
             runEventManagerTests, // 추가
-            injectEventManagerFaults // 추가
-        } from './js/tests/engineTests.js'; 
+            injectEventManagerFaults,
+            runGuardianManagerTests,    // 추가
+            injectGuardianManagerFaults // 추가
+        } from './js/tests/engineTests.js';
 
         document.addEventListener('DOMContentLoaded', () => {
             const renderer = new Renderer('gameCanvas');
@@ -99,6 +103,7 @@
             const ctx = renderer.ctx;
 
             const eventManager = new EventManager(); // EventManager 인스턴스 생성
+            const guardianManager = new GuardianManager(); // GuardianManager 인스턴스 생성
 
             // 테스트용 EventManager 구독 (debug.html에서만 필요)
             eventManager.subscribe('unitDeath', (data) => {
@@ -116,7 +121,8 @@
             // --- 버튼 이벤트 리스너 설정 ---
             document.getElementById('runAllEngineTestsBtn').addEventListener('click', () => {
                 runEngineTests(renderer, gameLoop);
-                runEventManagerTests(eventManager); // EventManager 테스트 실행
+                runEventManagerTests(eventManager);
+                runGuardianManagerTests(guardianManager); // GuardianManager 테스트 실행
             });
 
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
@@ -128,8 +134,11 @@
             document.getElementById('injectDrawFaultBtn').addEventListener('click', () => {
                 injectGameLoopFault('draw', setFaultFlag);
             });
-            document.getElementById('injectEventManagerFaultsBtn').addEventListener('click', () => { // 추가
+            document.getElementById('injectEventManagerFaultsBtn').addEventListener('click', () => {
                 injectEventManagerFaults(eventManager);
+            });
+            document.getElementById('injectGuardianManagerFaultsBtn').addEventListener('click', () => {
+                injectGuardianManagerFaults(guardianManager);
             });
 
             let isSimulatingEvents = false; // 이벤트 시뮬레이션 플래그 추가
@@ -180,7 +189,7 @@
                 ctx.textAlign = 'center';
                 ctx.fillText('Muscle & Blood', renderer.canvas.width / 2, renderer.canvas.height / 2);
                 ctx.font = '24px Arial';
-                ctx.fillText('디버그 모드 (이벤트 매니저 테스트)', renderer.canvas.width / 2, renderer.canvas.height / 2 + 50);
+                ctx.fillText('디버그 모드 (가디언 매니저 테스트)', renderer.canvas.width / 2, renderer.canvas.height / 2 + 50);
 
                 // FPS 카운터 업데이트
                 frameCount++;

--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,7 @@
 import { Renderer } from './Renderer.js';
 import { GameLoop } from './GameLoop.js';
 import { EventManager } from './managers/EventManager.js'; // <-- EventManager 불러오기
+import { GuardianManager } from './managers/GuardianManager.js'; // <-- GuardianManager 불러오기
 
 document.addEventListener('DOMContentLoaded', () => {
     // 1. 렌더러 엔진 초기화
@@ -15,6 +16,31 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 1. 이벤트 매니저 초기화
     const eventManager = new EventManager();
+    const guardianManager = new GuardianManager(); // <-- GuardianManager 인스턴스 생성
+
+    // 이곳에서 게임의 초기 데이터를 GuardianManager로 검증할 수 있습니다.
+    const initialGameData = {
+        units: [
+            { id: 'u1', name: 'Knight', hp: 100 },
+            { id: 'u2', name: 'Archer', hp: 70 }
+        ],
+        config: {
+            resolution: { width: 1280, height: 720 },
+            difficulty: 'normal'
+        }
+    };
+
+    try {
+        guardianManager.enforceRules(initialGameData);
+        console.log("[Main] Initial game data passed GuardianManager rules. \u2728");
+    } catch (e) {
+        if (e.name === "ImmutableRuleViolationError") {
+            console.error("[Main] CRITICAL ERROR: Game initialization failed due to immutable rule violation!", e.message);
+            return; // 오류 발생 시 게임 시작 중단
+        } else {
+            throw e;
+        }
+    }
 
     // 예시: 메인 스레드에서 'unitDeath' 이벤트를 구독
     eventManager.subscribe('unitDeath', (data) => {
@@ -50,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ctx.textAlign = 'center';
         ctx.fillText('Muscle & Blood', renderer.canvas.width / 2, renderer.canvas.height / 2);
         ctx.font = '24px Arial';
-        ctx.fillText('이벤트 매니저 작동 중...', renderer.canvas.width / 2, renderer.canvas.height / 2 + 50);
+        ctx.fillText('가디언 매니저 작동 중...', renderer.canvas.width / 2, renderer.canvas.height / 2 + 50);
     };
 
     const gameLoop = new GameLoop(update, draw);

--- a/js/managers/GuardianManager.js
+++ b/js/managers/GuardianManager.js
@@ -1,0 +1,63 @@
+// js/managers/GuardianManager.js
+
+// 커스텀 오류 클래스 정의 (Python의 ImmutableRuleError와 유사)
+class ImmutableRuleViolationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "ImmutableRuleViolationError";
+    }
+}
+
+export class GuardianManager {
+    constructor() {
+        console.log("\uD83D\uDEE1️ GuardianManager is now monitoring the system. \uD83D\uDEE1️");
+        // 앞으로 MapLoader나 TestRunner 같은 종속성을 받을 수 있습니다.
+    }
+
+    /**
+     * '작은 엔진': 게임 데이터의 불변 규칙을 검증합니다.
+     * 현재는 간단한 예시 규칙을 검증합니다.
+     * @param {object} gameData - 검증할 게임 데이터 (예: 유닛 데이터, 스탯 데이터 등)
+     * @returns {boolean} - 모든 규칙이 준수되었으면 true, 아니면 오류 발생.
+     * @throws {ImmutableRuleViolationError} - 불변 규칙이 위반되었을 때 발생.
+     */
+    enforceRules(gameData) {
+        console.log("[GuardianManager] Enforcing rules on provided game data...");
+
+        // --- 불변 규칙 예시 (작은 엔진의 역할) ---
+
+        // 규칙 1: 모든 유닛의 체력은 0보다 커야 한다.
+        if (gameData && gameData.units) {
+            for (const unit of gameData.units) {
+                if (unit.hp <= 0) {
+                    throw new ImmutableRuleViolationError(
+                        `Rule Violation: Unit '${unit.name}' (ID: ${unit.id}) has non-positive HP (${unit.hp}).`
+                    );
+                }
+            }
+        } else {
+            // 초기 게임 데이터가 없어도 오류는 아니지만, 규칙 검증이 불완전할 수 있음을 알림
+            console.warn("[GuardianManager] No unit data provided for HP rule enforcement.");
+        }
+
+        // 규칙 2: 게임의 최소 해상도는 800x600 이상이어야 한다.
+        if (gameData && gameData.config && gameData.config.resolution) {
+            const { width, height } = gameData.config.resolution;
+            if (width < 800 || height < 600) {
+                throw new ImmutableRuleViolationError(
+                    `Rule Violation: Minimum resolution requirement not met (${width}x${height}). Must be at least 800x600.`
+                );
+            }
+        } else {
+            console.warn("[GuardianManager] No resolution config provided for rule enforcement.");
+        }
+
+        // --- 모든 규칙이 준수됨 ---
+        console.log("[GuardianManager] All rules checked and respected. \u2705");
+        return true;
+    }
+
+    // 앞으로 맵 로딩 후 검증이나 특정 상태 변화 시 규칙을 검증하는 메서드가 추가될 수 있습니다.
+    // 예를 들어, setupMapValidation(mapLoader) { ... }
+    // 또는 onUnitCreated(unitData) { this.enforceRules({ units: [unitData] }); }
+}


### PR DESCRIPTION
## Summary
- introduce `GuardianManager` for enforcing immutable game rules
- integrate GuardianManager in main initialization
- extend debug page with GuardianManager controls and display
- add GuardianManager unit tests and fault injections

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6871451a95448327ab8864b1061d511b