### PR TITLE
Implement battle stage metrics and dynamic grid

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -41,7 +41,7 @@ export class GameEngine {
         this.layerEngine = new LayerEngine(this.renderer, this.cameraEngine);
 
         this.territoryManager = new TerritoryManager();
-        this.battleStageManager = new BattleStageManager();
+        this.battleStageManager = new BattleStageManager(this.measureManager);
         this.battleGridManager = new BattleGridManager(this.measureManager);
 
         this.sceneManager.registerScene('territoryScene', [this.territoryManager]);

--- a/js/managers/BattleGridManager.js
+++ b/js/managers/BattleGridManager.js
@@ -2,41 +2,69 @@
 
 export class BattleGridManager {
     constructor(measureManager) {
-        console.log("\ud83d\udcdc BattleGridManager initialized. Ready to draw the battlefield grid. \ud83d\udcdc");
+        console.log("\uD83D\uDCDC BattleGridManager initialized. Ready to draw the battlefield grid. \uD83D\uDCDC");
         this.measureManager = measureManager;
-        this.gridRows = 10;
-        this.gridCols = 15;
+        this.gridRows = 10; // 고정된 그리드 행 수
+        this.gridCols = 15; // 고정된 그리드 열 수
     }
 
+    /**
+     * 전투 그리드를 그립니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
+     */
     draw(ctx) {
-        const tileSize = this.measureManager.get('tileSize');
         const canvasWidth = ctx.canvas.width;
         const canvasHeight = ctx.canvas.height;
 
-        const totalGridWidth = this.gridCols * tileSize;
-        const totalGridHeight = this.gridRows * tileSize;
-        const offsetX = (canvasWidth - totalGridWidth) / 2;
-        const offsetY = (canvasHeight - totalGridHeight) / 2;
+        // 1. 배틀 스테이지의 실제 크기와 위치 계산
+        const stageWidthRatio = this.measureManager.get('battleStage.widthRatio');
+        const stageHeightRatio = this.measureManager.get('battleStage.heightRatio');
+        const stagePadding = this.measureManager.get('battleStage.padding');
 
-        ctx.strokeStyle = 'rgba(255, 255, 255, 0.3)';
+        const stageWidth = canvasWidth * stageWidthRatio;
+        const stageHeight = canvasHeight * stageHeightRatio;
+        const stageX = (canvasWidth - stageWidth) / 2;
+        const stageY = (canvasHeight - stageHeight) / 2;
+
+        // 2. 그리드가 그려질 수 있는 유효 영역 계산 (스테이지 내부 여백을 제외)
+        const gridDrawableWidth = stageWidth - 2 * stagePadding;
+        const gridDrawableHeight = stageHeight - 2 * stagePadding;
+
+        // 3. 15x10 그리드가 이 유효 영역에 딱 맞도록 유효 타일 크기 계산
+        const effectiveTileSize = Math.min(
+            gridDrawableWidth / this.gridCols,
+            gridDrawableHeight / this.gridRows
+        );
+
+        const totalGridWidth = this.gridCols * effectiveTileSize;
+        const totalGridHeight = this.gridRows * effectiveTileSize;
+
+        // 4. 그리드를 배틀 스테이지의 유효 영역 내 중앙에 배치
+        const gridOffsetX = stageX + stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
+        const gridOffsetY = stageY + stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
         ctx.lineWidth = 1;
 
+        // 세로선 그리기
         for (let i = 0; i <= this.gridCols; i++) {
             ctx.beginPath();
-            ctx.moveTo(offsetX + i * tileSize, offsetY);
-            ctx.lineTo(offsetX + i * tileSize, offsetY + totalGridHeight);
+            ctx.moveTo(gridOffsetX + i * effectiveTileSize, gridOffsetY);
+            ctx.lineTo(gridOffsetX + i * effectiveTileSize, gridOffsetY + totalGridHeight);
             ctx.stroke();
         }
 
+        // 가로선 그리기
         for (let i = 0; i <= this.gridRows; i++) {
             ctx.beginPath();
-            ctx.moveTo(offsetX, offsetY + i * tileSize);
-            ctx.lineTo(offsetX + totalGridWidth, offsetY + i * tileSize);
+            ctx.moveTo(gridOffsetX, gridOffsetY + i * effectiveTileSize);
+            ctx.lineTo(gridOffsetX + totalGridWidth, gridOffsetY + i * effectiveTileSize);
             ctx.stroke();
         }
 
-        ctx.strokeStyle = 'white';
+        // 그리드 영역 테두리 (확인용)
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
         ctx.lineWidth = 2;
-        ctx.strokeRect(offsetX, offsetY, totalGridWidth, totalGridHeight);
+        ctx.strokeRect(gridOffsetX, gridOffsetY, totalGridWidth, totalGridHeight);
     }
 }

--- a/js/managers/BattleStageManager.js
+++ b/js/managers/BattleStageManager.js
@@ -1,18 +1,35 @@
 // js/managers/BattleStageManager.js
 
 export class BattleStageManager {
-    constructor() {
-        console.log("\ud83c\udfdf\ufe0f BattleStageManager initialized. Preparing the arena. \ud83c\udfdf\ufe0f");
+    constructor(measureManager) {
+        console.log("\uD83C\uDFDF\uFE0F BattleStageManager initialized. Preparing the arena. \uD83C\uDFDF\uFE0F");
+        this.measureManager = measureManager;
     }
 
+    /**
+     * \uc804\ud22c \uc2a4\ud14c\uc774\uc9c0\ub97c \uadf8\ub9bd\ub2c8\ub2e4.
+     * @param {CanvasRenderingContext2D} ctx - \uce90\ub098\uc2a4 2D \ub80c\ub354\ub9c1 \ucee8\ud14d\uc2a4\ud2b8
+     */
     draw(ctx) {
+        const canvasWidth = ctx.canvas.width;
+        const canvasHeight = ctx.canvas.height;
+
+        const stageWidthRatio = this.measureManager.get('battleStage.widthRatio');
+        const stageHeightRatio = this.measureManager.get('battleStage.heightRatio');
+
+        const stageWidth = canvasWidth * stageWidthRatio;
+        const stageHeight = canvasHeight * stageHeightRatio;
+
+        const stageX = (canvasWidth - stageWidth) / 2;
+        const stageY = (canvasHeight - stageHeight) / 2;
+
         ctx.fillStyle = '#6A5ACD';
-        ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        ctx.fillRect(stageX, stageY, stageWidth, stageHeight);
 
         ctx.fillStyle = 'white';
         ctx.font = '40px Arial';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.fillText('전투가 시작됩니다!', ctx.canvas.width / 2, ctx.canvas.height / 2);
+        ctx.fillText('전투가 시작됩니다!', stageX + stageWidth / 2, stageY + stageHeight / 2);
     }
 }

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -18,6 +18,12 @@ export class MeasureManager {
                 buttonHeight: 50,
                 buttonWidth: 200,
                 buttonMargin: 10
+            },
+            // 새로 추가된 배틀 스테이지 크기와 내부 여백 설정
+            battleStage: {
+                widthRatio: 0.9, // 캔버스 너비 대비 배틀 스테이지 너비 비율
+                heightRatio: 0.8, // 캔버스 높이 대비 배틀 스테이지 높이 비율
+                padding: 40 // 배틀 스테이지 내부 여백 (그리드가 이 여백 안에 그려진다)
             }
         };
     }


### PR DESCRIPTION
## Summary
- expand `MeasureManager` with battle stage size and padding
- center the stage using new ratios in `BattleStageManager`
- compute grid tile size based on stage dimensions in `BattleGridManager`
- pass measure manager into `BattleStageManager` from `GameEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871b651ea5c83279ad997f1c45ced01