### PR TITLE
Update battle sim asset handling

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -167,12 +167,13 @@ export class GameEngine {
         console.log(`[GameEngine] Registered unit ID: ${UNITS.WARRIOR.id}`);
         console.log(`[GameEngine] Loaded warrior sprite: ${UNITS.WARRIOR.spriteId}`);
 
-        // 샘플 ID 조회 (확인용)
+        // 샘플 ID 조회 및 이미지 로드 (동기적 접근을 위해)
         const warriorData = await this.idManager.get(UNITS.WARRIOR.id);
-        console.log("[GameEngine] Retrieved Warrior Unit Data:", warriorData);
+        const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
 
-        // 3. 배틀 시뮬레이션 매니저에 전사 유닛 배치
-        this.battleSimulationManager.addUnit(UNITS.WARRIOR.id, 7, 4);
+        // ✨ 3. 배틀 시뮬레이션 매니저에 전사 유닛 배치 (로드된 데이터와 이미지를 함께 전달)
+        // fullUnitData, unitImage, gridX, gridY 순서로 전달합니다.
+        this.battleSimulationManager.addUnit(warriorData, warriorImage, 7, 4);
     }
 
     _update(deltaTime) {

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -5,7 +5,7 @@ export class BattleSimulationManager {
         console.log("\u2694\ufe0f BattleSimulationManager initialized. Preparing units for battle. \u2694\ufe0f");
         this.measureManager = measureManager;
         this.assetLoaderManager = assetLoaderManager;
-        this.idManager = idManager;
+        this.idManager = idManager; // Keep for other potential uses, though not directly in draw
         this.logicManager = logicManager;
         this.unitsOnGrid = [];
         this.gridRows = 10; // BattleGridManager와 동일한 그리드 차원
@@ -14,15 +14,26 @@ export class BattleSimulationManager {
 
     /**
      * 유닛을 특정 그리드 타일에 배치합니다.
-     * @param {string} unitId
+     * @param {object} fullUnitData - IdManager로부터 완전히 로드된 유닛 데이터
+     * @param {HTMLImageElement} unitImage - 로드된 유닛의 스프라이트 이미지
      * @param {number} gridX
      * @param {number} gridY
-     * @param {object} [additionalData={}]
      */
-    addUnit(unitId, gridX, gridY, additionalData = {}) {
-        const unitData = { unitId, gridX, gridY, ...additionalData };
-        this.unitsOnGrid.push(unitData);
-        console.log(`[BattleSimulationManager] Added unit '${unitId}' at (${gridX}, ${gridY}).`);
+    addUnit(fullUnitData, unitImage, gridX, gridY) {
+        // 유닛의 모든 필요한 데이터를 한 번에 저장합니다.
+        const unitInstance = {
+            id: fullUnitData.id,
+            name: fullUnitData.name,
+            spriteId: fullUnitData.spriteId,
+            image: unitImage, // ✨ 로드된 이미지 객체를 직접 저장합니다.
+            gridX,
+            gridY,
+            // 필요한 경우 다른 데이터도 여기에 추가할 수 있습니다.
+            baseStats: fullUnitData.baseStats,
+            type: fullUnitData.type
+        };
+        this.unitsOnGrid.push(unitInstance);
+        console.log(`[BattleSimulationManager] Added unit '${unitInstance.id}' at (${gridX}, ${gridY}).`);
     }
 
     /**
@@ -51,27 +62,21 @@ export class BattleSimulationManager {
         const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
 
         for (const unit of this.unitsOnGrid) {
-            this.idManager.get(unit.unitId).then(fullUnitData => {
-                if (fullUnitData && fullUnitData.spriteId) {
-                    const image = this.assetLoaderManager.getImage(fullUnitData.spriteId);
-                    if (image) {
-                        const drawX = gridOffsetX + unit.gridX * effectiveTileSize;
-                        const drawY = gridOffsetY + unit.gridY * effectiveTileSize;
+            // ✨ 이제 unit 객체에 이미지 자체가 포함되어 있으므로 비동기 호출 없이 바로 사용합니다.
+            const image = unit.image;
+            if (!image) {
+                console.warn(`[BattleSimulationManager] Image not available for unit '${unit.id}'. Skipping draw.`);
+                continue;
+            }
 
-                        const imageSize = effectiveTileSize;
-                        const imgOffsetX = (effectiveTileSize - imageSize) / 2;
-                        const imgOffsetY = (effectiveTileSize - imageSize) / 2;
+            const drawX = gridOffsetX + unit.gridX * effectiveTileSize;
+            const drawY = gridOffsetY + unit.gridY * effectiveTileSize;
 
-                        ctx.drawImage(image, drawX + imgOffsetX, drawY + imgOffsetY, imageSize, imageSize);
-                    } else {
-                        console.warn(`[BattleSimulationManager] Image for spriteId '${fullUnitData.spriteId}' not loaded for unit '${unit.unitId}'.`);
-                    }
-                } else {
-                    console.warn(`[BattleSimulationManager] Full unit data or spriteId not found for unit '${unit.unitId}'.`);
-                }
-            }).catch(error => {
-                console.error(`[BattleSimulationManager] Error retrieving unit data for '${unit.unitId}':`, error);
-            });
+            const imageSize = effectiveTileSize;
+            const imgOffsetX = (effectiveTileSize - imageSize) / 2;
+            const imgOffsetY = (effectiveTileSize - imageSize) / 2;
+
+            ctx.drawImage(image, drawX + imgOffsetX, drawY + imgOffsetY, imageSize, imageSize);
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor `BattleSimulationManager` to accept fully loaded unit data and images
- load warrior data and sprite first then feed them to `BattleSimulationManager`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6871d20d93a483278fd1e9e69ee62116