### PR TITLE
Implement camera, grid, and input managers

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -108,6 +108,10 @@
             const renderer = gameEngine.getRenderer();
             const eventManager = gameEngine.getEventManager();
             const guardianManager = gameEngine.getGuardianManager();
+            const uiManager = gameEngine.getUIManager();
+            const cameraManager = gameEngine.getCameraManager();
+            const gridManager = gameEngine.getGridManager();
+            const inputManager = gameEngine.getInputManager();
             const gameLoop = gameEngine.gameLoop; // GameLoop는 GameEngine에서 직접 노출되지 않으므로, GameEngine 내부에 getter를 추가해야 할 수도 있습니다. (현재 예시에서는 gameEngine.gameLoop로 접근)
 
 

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -6,6 +6,9 @@ import { GuardianManager } from './managers/GuardianManager.js';
 import { MeasureManager } from './managers/MeasureManager.js';
 import { MapManager } from './managers/MapManager.js';
 import { UIManager } from './managers/UIManager.js';
+import { GridManager } from './managers/GridManager.js';
+import { InputManager } from './managers/InputManager.js';
+import { CameraManager } from './managers/CameraManager.js';
 
 export class GameEngine {
     constructor(canvasId) {
@@ -28,6 +31,11 @@ export class GameEngine {
         // MapManager 및 UIManager 초기화
         this.mapManager = new MapManager(this.measureManager);
         this.uiManager = new UIManager(this.renderer, this.measureManager, this.eventManager);
+
+        // Camera, Grid, Input 매니저 초기화 (의존성 주의)
+        this.cameraManager = new CameraManager(this.renderer, this.measureManager, this.mapManager, this.uiManager);
+        this.gridManager = new GridManager(this.renderer, this.measureManager, this.mapManager);
+        this.inputManager = new InputManager(this.renderer.canvas, this.cameraManager);
 
         // 게임의 핵심 로직과 렌더링 함수 정의 (GameLoop에 전달될 콜백)
         this._update = this._update.bind(this); // `this` 컨텍스트 바인딩
@@ -100,6 +108,9 @@ export class GameEngine {
         this.renderer.ctx.fillText(`Map: ${mapRenderData.gridCols}x${mapRenderData.gridRows} Grid, Tile Size: ${mapRenderData.tileSize}`, 10, 30);
         this.mapManager.pathfindingEngine.findPath(0, 0, 1, 1);
 
+        // 카메라 변환을 적용하여 그리드 그리기
+        this.gridManager.draw(this.cameraManager.getTransform());
+
         // UI 매니저가 UI를 그립니다.
         this.uiManager.draw();
     }
@@ -135,5 +146,17 @@ export class GameEngine {
 
     getUIManager() {
         return this.uiManager;
+    }
+
+    getCameraManager() {
+        return this.cameraManager;
+    }
+
+    getGridManager() {
+        return this.gridManager;
+    }
+
+    getInputManager() {
+        return this.inputManager;
     }
 }

--- a/js/managers/CameraManager.js
+++ b/js/managers/CameraManager.js
@@ -1,0 +1,196 @@
+// js/managers/CameraManager.js
+
+export class CameraManager {
+    constructor(renderer, measureManager, mapManager, uiManager) {
+        console.log("\ud83d\udcf8 CameraManager initialized. Ready for dynamic views. \ud83d\udcf8");
+        this.renderer = renderer;
+        this.measureManager = measureManager;
+        this.mapManager = mapManager;
+        this.uiManager = uiManager;
+
+        this.canvas = renderer.canvas;
+
+        this.x = 0;
+        this.y = 0;
+        this.zoom = 1;
+
+        this.minZoom = 0.1;
+        this.maxZoom = 3.0;
+
+        this.isDragging = false;
+        this.lastMouseX = 0;
+        this.lastMouseY = 0;
+
+        this.touches = {};
+        this.lastPinchDistance = 0;
+
+        this._initializeCameraView();
+    }
+
+    _initializeCameraView() {
+        console.log("[CameraManager] Initializing camera view to fit map panel...");
+        const mapPixelWidth = this.mapManager.getGridDimensions().cols * this.mapManager.getTileSize();
+        const mapPixelHeight = this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize();
+
+        const mapPanelRect = this.uiManager.getMapPanelRect();
+        const panelWidth = mapPanelRect.width;
+        const panelHeight = mapPanelRect.height;
+
+        const zoomX = panelWidth / mapPixelWidth;
+        const zoomY = panelHeight / mapPixelHeight;
+        this.zoom = Math.min(zoomX, zoomY);
+
+        this.minZoom = Math.min(this.minZoom, this.zoom);
+
+        const scaledMapWidth = mapPixelWidth * this.zoom;
+        const scaledMapHeight = mapPixelHeight * this.zoom;
+
+        this.x = mapPanelRect.x + (panelWidth - scaledMapWidth) / 2;
+        this.y = mapPanelRect.y + (panelHeight - scaledMapHeight) / 2;
+
+        console.log(`[CameraManager] Initial Camera: x=${this.x.toFixed(2)}, y=${this.y.toFixed(2)}, zoom=${this.zoom.toFixed(4)}`);
+
+        this._clampCameraPosition();
+    }
+
+    pan(dx, dy) {
+        this.x += dx;
+        this.y += dy;
+        this._clampCameraPosition();
+    }
+
+    zoomAt(delta, mouseX, mouseY) {
+        const oldZoom = this.zoom;
+        let newZoom = this.zoom * (1 + delta * 0.1);
+        newZoom = Math.max(this.minZoom, Math.min(newZoom, this.maxZoom));
+
+        const zoomRatio = newZoom / oldZoom;
+
+        this.x = mouseX - (mouseX - this.x) * zoomRatio;
+        this.y = mouseY - (mouseY - this.y) * zoomRatio;
+        this.zoom = newZoom;
+
+        this._clampCameraPosition();
+        console.log(`[CameraManager] Zoomed to: ${this.zoom.toFixed(4)} at (${this.x.toFixed(2)}, ${this.y.toFixed(2)})`);
+    }
+
+    _clampCameraPosition() {
+        const mapPixelWidth = this.mapManager.getGridDimensions().cols * this.mapManager.getTileSize();
+        const mapPixelHeight = this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize();
+
+        const mapPanelRect = this.uiManager.getMapPanelRect();
+        const viewWidth = mapPanelRect.width;
+        const viewHeight = mapPanelRect.height;
+
+        const scaledMapWidth = mapPixelWidth * this.zoom;
+        const scaledMapHeight = mapPixelHeight * this.zoom;
+
+        let minX = mapPanelRect.x + viewWidth - scaledMapWidth;
+        let maxX = mapPanelRect.x;
+        let minY = mapPanelRect.y + viewHeight - scaledMapHeight;
+        let maxY = mapPanelRect.y;
+
+        if (scaledMapWidth < viewWidth) {
+            minX = mapPanelRect.x + (viewWidth - scaledMapWidth) / 2;
+            maxX = minX;
+        }
+        if (scaledMapHeight < viewHeight) {
+            minY = mapPanelRect.y + (viewHeight - scaledMapHeight) / 2;
+            maxY = minY;
+        }
+
+        this.x = Math.max(minX, Math.min(this.x, maxX));
+        this.y = Math.max(minY, Math.min(this.y, maxY));
+    }
+
+    getTransform() {
+        return {
+            x: this.x,
+            y: this.y,
+            zoom: this.zoom
+        };
+    }
+
+    startDrag(mouseX, mouseY) {
+        this.isDragging = true;
+        this.lastMouseX = mouseX;
+        this.lastMouseY = mouseY;
+    }
+
+    doDrag(mouseX, mouseY) {
+        if (this.isDragging) {
+            const dx = mouseX - this.lastMouseX;
+            const dy = mouseY - this.lastMouseY;
+            this.pan(dx, dy);
+            this.lastMouseX = mouseX;
+            this.lastMouseY = mouseY;
+        }
+    }
+
+    endDrag() {
+        this.isDragging = false;
+    }
+
+    onTouchStart(touches) {
+        for (let i = 0; i < touches.length; i++) {
+            const touch = touches[i];
+            this.touches[touch.identifier] = { x: touch.clientX, y: touch.clientY };
+        }
+
+        if (Object.keys(this.touches).length === 2) {
+            const [id1, id2] = Object.keys(this.touches);
+            const touch1 = this.touches[id1];
+            const touch2 = this.touches[id2];
+            this.lastPinchDistance = this._getDistance(touch1, touch2);
+        } else if (Object.keys(this.touches).length === 1) {
+            const touch = touches[0];
+            this.startDrag(touch.clientX, touch.clientY);
+        }
+    }
+
+    onTouchMove(touches) {
+        for (let i = 0; i < touches.length; i++) {
+            const touch = touches[i];
+            this.touches[touch.identifier] = { x: touch.clientX, y: touch.clientY };
+        }
+
+        if (Object.keys(this.touches).length === 2) {
+            const [id1, id2] = Object.keys(this.touches);
+            const touch1 = this.touches[id1];
+            const touch2 = this.touches[id2];
+            const currentPinchDistance = this._getDistance(touch1, touch2);
+
+            const zoomDelta = (currentPinchDistance - this.lastPinchDistance) * 0.005;
+            const centerX = (touch1.x + touch2.x) / 2;
+            const centerY = (touch1.y + touch2.y) / 2;
+
+            this.zoomAt(zoomDelta, centerX, centerY);
+            this.lastPinchDistance = currentPinchDistance;
+        } else if (Object.keys(this.touches).length === 1 && this.isDragging) {
+            const touch = touches[0];
+            this.doDrag(touch.clientX, touch.clientY);
+        }
+    }
+
+    onTouchEnd(touches) {
+        const endedTouchIds = new Set(Object.keys(this.touches));
+        for (let i = 0; i < touches.length; i++) {
+            endedTouchIds.delete(touches[i].identifier);
+        }
+        endedTouchIds.forEach(id => delete this.touches[id]);
+
+        if (Object.keys(this.touches).length < 2) {
+            this.lastPinchDistance = 0;
+        }
+
+        if (Object.keys(this.touches).length === 0 && this.isDragging) {
+            this.endDrag();
+        }
+    }
+
+    _getDistance(p1, p2) {
+        const dx = p2.x - p1.x;
+        const dy = p2.y - p1.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+}

--- a/js/managers/GridManager.js
+++ b/js/managers/GridManager.js
@@ -1,0 +1,54 @@
+// js/managers/GridManager.js
+
+export class GridManager {
+    constructor(renderer, measureManager, mapManager) {
+        console.log("\ud83d\udcc0 GridManager initialized. Ready to draw grids. \ud83d\udcc0");
+        this.renderer = renderer;
+        this.measureManager = measureManager;
+        this.mapManager = mapManager;
+
+        this.ctx = renderer.ctx;
+        this.gridCols = mapManager.getGridDimensions().cols;
+        this.gridRows = mapManager.getGridDimensions().rows;
+        this.tileSize = measureManager.get('tileSize');
+    }
+
+    /**
+     * 맵 화면에 그리드 선을 그립니다.
+     * CameraManager의 변환 정보를 적용하여 현재 카메라 뷰에 맞춰 그립니다.
+     * @param {{x: number, y: number, zoom: number}} cameraTransform - CameraManager로부터 받은 카메라 변환 정보
+     */
+    draw(cameraTransform) {
+        const ctx = this.ctx;
+        const totalMapWidth = this.gridCols * this.tileSize;
+        const totalMapHeight = this.gridRows * this.tileSize;
+
+        ctx.save();
+
+        ctx.translate(cameraTransform.x, cameraTransform.y);
+        ctx.scale(cameraTransform.zoom, cameraTransform.zoom);
+
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.3)';
+        ctx.lineWidth = 1;
+
+        for (let i = 0; i <= this.gridCols; i++) {
+            const x = i * this.tileSize;
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, totalMapHeight);
+            ctx.stroke();
+        }
+
+        for (let i = 0; i <= this.gridRows; i++) {
+            const y = i * this.tileSize;
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(totalMapWidth, y);
+            ctx.stroke();
+        }
+
+        // TODO: 타일 타입에 따른 배경색이나 이미지 그리기
+
+        ctx.restore();
+    }
+}

--- a/js/managers/InputManager.js
+++ b/js/managers/InputManager.js
@@ -1,0 +1,61 @@
+// js/managers/InputManager.js
+
+export class InputManager {
+    constructor(canvas, cameraManager) {
+        console.log("\ud83d\udcbb InputManager initialized. Ready to listen inputs. \ud83d\udcbb");
+        this.canvas = canvas;
+        this.cameraManager = cameraManager;
+
+        this.canvas.addEventListener('mousedown', this._onMouseDown.bind(this));
+        this.canvas.addEventListener('mousemove', this._onMouseMove.bind(this));
+        this.canvas.addEventListener('mouseup', this._onMouseUp.bind(this));
+        this.canvas.addEventListener('mouseout', this._onMouseUp.bind(this));
+
+        this.canvas.addEventListener('wheel', this._onWheel.bind(this));
+
+        this.canvas.addEventListener('touchstart', this._onTouchStart.bind(this));
+        this.canvas.addEventListener('touchmove', this._onTouchMove.bind(this));
+        this.canvas.addEventListener('touchend', this._onTouchEnd.bind(this));
+        this.canvas.addEventListener('touchcancel', this._onTouchEnd.bind(this));
+    }
+
+    _onMouseDown(event) {
+        if (event.button === 0) {
+            this.cameraManager.startDrag(event.clientX, event.clientY);
+        }
+    }
+
+    _onMouseMove(event) {
+        if (this.cameraManager.isDragging) {
+            this.cameraManager.doDrag(event.clientX, event.clientY);
+        }
+    }
+
+    _onMouseUp(event) {
+        this.cameraManager.endDrag();
+    }
+
+    _onWheel(event) {
+        event.preventDefault();
+        const delta = Math.sign(event.deltaY);
+        const zoomDelta = -delta;
+        const rect = this.canvas.getBoundingClientRect();
+        const mouseX = event.clientX - rect.left;
+        const mouseY = event.clientY - rect.top;
+        this.cameraManager.zoomAt(zoomDelta, mouseX, mouseY);
+    }
+
+    _onTouchStart(event) {
+        event.preventDefault();
+        this.cameraManager.onTouchStart(event.touches);
+    }
+
+    _onTouchMove(event) {
+        event.preventDefault();
+        this.cameraManager.onTouchMove(event.touches);
+    }
+
+    _onTouchEnd(event) {
+        this.cameraManager.onTouchEnd(event.changedTouches);
+    }
+}

--- a/js/managers/UIManager.js
+++ b/js/managers/UIManager.js
@@ -118,6 +118,22 @@ export class UIManager {
         }
     }
 
+    /**
+     * 맵 화면 패널이 캔버스 내에서 차지하는 영역의 정보를 반환합니다.
+     * CameraManager가 이를 참조하여 맵의 초기 줌 및 드래그 경계를 계산합니다.
+     * @returns {{x: number, y: number, width: number, height: number}} 맵 패널의 픽셀 좌표와 크기
+     */
+    getMapPanelRect() {
+        const x = (this.canvas.width - this.mapPanelWidth) / 2;
+        const y = (this.canvas.height - this.mapPanelHeight) / 2;
+        return {
+            x: x,
+            y: y,
+            width: this.mapPanelWidth,
+            height: this.mapPanelHeight
+        };
+    }
+
     // 테스트를 위해 맵 패널 크기와 버튼 크기를 반환합니다.
     getMapPanelDimensions() {
         return {


### PR DESCRIPTION
## Summary
- add `CameraManager`, `GridManager`, and `InputManager` modules
- expose new managers through `GameEngine` and wire them in
- allow `UIManager` to report map panel rect
- draw grids using camera transform
- update debug page to access new managers

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871545e9ddc83279cf02b60632c264f