### PR TITLE
Remove stray pathfinding call

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -106,7 +106,6 @@ export class GameEngine {
         this.renderer.ctx.font = '20px Arial';
         this.renderer.ctx.textAlign = 'left';
         this.renderer.ctx.fillText(`Map: ${mapRenderData.gridCols}x${mapRenderData.gridRows} Grid, Tile Size: ${mapRenderData.tileSize}`, 10, 30);
-        this.mapManager.pathfindingEngine.findPath(0, 0, 1, 1);
 
         // 카메라 변환을 적용하여 그리드 그리기
         this.gridManager.draw(this.cameraManager.getTransform());


### PR DESCRIPTION
## Summary
- clean up the GameEngine rendering step
- remove leftover pathfindingEngine call in `_draw`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871587b8fac832780c00c835f5e12c5