### PR TITLE
Add mobile compatibility manager

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -11,6 +11,7 @@ import { SceneManager } from './managers/SceneManager.js';
 import { CameraEngine } from './managers/CameraEngine.js';
 import { InputManager } from './managers/InputManager.js';
 import { LogicManager } from './managers/LogicManager.js';
+import { CompatibilityManager } from './managers/CompatibilityManager.js';
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
@@ -29,12 +30,22 @@ export class GameEngine {
         this.guardianManager = new GuardianManager();
         this.measureManager = new MeasureManager();
 
-        this.renderer.canvas.width = this.measureManager.get('gameResolution.width');
-        this.renderer.canvas.height = this.measureManager.get('gameResolution.height');
+        // 화면 크기와 방향을 관리하는 CompatibilityManager 초기화
+        this.compatibilityManager = new CompatibilityManager(
+            this.measureManager,
+            this.renderer,
+            null,
+            null
+        );
 
         this.mapManager = new MapManager(this.measureManager);
 
         this.uiEngine = new UIEngine(this.renderer, this.measureManager, this.eventManager);
+
+        // CompatibilityManager에 UIEngine과 MapManager 참조를 전달한 후, 초기 해상도 조정
+        this.compatibilityManager.uiEngine = this.uiEngine;
+        this.compatibilityManager.mapManager = this.mapManager;
+        this.compatibilityManager.adjustResolution();
 
         this.sceneManager = new SceneManager();
 
@@ -131,4 +142,5 @@ export class GameEngine {
     getCameraEngine() { return this.cameraEngine; }
     getInputManager() { return this.inputManager; }
     getLogicManager() { return this.logicManager; }
+    getCompatibilityManager() { return this.compatibilityManager; }
 }

--- a/js/Renderer.js
+++ b/js/Renderer.js
@@ -8,9 +8,7 @@ export class Renderer {
         }
         this.ctx = this.canvas.getContext('2d');
 
-        // 캔버스 크기 설정 (게임 디자인에 맞게 조절 가능)
-        this.canvas.width = 1280;
-        this.canvas.height = 720;
+        // 캔버스 크기 설정은 CompatibilityManager를 통해 동적으로 결정됩니다.
 
         console.log("Renderer initialized.");
     }

--- a/js/managers/CompatibilityManager.js
+++ b/js/managers/CompatibilityManager.js
@@ -1,0 +1,59 @@
+// js/managers/CompatibilityManager.js
+
+export class CompatibilityManager {
+    constructor(measureManager, renderer, uiEngine, mapManager) {
+        console.log("\ud83d\udcf1 CompatibilityManager initialized. Adapting to screen changes. \ud83d\udcf1");
+        this.measureManager = measureManager;
+        this.renderer = renderer;
+        this.uiEngine = uiEngine;
+        this.mapManager = mapManager;
+
+        this.baseGameWidth = this.measureManager.get('gameResolution.width');
+        this.baseGameHeight = this.measureManager.get('gameResolution.height');
+        this.baseAspectRatio = this.baseGameWidth / this.baseGameHeight;
+
+        this._setupEventListeners();
+        this.adjustResolution();
+    }
+
+    _setupEventListeners() {
+        window.addEventListener('resize', this.adjustResolution.bind(this));
+        console.log("[CompatibilityManager] Listening for window resize events.");
+    }
+
+    adjustResolution() {
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+
+        let newGameWidth;
+        let newGameHeight;
+
+        const currentViewportAspectRatio = viewportWidth / viewportHeight;
+
+        if (currentViewportAspectRatio > this.baseAspectRatio) {
+            newGameHeight = viewportHeight;
+            newGameWidth = newGameHeight * this.baseAspectRatio;
+        } else {
+            newGameWidth = viewportWidth;
+            newGameHeight = newGameWidth / this.baseAspectRatio;
+        }
+
+        newGameWidth = Math.floor(newGameWidth);
+        newGameHeight = Math.floor(newGameHeight);
+
+        this.measureManager.updateGameResolution(newGameWidth, newGameHeight);
+
+        this.renderer.canvas.width = newGameWidth;
+        this.renderer.canvas.height = newGameHeight;
+
+        console.log(`[CompatibilityManager] Canvas adjusted to: ${newGameWidth}x${newGameHeight}`);
+
+        if (this.uiEngine && this.uiEngine.recalculateUIDimensions) {
+            this.uiEngine.recalculateUIDimensions();
+        }
+        if (this.mapManager && this.mapManager.recalculateMapDimensions) {
+            this.mapManager.recalculateMapDimensions();
+        }
+    }
+}
+

--- a/js/managers/MapManager.js
+++ b/js/managers/MapManager.js
@@ -6,7 +6,7 @@ export class MapManager {
         this.measureManager = measureManager;
 
         // 측정값을 기반으로 초기 맵 크기를 계산
-        this._recalculateMapDimensions();
+        this.recalculateMapDimensions();
 
         this.mapData = this._generateRandomMap();
         this.pathfindingEngine = this._createPathfindingEngine();
@@ -18,7 +18,7 @@ export class MapManager {
      * 맵의 그리드 및 타일 크기를 MeasureManager로부터 다시 계산합니다.
      * 측정값이 변경된 경우 호출됩니다.
      */
-    _recalculateMapDimensions() {
+    recalculateMapDimensions() {
         console.log("[MapManager] Recalculating map dimensions based on MeasureManager...");
         this.gridRows = this.measureManager.get('mapGrid.rows');
         this.gridCols = this.measureManager.get('mapGrid.cols');

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -69,4 +69,15 @@ export class MeasureManager {
         console.log(`[MeasureManager] Set '${keyPath}' to ${value}`);
         return true;
     }
+
+    /**
+     * 게임의 해상도(캔버스 크기)를 업데이트합니다.
+     * @param {number} width - 새로운 너비
+     * @param {number} height - 새로운 높이
+     */
+    updateGameResolution(width, height) {
+        this._measurements.gameResolution.width = width;
+        this._measurements.gameResolution.height = height;
+        console.log(`[MeasureManager] Game resolution updated to: ${width}x${height}`);
+    }
 }

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -12,7 +12,7 @@ export class UIEngine {
 
         this._currentUIState = 'mapScreen';
 
-        this._recalculateUIDimensions();
+        this.recalculateUIDimensions();
 
         this.battleStartButton = {
             x: (this.canvas.width - this.buttonWidth) / 2,
@@ -25,7 +25,7 @@ export class UIEngine {
         console.log("[UIEngine] Initialized for overlay UI rendering.");
     }
 
-    _recalculateUIDimensions() {
+    recalculateUIDimensions() {
         console.log("[UIEngine] Recalculating UI dimensions based on MeasureManager...");
         this.mapPanelWidth = this.canvas.width * this.measureManager.get('ui.mapPanelWidthRatio');
         this.mapPanelHeight = this.canvas.height * this.measureManager.get('ui.mapPanelHeightRatio');

--- a/tests/integration/measureManagerIntegrationTests.js
+++ b/tests/integration/measureManagerIntegrationTests.js
@@ -33,8 +33,8 @@ export function runMeasureManagerIntegrationTest(gameEngine) {
     measureManager.set('mapGrid.cols', newMapGridCols);
     measureManager.set('ui.mapPanelWidthRatio', newMapPanelWidthRatio);
 
-    uiEngine._recalculateUIDimensions();
-    mapManager._recalculateMapDimensions();
+    uiEngine.recalculateUIDimensions();
+    mapManager.recalculateMapDimensions();
 
     const uiNewMapPanelWidth = uiEngine.getMapPanelDimensions().width;
     const mapNewTileSize = mapManager.getTileSize();


### PR DESCRIPTION
## Summary
- update MeasureManager so the game resolution can be updated at runtime
- avoid hard-coded canvas size in Renderer
- add CompatibilityManager to adjust resolution according to screen size
- integrate CompatibilityManager in GameEngine
- expose UI and map dimension recalculation methods
- update integration tests

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871be7400ec83279323213e62417dfd