### PR TITLE
Introduce LayerManager and adjust camera/grid/UI

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -112,6 +112,7 @@
             const cameraManager = gameEngine.getCameraManager();
             const gridManager = gameEngine.getGridManager();
             const inputManager = gameEngine.getInputManager();
+            const layerManager = gameEngine.getLayerManager();
             const gameLoop = gameEngine.gameLoop; // GameLoop는 GameEngine에서 직접 노출되지 않으므로, GameEngine 내부에 getter를 추가해야 할 수도 있습니다. (현재 예시에서는 gameEngine.gameLoop로 접근)
 
 

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -9,6 +9,7 @@ import { UIManager } from './managers/UIManager.js';
 import { GridManager } from './managers/GridManager.js';
 import { InputManager } from './managers/InputManager.js';
 import { CameraManager } from './managers/CameraManager.js';
+import { LayerManager } from './managers/LayerManager.js';
 
 export class GameEngine {
     constructor(canvasId) {
@@ -36,6 +37,7 @@ export class GameEngine {
         this.cameraManager = new CameraManager(this.renderer, this.measureManager, this.mapManager, this.uiManager);
         this.gridManager = new GridManager(this.renderer, this.measureManager, this.mapManager);
         this.inputManager = new InputManager(this.renderer.canvas, this.cameraManager);
+        this.layerManager = new LayerManager(this.renderer, this.measureManager, this.gridManager, this.uiManager, this.cameraManager);
 
         // 게임의 핵심 로직과 렌더링 함수 정의 (GameLoop에 전달될 콜백)
         this._update = this._update.bind(this); // `this` 컨텍스트 바인딩
@@ -97,21 +99,13 @@ export class GameEngine {
      * 게임 루프의 그리기 단계에서 호출될 핵심 렌더링 함수입니다.
      */
     _draw() {
-        // 렌더러를 사용하여 기본 배경과 맵 정보를 그립니다.
-        this.renderer.clear();
-        this.renderer.drawBackground();
+        this.layerManager.drawLayers();
 
         const mapRenderData = this.mapManager.getMapRenderData();
         this.renderer.ctx.fillStyle = 'gray';
         this.renderer.ctx.font = '20px Arial';
         this.renderer.ctx.textAlign = 'left';
         this.renderer.ctx.fillText(`Map: ${mapRenderData.gridCols}x${mapRenderData.gridRows} Grid, Tile Size: ${mapRenderData.tileSize}`, 10, 30);
-
-        // 카메라 변환을 적용하여 그리드 그리기
-        this.gridManager.draw(this.cameraManager.getTransform());
-
-        // UI 매니저가 UI를 그립니다.
-        this.uiManager.draw();
     }
 
     /**
@@ -157,5 +151,9 @@ export class GameEngine {
 
     getInputManager() {
         return this.inputManager;
+    }
+
+    getLayerManager() {
+        return this.layerManager;
     }
 }

--- a/js/managers/CameraManager.js
+++ b/js/managers/CameraManager.js
@@ -16,6 +16,7 @@ export class CameraManager {
 
         this.minZoom = 0.1;
         this.maxZoom = 3.0;
+        this.gridPaddingY = measureManager.get('gridPaddingY');
 
         this.isDragging = false;
         this.lastMouseX = 0;
@@ -30,23 +31,23 @@ export class CameraManager {
     _initializeCameraView() {
         console.log("[CameraManager] Initializing camera view to fit map panel...");
         const mapPixelWidth = this.mapManager.getGridDimensions().cols * this.mapManager.getTileSize();
-        const mapPixelHeight = this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize();
+        const totalGameWorldHeight = (this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize()) + (this.gridPaddingY * 2);
 
         const mapPanelRect = this.uiManager.getMapPanelRect();
         const panelWidth = mapPanelRect.width;
         const panelHeight = mapPanelRect.height;
 
         const zoomX = panelWidth / mapPixelWidth;
-        const zoomY = panelHeight / mapPixelHeight;
+        const zoomY = panelHeight / totalGameWorldHeight;
         this.zoom = Math.min(zoomX, zoomY);
 
         this.minZoom = Math.min(this.minZoom, this.zoom);
 
         const scaledMapWidth = mapPixelWidth * this.zoom;
-        const scaledMapHeight = mapPixelHeight * this.zoom;
+        const scaledGameWorldHeight = totalGameWorldHeight * this.zoom;
 
         this.x = mapPanelRect.x + (panelWidth - scaledMapWidth) / 2;
-        this.y = mapPanelRect.y + (panelHeight - scaledMapHeight) / 2;
+        this.y = mapPanelRect.y + (panelHeight - scaledGameWorldHeight) / 2;
 
         console.log(`[CameraManager] Initial Camera: x=${this.x.toFixed(2)}, y=${this.y.toFixed(2)}, zoom=${this.zoom.toFixed(4)}`);
 
@@ -77,25 +78,26 @@ export class CameraManager {
     _clampCameraPosition() {
         const mapPixelWidth = this.mapManager.getGridDimensions().cols * this.mapManager.getTileSize();
         const mapPixelHeight = this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize();
+        const totalGameWorldHeight = mapPixelHeight + (this.gridPaddingY * 2);
 
         const mapPanelRect = this.uiManager.getMapPanelRect();
         const viewWidth = mapPanelRect.width;
         const viewHeight = mapPanelRect.height;
 
         const scaledMapWidth = mapPixelWidth * this.zoom;
-        const scaledMapHeight = mapPixelHeight * this.zoom;
+        const scaledGameWorldHeight = totalGameWorldHeight * this.zoom;
 
         let minX = mapPanelRect.x + viewWidth - scaledMapWidth;
         let maxX = mapPanelRect.x;
-        let minY = mapPanelRect.y + viewHeight - scaledMapHeight;
+        let minY = mapPanelRect.y + viewHeight - scaledGameWorldHeight;
         let maxY = mapPanelRect.y;
 
         if (scaledMapWidth < viewWidth) {
             minX = mapPanelRect.x + (viewWidth - scaledMapWidth) / 2;
             maxX = minX;
         }
-        if (scaledMapHeight < viewHeight) {
-            minY = mapPanelRect.y + (viewHeight - scaledMapHeight) / 2;
+        if (scaledGameWorldHeight < viewHeight) {
+            minY = mapPanelRect.y + (viewHeight - scaledGameWorldHeight) / 2;
             maxY = minY;
         }
 

--- a/js/managers/GridManager.js
+++ b/js/managers/GridManager.js
@@ -11,6 +11,8 @@ export class GridManager {
         this.gridCols = mapManager.getGridDimensions().cols;
         this.gridRows = mapManager.getGridDimensions().rows;
         this.tileSize = measureManager.get('tileSize');
+        this.gridPaddingY = measureManager.get('gridPaddingY');
+        this.gridColor = measureManager.get('colors.grid');
     }
 
     /**
@@ -28,8 +30,10 @@ export class GridManager {
         ctx.translate(cameraTransform.x, cameraTransform.y);
         ctx.scale(cameraTransform.zoom, cameraTransform.zoom);
 
-        ctx.strokeStyle = 'rgba(255, 255, 255, 0.3)';
-        ctx.lineWidth = 1;
+        ctx.translate(0, this.gridPaddingY / cameraTransform.zoom);
+
+        ctx.strokeStyle = this.gridColor;
+        ctx.lineWidth = 1 / cameraTransform.zoom;
 
         for (let i = 0; i <= this.gridCols; i++) {
             const x = i * this.tileSize;

--- a/js/managers/LayerManager.js
+++ b/js/managers/LayerManager.js
@@ -1,0 +1,36 @@
+// js/managers/LayerManager.js
+
+export class LayerManager {
+    constructor(renderer, measureManager, gridManager, uiManager, cameraManager) {
+        console.log("\uD83C\uDFA8 LayerManager initialized. Orchestrating drawing order. \uD83C\uDFA8");
+        this.renderer = renderer;
+        this.measureManager = measureManager;
+        this.gridManager = gridManager;
+        this.uiManager = uiManager;
+        this.cameraManager = cameraManager;
+
+        this.ctx = renderer.ctx;
+        this.canvas = renderer.canvas;
+
+        this.gameScreenColor = measureManager.get('colors.gameScreen');
+        this.mapPanelRect = uiManager.getMapPanelRect();
+    }
+
+    drawLayers() {
+        this.renderer.clear();
+        this.renderer.drawBackground();
+
+        this.ctx.save();
+        this.ctx.fillStyle = this.gameScreenColor;
+        this.ctx.fillRect(
+            this.mapPanelRect.x,
+            this.mapPanelRect.y,
+            this.mapPanelRect.width,
+            this.mapPanelRect.height
+        );
+        this.ctx.restore();
+
+        this.gridManager.draw(this.cameraManager.getTransform());
+        this.uiManager.draw();
+    }
+}

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -6,8 +6,8 @@ export class MeasureManager {
 
         // 게임의 모든 사이즈 관련 설정을 이곳에 정의
         this._measurements = {
-            tileSize: 512, // 맵 타일의 기본 사이즈
-            mapGrid: { rows: 10, cols: 15 }, // 맵 그리드의 행/열
+            tileSize: 512,
+            mapGrid: { rows: 10, cols: 15 },
             gameResolution: {
                 width: 1280,
                 height: 720
@@ -17,7 +17,14 @@ export class MeasureManager {
                 mapPanelHeightRatio: 0.9,
                 buttonHeight: 50,
                 buttonWidth: 200,
-                buttonMargin: 10
+                buttonMargin: 10,
+                mapPanelColor: 'rgba(50, 50, 200, 0.7)'
+            },
+            gridPaddingY: 100,
+            colors: {
+                gameScreen: 'yellow',
+                grid: 'red',
+                background: '#333'
             }
         };
     }

--- a/js/managers/UIManager.js
+++ b/js/managers/UIManager.js
@@ -11,6 +11,7 @@ export class UIManager {
         this.ctx = renderer.ctx;
 
         this.uiState = 'mapScreen';
+        this.mapPanelColor = this.measureManager.get('ui.mapPanelColor');
 
         // 초기 UI 크기 설정을 MeasureManager 값에 맞추어 계산
         this._recalculateUIDimensions();
@@ -84,7 +85,7 @@ export class UIManager {
         this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
         if (this.uiStateEngine.getState() === 'mapScreen') {
-            this.ctx.fillStyle = 'lightblue';
+            this.ctx.fillStyle = this.mapPanelColor;
             this.ctx.fillRect(
                 (this.canvas.width - this.mapPanelWidth) / 2,
                 (this.canvas.height - this.mapPanelHeight) / 2,


### PR DESCRIPTION
## Summary
- expand measurement config with colors and padding
- support padded grid drawing and map panel tinting
- adjust camera initialization and boundaries for padding
- centralize drawing with new `LayerManager`
- connect layer manager in `GameEngine` and debug page

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68715b8e208c8327a3c4b2a04604df62