### PR TITLE
Update layer handling and camera view

### DIFF
--- a/js/managers/CameraManager.js
+++ b/js/managers/CameraManager.js
@@ -31,22 +31,27 @@ export class CameraManager {
     _initializeCameraView() {
         console.log("[CameraManager] Initializing camera view to fit map panel...");
         const mapPixelWidth = this.mapManager.getGridDimensions().cols * this.mapManager.getTileSize();
-        const totalGameWorldHeight = (this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize()) + (this.gridPaddingY * 2);
+        const mapPixelHeight = this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize();
+        // '전체 게임 세계'의 높이 = 맵 높이 + 위아래 패딩
+        const totalGameWorldHeight = mapPixelHeight + (this.gridPaddingY * 2);
 
         const mapPanelRect = this.uiManager.getMapPanelRect();
         const panelWidth = mapPanelRect.width;
         const panelHeight = mapPanelRect.height;
 
+        // 패널 영역을 가득 채울 수 있는 초기 줌 계산
         const zoomX = panelWidth / mapPixelWidth;
         const zoomY = panelHeight / totalGameWorldHeight;
         this.zoom = Math.min(zoomX, zoomY);
 
+        // 너무 작게 축소되지 않도록 최소 줌 보정
         this.minZoom = Math.min(this.minZoom, this.zoom);
 
-        const scaledMapWidth = mapPixelWidth * this.zoom;
+        // 패널 중앙 배치를 위한 위치 계산
+        const scaledGameWorldWidth = mapPixelWidth * this.zoom;
         const scaledGameWorldHeight = totalGameWorldHeight * this.zoom;
 
-        this.x = mapPanelRect.x + (panelWidth - scaledMapWidth) / 2;
+        this.x = mapPanelRect.x + (panelWidth - scaledGameWorldWidth) / 2;
         this.y = mapPanelRect.y + (panelHeight - scaledGameWorldHeight) / 2;
 
         console.log(`[CameraManager] Initial Camera: x=${this.x.toFixed(2)}, y=${this.y.toFixed(2)}, zoom=${this.zoom.toFixed(4)}`);
@@ -78,22 +83,23 @@ export class CameraManager {
     _clampCameraPosition() {
         const mapPixelWidth = this.mapManager.getGridDimensions().cols * this.mapManager.getTileSize();
         const mapPixelHeight = this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize();
+        // 전체 게임 세계 높이 계산 (패딩 포함)
         const totalGameWorldHeight = mapPixelHeight + (this.gridPaddingY * 2);
 
         const mapPanelRect = this.uiManager.getMapPanelRect();
         const viewWidth = mapPanelRect.width;
         const viewHeight = mapPanelRect.height;
 
-        const scaledMapWidth = mapPixelWidth * this.zoom;
+        const scaledGameWorldWidth = mapPixelWidth * this.zoom;
         const scaledGameWorldHeight = totalGameWorldHeight * this.zoom;
 
-        let minX = mapPanelRect.x + viewWidth - scaledMapWidth;
+        let minX = mapPanelRect.x + viewWidth - scaledGameWorldWidth;
         let maxX = mapPanelRect.x;
         let minY = mapPanelRect.y + viewHeight - scaledGameWorldHeight;
         let maxY = mapPanelRect.y;
 
-        if (scaledMapWidth < viewWidth) {
-            minX = mapPanelRect.x + (viewWidth - scaledMapWidth) / 2;
+        if (scaledGameWorldWidth < viewWidth) {
+            minX = mapPanelRect.x + (viewWidth - scaledGameWorldWidth) / 2;
             maxX = minX;
         }
         if (scaledGameWorldHeight < viewHeight) {

--- a/js/managers/LayerManager.js
+++ b/js/managers/LayerManager.js
@@ -12,16 +12,26 @@ export class LayerManager {
         this.ctx = renderer.ctx;
         this.canvas = renderer.canvas;
 
+        // 색상 및 레이아웃 설정 값을 MeasureManager로부터 가져옴
         this.gameScreenColor = measureManager.get('colors.gameScreen');
+        this.mapPanelColor = measureManager.get('ui.mapPanelColor');
         this.mapPanelRect = uiManager.getMapPanelRect();
+
+        // 그리드 정보는 GridManager가 보유한 MapManager에서 참조
+        this.mapManager = gridManager.mapManager;
+        this.mapPixelWidth = this.mapManager.getGridDimensions().cols * this.mapManager.getTileSize();
+        this.mapPixelHeight = this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize();
+        this.gridPaddingY = this.measureManager.get('gridPaddingY');
     }
 
     drawLayers() {
+        // Layer 0: 기본 배경 지우기
         this.renderer.clear();
         this.renderer.drawBackground();
 
+        // Layer 1: 맵 패널 자체(검정색) - 게임 화면의 컨테이너 역할
         this.ctx.save();
-        this.ctx.fillStyle = this.gameScreenColor;
+        this.ctx.fillStyle = this.mapPanelColor;
         this.ctx.fillRect(
             this.mapPanelRect.x,
             this.mapPanelRect.y,
@@ -30,7 +40,23 @@ export class LayerManager {
         );
         this.ctx.restore();
 
-        this.gridManager.draw(this.cameraManager.getTransform());
+        // Layer 2: 카메라가 움직이는 게임 세계 배경 (노랑색)
+        const cameraTransform = this.cameraManager.getTransform();
+        this.ctx.save();
+        this.ctx.translate(cameraTransform.x, cameraTransform.y);
+        this.ctx.scale(cameraTransform.zoom, cameraTransform.zoom);
+
+        this.ctx.fillStyle = this.gameScreenColor;
+        const totalGameWorldWidth = this.mapManager.getGridDimensions().cols * this.mapManager.getTileSize();
+        const totalGameWorldHeight = (this.mapManager.getGridDimensions().rows * this.mapManager.getTileSize()) + (this.gridPaddingY * 2);
+        this.ctx.fillRect(0, 0, totalGameWorldWidth, totalGameWorldHeight);
+
+        // Layer 3: 그리드(빨간색) - GridManager가 자체적으로 카메라 변환을 적용함
+        this.gridManager.draw(cameraTransform);
+
+        this.ctx.restore();
+
+        // Layer 4: UI 요소들 - 카메라 변환과 독립적으로 그려짐
         this.uiManager.draw();
     }
 }

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -13,17 +13,23 @@ export class MeasureManager {
                 height: 720
             },
             ui: {
-                mapPanelWidthRatio: 0.7,
-                mapPanelHeightRatio: 0.9,
+                // 맵 패널이 캔버스를 거의 가득 채우도록 비율을 확대
+                mapPanelWidthRatio: 0.95,
+                mapPanelHeightRatio: 0.95,
                 buttonHeight: 50,
                 buttonWidth: 200,
                 buttonMargin: 10,
-                mapPanelColor: 'rgba(50, 50, 200, 0.7)'
+                // 맵 패널 기본 배경색은 검정색으로 통일
+                mapPanelColor: 'black'
             },
+            // 게임 월드의 위아래 여백(유닛 배치 등을 위한 패딩)
             gridPaddingY: 100,
             colors: {
+                // 실제 게임 화면을 채울 색상
                 gameScreen: 'yellow',
+                // 그리드 선 색상
                 grid: 'red',
+                // 전체 캔버스 기본 배경색
                 background: '#333'
             }
         };

--- a/js/managers/UIManager.js
+++ b/js/managers/UIManager.js
@@ -11,7 +11,6 @@ export class UIManager {
         this.ctx = renderer.ctx;
 
         this.uiState = 'mapScreen';
-        this.mapPanelColor = this.measureManager.get('ui.mapPanelColor');
 
         // 초기 UI 크기 설정을 MeasureManager 값에 맞추어 계산
         this._recalculateUIDimensions();
@@ -28,6 +27,10 @@ export class UIManager {
         this.canvas.addEventListener('click', this._handleClick.bind(this));
 
         this.uiStateEngine = this._createUIStateEngine();
+
+        // 경계선 스타일 (맵 패널 배경은 LayerManager가 담당)
+        this.mapPanelBorderColor = 'white';
+        this.mapPanelBorderWidth = 2;
     }
 
     /**
@@ -81,17 +84,23 @@ export class UIManager {
     }
 
     draw() {
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
-        this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+        // 배경색 채우기는 LayerManager에서 수행하므로 UIManager는 경계선만 그린다.
+
+        // 맵 패널 경계선
+        const mapPanelRect = this.getMapPanelRect();
+        this.ctx.save();
+        this.ctx.strokeStyle = this.mapPanelBorderColor;
+        this.ctx.lineWidth = this.mapPanelBorderWidth;
+        this.ctx.strokeRect(
+            mapPanelRect.x,
+            mapPanelRect.y,
+            mapPanelRect.width,
+            mapPanelRect.height
+        );
+        this.ctx.restore();
 
         if (this.uiStateEngine.getState() === 'mapScreen') {
-            this.ctx.fillStyle = this.mapPanelColor;
-            this.ctx.fillRect(
-                (this.canvas.width - this.mapPanelWidth) / 2,
-                (this.canvas.height - this.mapPanelHeight) / 2,
-                this.mapPanelWidth,
-                this.mapPanelHeight
-            );
+            // 맵 화면 UI 텍스트 및 버튼
             this.ctx.fillStyle = 'black';
             this.ctx.font = '30px Arial';
             this.ctx.textAlign = 'center';


### PR DESCRIPTION
## Summary
- expand map panel ratios and colors via `MeasureManager`
- draw map panel borders only in `UIManager`
- restructure `LayerManager` layering to render map background and grid
- clarify camera initialization and clamp logic for padded maps

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68715eda691883279a3950d2a726d188