### PR TITLE
Add MeasureManager integration and UI/Map recalculations

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -65,6 +65,7 @@
         
         <h4>엔진 기본 테스트</h4>
         <button id="runAllEngineTestsBtn">모든 엔진 테스트 실행</button>
+        <button id="runMeasureManagerIntegrationTestBtn">측량 매니저 통합 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -87,8 +88,9 @@
             runEventManagerTests,
             injectEventManagerFaults,
             runGuardianManagerTests,
-            injectGuardianManagerFaults
-        } from './js/tests/engineTests.js'; 
+            injectGuardianManagerFaults,
+            runMeasureManagerIntegrationTest
+        } from './js/tests/engineTests.js';
 
         document.addEventListener('DOMContentLoaded', () => {
             let gameEngine; // gameEngine 인스턴스를 스코프 밖으로 뺍니다.
@@ -128,6 +130,11 @@
                 runEngineTests(renderer, gameLoop);
                 runEventManagerTests(eventManager);
                 runGuardianManagerTests(guardianManager);
+                runMeasureManagerIntegrationTest(gameEngine);
+            });
+
+            document.getElementById('runMeasureManagerIntegrationTestBtn').addEventListener('click', () => {
+                runMeasureManagerIntegrationTest(gameEngine);
             });
 
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
@@ -214,6 +221,7 @@
             runEngineTests(renderer, gameLoop);
             runEventManagerTests(eventManager); // EventManager 테스트도 자동 실행
             runGuardianManagerTests(guardianManager); // GuardianManager 테스트도 자동 실행
+            runMeasureManagerIntegrationTest(gameEngine); // MeasureManager 통합 테스트도 자동 실행
         });
     </script>
 </body>

--- a/js/managers/MapManager.js
+++ b/js/managers/MapManager.js
@@ -5,14 +5,24 @@ export class MapManager {
         console.log("\ud83d\udddc\ufe0f MapManager initialized. Ready to build worlds. \ud83d\udddc\ufe0f");
         this.measureManager = measureManager;
 
-        this.gridRows = this.measureManager.get('mapGrid.rows');
-        this.gridCols = this.measureManager.get('mapGrid.cols');
-        this.tileSize = this.measureManager.get('tileSize');
+        // 측정값을 기반으로 초기 맵 크기를 계산
+        this._recalculateMapDimensions();
 
         this.mapData = this._generateRandomMap();
         this.pathfindingEngine = this._createPathfindingEngine();
 
         console.log(`[MapManager] Map grid: ${this.gridCols}x${this.gridRows}, Tile size: ${this.tileSize}`);
+    }
+
+    /**
+     * 맵의 그리드 및 타일 크기를 MeasureManager로부터 다시 계산합니다.
+     * 측정값이 변경된 경우 호출됩니다.
+     */
+    _recalculateMapDimensions() {
+        console.log("[MapManager] Recalculating map dimensions based on MeasureManager...");
+        this.gridRows = this.measureManager.get('mapGrid.rows');
+        this.gridCols = this.measureManager.get('mapGrid.cols');
+        this.tileSize = this.measureManager.get('tileSize');
     }
 
     _createPathfindingEngine() {
@@ -60,5 +70,17 @@ export class MapManager {
             gridRows: this.gridRows,
             tileSize: this.tileSize
         };
+    }
+
+    // 테스트를 위해 그리드 크기와 타일 크기를 반환합니다.
+    getGridDimensions() {
+        return {
+            rows: this.gridRows,
+            cols: this.gridCols
+        };
+    }
+
+    getTileSize() {
+        return this.tileSize;
     }
 }

--- a/js/managers/UIManager.js
+++ b/js/managers/UIManager.js
@@ -12,12 +12,10 @@ export class UIManager {
 
         this.uiState = 'mapScreen';
 
-        this.mapPanelWidth = this.canvas.width * this.measureManager.get('ui.mapPanelWidthRatio');
-        this.mapPanelHeight = this.canvas.height * this.measureManager.get('ui.mapPanelHeightRatio');
-        this.buttonHeight = this.measureManager.get('ui.buttonHeight');
-        this.buttonWidth = this.measureManager.get('ui.buttonWidth');
-        this.buttonMargin = this.measureManager.get('ui.buttonMargin');
+        // 초기 UI 크기 설정을 MeasureManager 값에 맞추어 계산
+        this._recalculateUIDimensions();
 
+        // UI 요소 초기화 (버튼 위치 계산)
         this.battleStartButton = {
             x: (this.canvas.width - this.buttonWidth) / 2,
             y: this.canvas.height - this.buttonHeight - this.buttonMargin,
@@ -29,6 +27,28 @@ export class UIManager {
         this.canvas.addEventListener('click', this._handleClick.bind(this));
 
         this.uiStateEngine = this._createUIStateEngine();
+    }
+
+    /**
+     * UI 요소들의 크기와 위치를 MeasureManager로부터 다시 계산합니다.
+     * 캔버스 크기 변화나 측정값 변경 시 호출됩니다.
+     */
+    _recalculateUIDimensions() {
+        console.log("[UIManager] Recalculating UI dimensions based on MeasureManager...");
+        this.mapPanelWidth = this.canvas.width * this.measureManager.get('ui.mapPanelWidthRatio');
+        this.mapPanelHeight = this.canvas.height * this.measureManager.get('ui.mapPanelHeightRatio');
+        this.buttonHeight = this.measureManager.get('ui.buttonHeight');
+        this.buttonWidth = this.measureManager.get('ui.buttonWidth');
+        this.buttonMargin = this.measureManager.get('ui.buttonMargin');
+
+        // 버튼 위치도 새로 계산
+        this.battleStartButton = {
+            x: (this.canvas.width - this.buttonWidth) / 2,
+            y: this.canvas.height - this.buttonHeight - this.buttonMargin,
+            width: this.buttonWidth,
+            height: this.buttonHeight,
+            text: '전투 시작'
+        };
     }
 
     _createUIStateEngine() {
@@ -96,5 +116,20 @@ export class UIManager {
             this.ctx.textAlign = 'center';
             this.ctx.fillText('전투 중!', this.canvas.width / 2, this.canvas.height / 2);
         }
+    }
+
+    // 테스트를 위해 맵 패널 크기와 버튼 크기를 반환합니다.
+    getMapPanelDimensions() {
+        return {
+            width: this.mapPanelWidth,
+            height: this.mapPanelHeight
+        };
+    }
+
+    getButtonDimensions() {
+        return {
+            width: this.battleStartButton.width,
+            height: this.battleStartButton.height
+        };
     }
 }


### PR DESCRIPTION
## Summary
- allow UIManager and MapManager to recalc dimensions via new methods
- expose getters for easier testing
- add MeasureManager integration test
- extend debug.html with new test controls

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68714fe89b7c832792296419a136dc5f