### PR TITLE
Add Map and Grid drawing managers

### DIFF
--- a/js/managers/GridManager.js
+++ b/js/managers/GridManager.js
@@ -1,0 +1,47 @@
+// js/managers/GridManager.js
+
+export class GridManager {
+    constructor(measureManager) {
+        console.log("\u25a3 GridManager initialized. Ready to draw grids. \u25a3");
+        this.measureManager = measureManager;
+    }
+
+    /**
+     * 맵 위에 그리드 라인을 그립니다. UIEngine에서 호출되어 "2층 그리드" 역할을 합니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 렌더링 컨텍스트
+     * @param {number} offsetX - 그리기 시작할 X 오프셋
+     * @param {number} offsetY - 그리기 시작할 Y 오프셋
+     * @param {number} panelWidth - 맵 패널의 너비
+     * @param {number} panelHeight - 맵 패널의 높이
+     */
+    draw(ctx, offsetX, offsetY, panelWidth, panelHeight) {
+        const gridRows = this.measureManager.get('mapGrid.rows');
+        const gridCols = this.measureManager.get('mapGrid.cols');
+
+        if (!gridRows || !gridCols) {
+            console.warn("[GridManager] Cannot draw grid: mapGrid dimensions not found in MeasureManager.");
+            return;
+        }
+
+        const tileWidth = panelWidth / gridCols;
+        const tileHeight = panelHeight / gridRows;
+
+        ctx.strokeStyle = 'rgba(0, 0, 0, 0.5)';
+        ctx.lineWidth = 1;
+
+        for (let i = 0; i <= gridCols; i++) {
+            ctx.beginPath();
+            ctx.moveTo(offsetX + i * tileWidth, offsetY);
+            ctx.lineTo(offsetX + i * tileWidth, offsetY + panelHeight);
+            ctx.stroke();
+        }
+
+        for (let i = 0; i <= gridRows; i++) {
+            ctx.beginPath();
+            ctx.moveTo(offsetX, offsetY + i * tileHeight);
+            ctx.lineTo(offsetX + panelWidth, offsetY + i * tileHeight);
+            ctx.stroke();
+        }
+        console.log("[GridManager] Grid drawn.");
+    }
+}

--- a/js/managers/MapManager.js
+++ b/js/managers/MapManager.js
@@ -72,6 +72,42 @@ export class MapManager {
         };
     }
 
+    /**
+     * 맵 패널에 배경과 타일을 그립니다. UIEngine에서 호출되어
+     * "1층 게임 화면"을 담당합니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 렌더링 컨텍스트
+     * @param {number} offsetX - 그리기 시작할 X 오프셋
+     * @param {number} offsetY - 그리기 시작할 Y 오프셋
+     * @param {number} panelWidth - 맵 패널의 너비
+     * @param {number} panelHeight - 맵 패널의 높이
+     */
+    draw(ctx, offsetX, offsetY, panelWidth, panelHeight) {
+        // 맵 패널 전체를 채우는 기본 배경색
+        ctx.fillStyle = '#6B8E23';
+        ctx.fillRect(offsetX, offsetY, panelWidth, panelHeight);
+
+        // 타일 단위로 맵을 그림
+        const tileWidth = panelWidth / this.gridCols;
+        const tileHeight = panelHeight / this.gridRows;
+
+        for (let y = 0; y < this.gridRows; y++) {
+            for (let x = 0; x < this.gridCols; x++) {
+                const tileType = this.mapData[y][x];
+                const tileX = offsetX + x * tileWidth;
+                const tileY = offsetY + y * tileHeight;
+
+                if (tileType === 'obstacle') {
+                    ctx.fillStyle = '#8B4513';
+                } else {
+                    ctx.fillStyle = '#A0C060';
+                }
+                ctx.fillRect(tileX, tileY, tileWidth, tileHeight);
+            }
+        }
+
+        console.log('[MapManager] Map drawn.');
+    }
+
     // 테스트를 위해 그리드 크기와 타일 크기를 반환합니다.
     getGridDimensions() {
         return {

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -1,11 +1,20 @@
 // js/managers/UIEngine.js
 
+// MapManager와 GridManager를 불러옵니다.
+import { MapManager } from './MapManager.js';
+import { GridManager } from './GridManager.js';
+
 export class UIEngine {
-    constructor(renderer, measureManager, eventManager) {
+    // 생성자에서 mapManager와 gridManager를 추가로 받습니다.
+    constructor(renderer, measureManager, eventManager, mapManager, gridManager) {
         console.log("\ud83d\udcbb UIEngine initialized. Ready to draw interfaces. \ud83d\udcbb");
         this.renderer = renderer;
         this.measureManager = measureManager;
         this.eventManager = eventManager;
+
+        // MapManager와 GridManager 인스턴스 저장
+        this.mapManager = mapManager;
+        this.gridManager = gridManager;
 
         this.canvas = renderer.canvas;
         this.ctx = renderer.ctx;
@@ -26,6 +35,7 @@ export class UIEngine {
 
         this.canvas.addEventListener('click', this._handleClick.bind(this));
 
+        // UI 상태를 관리하는 내부 "작은 엔진"
         this.uiStateEngine = this._createUIStateEngine();
     }
 
@@ -35,8 +45,11 @@ export class UIEngine {
      */
     _recalculateUIDimensions() {
         console.log("[UIEngine] Recalculating UI dimensions based on MeasureManager...");
+        // 맵 패널 크기를 계산하고 중앙에 배치하기 위한 좌표도 저장
         this.mapPanelWidth = this.canvas.width * this.measureManager.get('ui.mapPanelWidthRatio');
         this.mapPanelHeight = this.canvas.height * this.measureManager.get('ui.mapPanelHeightRatio');
+        this.mapPanelX = (this.canvas.width - this.mapPanelWidth) / 2;
+        this.mapPanelY = (this.canvas.height - this.mapPanelHeight) / 2;
         this.buttonHeight = this.measureManager.get('ui.buttonHeight');
         this.buttonWidth = this.measureManager.get('ui.buttonWidth');
         this.buttonMargin = this.measureManager.get('ui.buttonMargin');
@@ -80,22 +93,33 @@ export class UIEngine {
     }
 
     draw() {
+        // 전체 화면의 반투명 배경 (모든 UI 인터페이스의 공통 배경)
         this.ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
         this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
         if (this.uiStateEngine.getState() === 'mapScreen') {
+            // 맵 패널 배경 (아파트 A동의 외부 형태)
             this.ctx.fillStyle = 'lightblue';
             this.ctx.fillRect(
-                (this.canvas.width - this.mapPanelWidth) / 2,
-                (this.canvas.height - this.mapPanelHeight) / 2,
+                this.mapPanelX,
+                this.mapPanelY,
                 this.mapPanelWidth,
                 this.mapPanelHeight
             );
+
+            // 1층 게임 화면 매니저 (MapManager) 호출
+            this.mapManager.draw(this.ctx, this.mapPanelX, this.mapPanelY, this.mapPanelWidth, this.mapPanelHeight);
+
+            // 2층 그리드 매니저 (GridManager) 호출
+            this.gridManager.draw(this.ctx, this.mapPanelX, this.mapPanelY, this.mapPanelWidth, this.mapPanelHeight);
+
+            // 맵 화면 텍스트 (옵션, 맵과 그리드 위에 그려집니다)
             this.ctx.fillStyle = 'black';
             this.ctx.font = '30px Arial';
             this.ctx.textAlign = 'center';
             this.ctx.fillText('맵 화면 (지도 영역)', this.canvas.width / 2, this.canvas.height / 2);
 
+            // '전투 시작' 버튼 (UI 요소)
             this.ctx.fillStyle = 'darkgreen';
             this.ctx.fillRect(
                 this.battleStartButton.x,


### PR DESCRIPTION
## Summary
- implement `MapManager.draw` to render the base map
- add new `GridManager` that draws overlay grid
- extend `UIEngine` to use `MapManager` and `GridManager`
- update `GameEngine` to wire managers together

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl -s http://localhost:8000/debug.html | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6871678ad1188327baafc882923c074b