### PR TITLE
Introduce LayerEngine and upgrade UI manager

### DIFF
--- a/js/managers/LayerEngine.js
+++ b/js/managers/LayerEngine.js
@@ -1,0 +1,30 @@
+// js/managers/LayerEngine.js
+
+export class LayerEngine {
+    constructor(renderer) {
+        console.log("\uD83C\uDCC3 LayerEngine initialized. Ready to manage rendering layers. \uD83C\uDCC3");
+        this.renderer = renderer;
+        this.layers = [];
+    }
+
+    registerLayer(name, drawFunction, zIndex) {
+        const existingLayerIndex = this.layers.findIndex(layer => layer.name === name);
+        if (existingLayerIndex !== -1) {
+            console.warn(`[LayerEngine] Layer '${name}' already exists. Overwriting.`);
+            this.layers[existingLayerIndex] = { name, drawFunction, zIndex };
+        } else {
+            this.layers.push({ name, drawFunction, zIndex });
+        }
+        this.layers.sort((a, b) => a.zIndex - b.zIndex);
+        console.log(`[LayerEngine] Registered layer: ${name} with zIndex: ${zIndex}`);
+    }
+
+    draw() {
+        this.renderer.clear();
+        this.renderer.drawBackground();
+
+        for (const layer of this.layers) {
+            layer.drawFunction(this.renderer.ctx);
+        }
+    }
+}

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -1,8 +1,8 @@
-// js/managers/UIManager.js
+// js/managers/UIEngine.js
 
-export class UIManager {
+export class UIEngine {
     constructor(renderer, measureManager, eventManager) {
-        console.log("\ud83d\udcbb UIManager initialized. Ready to draw interfaces. \ud83d\udcbb");
+        console.log("\ud83d\udcbb UIEngine initialized. Ready to draw interfaces. \ud83d\udcbb");
         this.renderer = renderer;
         this.measureManager = measureManager;
         this.eventManager = eventManager;
@@ -34,7 +34,7 @@ export class UIManager {
      * 캔버스 크기 변화나 측정값 변경 시 호출됩니다.
      */
     _recalculateUIDimensions() {
-        console.log("[UIManager] Recalculating UI dimensions based on MeasureManager...");
+        console.log("[UIEngine] Recalculating UI dimensions based on MeasureManager...");
         this.mapPanelWidth = this.canvas.width * this.measureManager.get('ui.mapPanelWidthRatio');
         this.mapPanelHeight = this.canvas.height * this.measureManager.get('ui.mapPanelHeightRatio');
         this.buttonHeight = this.measureManager.get('ui.buttonHeight');
@@ -52,11 +52,11 @@ export class UIManager {
     }
 
     _createUIStateEngine() {
-        console.log("[UIManager] Small Engine: UI State Engine created.");
+        console.log("[UIEngine] Small Engine: UI State Engine created.");
         return {
             getState: () => this.uiState,
             setState: (newState) => {
-                console.log(`[UIManager] UI State changed from '${this.uiState}' to '${newState}'`);
+                console.log(`[UIEngine] UI State changed from '${this.uiState}' to '${newState}'`);
                 this.uiState = newState;
             }
         };
@@ -72,7 +72,7 @@ export class UIManager {
                 mouseX >= this.battleStartButton.x && mouseX <= this.battleStartButton.x + this.battleStartButton.width &&
                 mouseY >= this.battleStartButton.y && mouseY <= this.battleStartButton.y + this.battleStartButton.height
             ) {
-                console.log("[UIManager] '전투 시작' 버튼 클릭됨!");
+                console.log("[UIEngine] '전투 시작' 버튼 클릭됨!");
                 this.eventManager.emit('battleStart', { mapId: 'currentMap', difficulty: 'normal' });
                 this.uiStateEngine.setState('combatScreen');
             }

--- a/tests/index.js
+++ b/tests/index.js
@@ -4,7 +4,7 @@ export { runEventManagerTests } from './unit/eventManagerUnitTests.js';
 export { runGuardianManagerTests } from './unit/guardianManagerUnitTests.js';
 export { runMeasureManagerUnitTests } from './unit/measureManagerUnitTests.js';
 export { runMapManagerUnitTests } from './unit/mapManagerUnitTests.js';
-export { runUIManagerUnitTests } from './unit/uiManagerUnitTests.js';
+export { runUIEngineUnitTests } from './unit/uiEngineUnitTests.js';
 
 export { runMeasureManagerIntegrationTest } from './integration/measureManagerIntegrationTests.js';
 

--- a/tests/integration/measureManagerIntegrationTests.js
+++ b/tests/integration/measureManagerIntegrationTests.js
@@ -2,7 +2,7 @@ export function runMeasureManagerIntegrationTest(gameEngine) {
     console.log("--- MeasureManager Integration Test Start ---");
 
     const measureManager = gameEngine.getMeasureManager();
-    const uiManager = gameEngine.getUIManager();
+    const uiEngine = gameEngine.getUIEngine();
     const mapManager = gameEngine.getMapManager();
 
     let testCount = 0;
@@ -13,7 +13,7 @@ export function runMeasureManagerIntegrationTest(gameEngine) {
     const initialMapGridCols = measureManager.get('mapGrid.cols');
     const initialMapPanelWidthRatio = measureManager.get('ui.mapPanelWidthRatio');
 
-    const uiInitialMapPanelWidth = uiManager.getMapPanelDimensions().width;
+    const uiInitialMapPanelWidth = uiEngine.getMapPanelDimensions().width;
     const mapInitialTileSize = mapManager.getTileSize();
     const mapInitialGridCols = mapManager.getGridDimensions().cols;
 
@@ -33,10 +33,10 @@ export function runMeasureManagerIntegrationTest(gameEngine) {
     measureManager.set('mapGrid.cols', newMapGridCols);
     measureManager.set('ui.mapPanelWidthRatio', newMapPanelWidthRatio);
 
-    uiManager._recalculateUIDimensions();
+    uiEngine._recalculateUIDimensions();
     mapManager._recalculateMapDimensions();
 
-    const uiNewMapPanelWidth = uiManager.getMapPanelDimensions().width;
+    const uiNewMapPanelWidth = uiEngine.getMapPanelDimensions().width;
     const mapNewTileSize = mapManager.getTileSize();
     const mapNewGridCols = mapManager.getGridDimensions().cols;
 

--- a/tests/unit/uiEngineUnitTests.js
+++ b/tests/unit/uiEngineUnitTests.js
@@ -1,0 +1,3 @@
+export function runUIEngineUnitTests() {
+    console.warn('UIEngine unit tests are not implemented yet.');
+}

--- a/tests/unit/uiManagerUnitTests.js
+++ b/tests/unit/uiManagerUnitTests.js
@@ -1,3 +1,0 @@
-export function runUIManagerUnitTests() {
-    console.warn('UIManager unit tests are not implemented yet.');
-}


### PR DESCRIPTION
## Summary
- rename UIManager to **UIEngine** and adjust implementation
- add **LayerEngine** to manage rendering order
- update GameEngine to use UIEngine and LayerEngine
- adapt integration tests and exports for the new engine names

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687165d5c93083279c299b5aa3ad062c