### PR TITLE
Add min resolution constraints

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -30,26 +30,30 @@ export class GameEngine {
         this.guardianManager = new GuardianManager();
         this.measureManager = new MeasureManager();
 
-        // 화면 크기와 방향을 관리하는 CompatibilityManager 초기화
+        // SceneManager 초기화 (LogicManager보다 먼저 초기화되어야 함)
+        this.sceneManager = new SceneManager();
+
+        // LogicManager 초기화
+        this.logicManager = new LogicManager(this.measureManager, this.sceneManager);
+
+        // CompatibilityManager 초기화 (LogicManager를 전달)
         this.compatibilityManager = new CompatibilityManager(
             this.measureManager,
             this.renderer,
-            null,
-            null
+            null, // UIEngine (temp null)
+            null,  // MapManager (temp null)
+            this.logicManager // LogicManager 전달
         );
 
+        // UIEngine과 MapManager 초기화 (CompatibilityManager가 재계산 메서드를 호출할 수 있도록)
         this.mapManager = new MapManager(this.measureManager);
-
         this.uiEngine = new UIEngine(this.renderer, this.measureManager, this.eventManager);
 
-        // CompatibilityManager에 UIEngine과 MapManager 참조를 전달한 후, 초기 해상도 조정
+        // CompatibilityManager에 UIEngine과 MapManager 참조 설정 (생성 후)
         this.compatibilityManager.uiEngine = this.uiEngine;
         this.compatibilityManager.mapManager = this.mapManager;
+        // 초기 캔버스 크기 조정 및 다른 매니저 재계산 트리거 (모든 매니저가 초기화된 후 한 번 더 호출)
         this.compatibilityManager.adjustResolution();
-
-        this.sceneManager = new SceneManager();
-
-        this.logicManager = new LogicManager(this.measureManager, this.sceneManager);
 
         this.cameraEngine = new CameraEngine(this.renderer, this.logicManager, this.sceneManager);
         this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine);

--- a/js/managers/CompatibilityManager.js
+++ b/js/managers/CompatibilityManager.js
@@ -1,12 +1,13 @@
 // js/managers/CompatibilityManager.js
 
 export class CompatibilityManager {
-    constructor(measureManager, renderer, uiEngine, mapManager) {
+    constructor(measureManager, renderer, uiEngine, mapManager, logicManager) {
         console.log("\ud83d\udcf1 CompatibilityManager initialized. Adapting to screen changes. \ud83d\udcf1");
         this.measureManager = measureManager;
         this.renderer = renderer;
         this.uiEngine = uiEngine;
         this.mapManager = mapManager;
+        this.logicManager = logicManager;
 
         this.baseGameWidth = this.measureManager.get('gameResolution.width');
         this.baseGameHeight = this.measureManager.get('gameResolution.height');
@@ -21,9 +22,24 @@ export class CompatibilityManager {
         console.log("[CompatibilityManager] Listening for window resize events.");
     }
 
+    /**
+     * 현재 뷰포트에 맞춰 게임 해상도를 조정합니다.
+     * 원본 게임의 가로세로 비율을 유지하면서 화면에 "포함(contain)"되도록 합니다.
+     * GuardianManager의 최소 해상도 요구 사항을 충족하도록 보장합니다.
+     */
     adjustResolution() {
         const viewportWidth = window.innerWidth;
         const viewportHeight = window.innerHeight;
+
+        // 뷰포트가 0이거나 유효하지 않으면 기본 해상도로 돌아가거나 경고
+        if (viewportWidth === 0 || viewportHeight === 0) {
+            console.warn("[CompatibilityManager] Viewport dimensions are zero, cannot adjust resolution.");
+            const minRes = this.logicManager.getMinGameResolution();
+            this.measureManager.updateGameResolution(minRes.minWidth, minRes.minHeight);
+            this.renderer.canvas.width = minRes.minWidth;
+            this.renderer.canvas.height = minRes.minHeight;
+            return;
+        }
 
         let newGameWidth;
         let newGameHeight;
@@ -31,15 +47,37 @@ export class CompatibilityManager {
         const currentViewportAspectRatio = viewportWidth / viewportHeight;
 
         if (currentViewportAspectRatio > this.baseAspectRatio) {
+            // 뷰포트가 게임 기본 비율보다 가로로 넓다면, 높이에 맞춰 스케일
             newGameHeight = viewportHeight;
             newGameWidth = newGameHeight * this.baseAspectRatio;
         } else {
+            // 뷰포트가 게임 기본 비율보다 세로로 길거나 가로로 좁다면, 너비에 맞춰 스케일
             newGameWidth = viewportWidth;
             newGameHeight = newGameWidth / this.baseAspectRatio;
         }
 
+        // 소수점 제거
         newGameWidth = Math.floor(newGameWidth);
         newGameHeight = Math.floor(newGameHeight);
+
+        // GuardianManager의 최소 해상도 요구 사항 가져오기
+        const minRequiredResolution = this.logicManager.getMinGameResolution();
+
+        // 계산된 해상도가 최소 요구 사항보다 작을 경우 조정
+        if (newGameWidth < minRequiredResolution.minWidth || newGameHeight < minRequiredResolution.minHeight) {
+            console.warn(`[CompatibilityManager] Calculated resolution ${newGameWidth}x${newGameHeight} is below minimum requirement ${minRequiredResolution.minWidth}x${minRequiredResolution.minHeight}. Forcing minimums.`);
+
+            const scaleToFitMinWidth = minRequiredResolution.minWidth / newGameWidth;
+            const scaleToFitMinHeight = minRequiredResolution.minHeight / newGameHeight;
+
+            const forcedScale = Math.max(scaleToFitMinWidth, scaleToFitMinHeight);
+
+            newGameWidth = Math.floor(newGameWidth * forcedScale);
+            newGameHeight = Math.floor(newGameHeight * forcedScale);
+
+            newGameWidth = Math.max(newGameWidth, minRequiredResolution.minWidth);
+            newGameHeight = Math.max(newGameHeight, minRequiredResolution.minHeight);
+        }
 
         this.measureManager.updateGameResolution(newGameWidth, newGameHeight);
 

--- a/js/managers/LogicManager.js
+++ b/js/managers/LogicManager.js
@@ -90,4 +90,13 @@ export class LogicManager {
 
         return { x: clampedX, y: clampedY };
     }
+
+    /**
+     * 게임이 시작하기 위해 필요한 최소 해상도 요구 사항을 반환합니다.
+     * @returns {{minWidth: number, minHeight: number}} 최소 너비와 높이
+     */
+    getMinGameResolution() {
+        // 이 값은 GuardianManager.js의 규칙과 동기화되어야 합니다.
+        return { minWidth: 800, minHeight: 600 };
+    }
 }

--- a/tests/unit/compatibilityManagerUnitTests.js
+++ b/tests/unit/compatibilityManagerUnitTests.js
@@ -25,6 +25,11 @@ export function runCompatibilityManagerUnitTests(compatibilityManagerClass) {
         canvas: { width: 0, height: 0 }
     };
 
+    // mock LogicManager with minimum resolution info
+    const mockLogicManager = {
+        getMinGameResolution: () => ({ minWidth: 800, minHeight: 600 })
+    };
+
     // \ubaa8\uc758 UIEngine, MapManager
     const mockUIEngine = {
         recalculateUIDimensionsCalled: false,
@@ -47,7 +52,7 @@ export function runCompatibilityManagerUnitTests(compatibilityManagerClass) {
     // \ud14c\uc2a4\ud2b8 1: \ucd08\uae30\ud654 \ubc0f \ucd08\uae30 \uc870\uc815 \ud655\uc778 (Landscape)
     testCount++;
     setViewport(1920, 1080);
-    const compatibilityManager1 = new compatibilityManagerClass(mockMeasureManager, mockRenderer, mockUIEngine, mockMapManager);
+    const compatibilityManager1 = new compatibilityManagerClass(mockMeasureManager, mockRenderer, mockUIEngine, mockMapManager, mockLogicManager);
     compatibilityManager1.adjustResolution();
 
     if (mockMeasureManager._resolution.width === 1920 && mockMeasureManager._resolution.height === 1080 &&
@@ -111,7 +116,7 @@ export function runCompatibilityManagerUnitTests(compatibilityManagerClass) {
     };
     try {
         compatibilityManager1.adjustResolution();
-        if (mockMeasureManager._resolution.width === 0 && mockMeasureManager._resolution.height === 0 && warnCalled) {
+        if (mockMeasureManager._resolution.width === 800 && mockMeasureManager._resolution.height === 600 && warnCalled) {
             console.log("CompatibilityManager: Handles zero viewport gracefully. [PASS]");
             passCount++;
         } else {


### PR DESCRIPTION
## Summary
- add `getMinGameResolution` to `LogicManager`
- enforce minimum game resolution through `CompatibilityManager`
- initialize `CompatibilityManager` with `LogicManager` in `GameEngine`
- update CompatibilityManager unit tests for new logic

## Testing
- `npm test`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871c222c010832798fbb182ddc41832