### PR TITLE
Add asset loading and battle simulation managers

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -1,0 +1,25 @@
+// data/class.js
+
+// 이 모듈은 게임 내 모든 클래스의 기본 정보를 정의합니다.
+// IdManager와 연동하여 고유 ID를 사용합니다.
+
+export const CLASS_ROLES = {
+    MELEE_DPS: 'melee_dps',
+    RANGED_DPS: 'ranged_dps',
+    TANK: 'tank',
+    HEALER: 'healer',
+    MAGIC_DPS: 'magic_dps'
+};
+
+export const CLASSES = {
+    WARRIOR: {
+        id: 'class_warrior',
+        name: '전사',
+        role: CLASS_ROLES.MELEE_DPS,
+        description: '강력한 근접 공격과 방어력을 겸비한 병종.',
+        skills: ['skill_melee_attack', 'skill_shield_block']
+    }
+    // 다른 클래스들이 여기에 추가됩니다.
+    // MAGE: { id: 'class_mage', ... }
+    // ARCHER: { id: 'class_archer', ... }
+};

--- a/data/unit.js
+++ b/data/unit.js
@@ -1,0 +1,29 @@
+// data/unit.js
+
+// 이 모듈은 게임 내 모든 유닛의 기본 정보를 정의합니다.
+// IdManager와 연동하여 고유 ID를 사용합니다.
+
+export const UNIT_TYPES = {
+    MERCENARY: 'mercenary',
+    NEUTRAL: 'neutral',
+    ENEMY: 'enemy'
+};
+
+export const UNITS = {
+    // 전사 유닛 ID (IdManager에 등록될 예정)
+    WARRIOR: {
+        id: 'unit_warrior_001',
+        name: '용맹한 전사',
+        classId: 'class_warrior',
+        type: UNIT_TYPES.MERCENARY,
+        baseStats: {
+            hp: 100,
+            attack: 20,
+            defense: 10,
+            speed: 5
+        },
+        spriteId: 'sprite_warrior_default'
+    }
+    // 다른 유닛들이 여기에 추가됩니다.
+    // ARCHER: { id: 'unit_archer_001', ... }
+};

--- a/js/managers/AssetLoaderManager.js
+++ b/js/managers/AssetLoaderManager.js
@@ -1,0 +1,47 @@
+// js/managers/AssetLoaderManager.js
+
+export class AssetLoaderManager {
+    constructor() {
+        console.log("\ud83d\udce6 AssetLoaderManager initialized. Ready to load game assets. \ud83d\udce6");
+        this.assets = new Map();
+    }
+
+    /**
+     * 이미지를 로드하고 관리합니다.
+     * @param {string} assetId - 에셋의 고유 ID
+     * @param {string} url - 이미지 파일의 경로
+     * @returns {Promise<HTMLImageElement>}
+     */
+    loadImage(assetId, url) {
+        if (this.assets.has(assetId)) {
+            console.warn(`[AssetLoaderManager] Asset '${assetId}' is already loaded. Returning existing asset.`);
+            return Promise.resolve(this.assets.get(assetId));
+        }
+
+        return new Promise((resolve, reject) => {
+            const img = new Image();
+            img.onload = () => {
+                this.assets.set(assetId, img);
+                console.log(`[AssetLoaderManager] Image '${assetId}' loaded from ${url}`);
+                resolve(img);
+            };
+            img.onerror = (e) => {
+                console.error(`[AssetLoaderManager] Failed to load image '${assetId}' from ${url}:`, e);
+                reject(new Error(`Failed to load image: ${url}`));
+            };
+            img.src = url;
+        });
+    }
+
+    /**
+     * 로드된 이미지 에셋을 ID로 가져옵니다.
+     * @param {string} assetId
+     * @returns {HTMLImageElement | undefined}
+     */
+    getImage(assetId) {
+        if (!this.assets.has(assetId)) {
+            console.warn(`[AssetLoaderManager] Image asset '${assetId}' not found. Was it loaded?`);
+        }
+        return this.assets.get(assetId);
+    }
+}

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -1,0 +1,74 @@
+// js/managers/BattleSimulationManager.js
+
+export class BattleSimulationManager {
+    constructor(measureManager, assetLoaderManager, idManager) {
+        console.log("\u2694\ufe0f BattleSimulationManager initialized. Preparing units for battle. \u2694\ufe0f");
+        this.measureManager = measureManager;
+        this.assetLoaderManager = assetLoaderManager;
+        this.idManager = idManager;
+        this.unitsOnGrid = [];
+        this.gridRows = 10;
+        this.gridCols = 15;
+    }
+
+    /**
+     * 유닛을 특정 그리드 타일에 배치합니다.
+     * @param {string} unitId
+     * @param {number} gridX
+     * @param {number} gridY
+     * @param {object} [additionalData={}]
+     */
+    addUnit(unitId, gridX, gridY, additionalData = {}) {
+        const unitData = { unitId, gridX, gridY, ...additionalData };
+        this.unitsOnGrid.push(unitData);
+        console.log(`[BattleSimulationManager] Added unit '${unitId}' at (${gridX}, ${gridY}).`);
+    }
+
+    /**
+     * 배틀 그리드에 배치된 모든 유닛을 그립니다.
+     * @param {CanvasRenderingContext2D} ctx
+     */
+    draw(ctx) {
+        const canvasWidth = ctx.canvas.width;
+        const canvasHeight = ctx.canvas.height;
+        const stagePadding = this.measureManager.get('battleStage.padding');
+
+        const gridDrawableWidth = canvasWidth - 2 * stagePadding;
+        const gridDrawableHeight = canvasHeight - 2 * stagePadding;
+
+        const effectiveTileSize = Math.min(
+            gridDrawableWidth / this.gridCols,
+            gridDrawableHeight / this.gridRows
+        );
+
+        const totalGridWidth = this.gridCols * effectiveTileSize;
+        const totalGridHeight = this.gridRows * effectiveTileSize;
+
+        const gridOffsetX = stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
+        const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+
+        for (const unit of this.unitsOnGrid) {
+            this.idManager.get(unit.unitId).then(fullUnitData => {
+                if (fullUnitData && fullUnitData.spriteId) {
+                    const image = this.assetLoaderManager.getImage(fullUnitData.spriteId);
+                    if (image) {
+                        const drawX = gridOffsetX + unit.gridX * effectiveTileSize;
+                        const drawY = gridOffsetY + unit.gridY * effectiveTileSize;
+
+                        const imageSize = effectiveTileSize;
+                        const imgOffsetX = (effectiveTileSize - imageSize) / 2;
+                        const imgOffsetY = (effectiveTileSize - imageSize) / 2;
+
+                        ctx.drawImage(image, drawX + imgOffsetX, drawY + imgOffsetY, imageSize, imageSize);
+                    } else {
+                        console.warn(`[BattleSimulationManager] Image for spriteId '${fullUnitData.spriteId}' not loaded for unit '${unit.unitId}'.`);
+                    }
+                } else {
+                    console.warn(`[BattleSimulationManager] Full unit data or spriteId not found for unit '${unit.unitId}'.`);
+                }
+            }).catch(error => {
+                console.error(`[BattleSimulationManager] Error retrieving unit data for '${unit.unitId}':`, error);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement AssetLoaderManager for game asset loading
- implement BattleSimulationManager to render units on the battle grid
- add basic unit/class data definitions
- integrate new managers in GameEngine

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871c824547c8327b4d1c8dd3e3b2420