### PR TITLE
Fix sample unit positions and load skeleton sprite

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -180,6 +180,8 @@ export class GameEngine {
         const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
 
         this.battleSimulationManager.addUnit({ ...warriorData, currentHp: warriorData.baseStats.hp }, warriorImage, 7, 4);
+        // 아군은 왼쪽에서 시작하므로 전사 유닛을 좀 더 왼쪽에 배치합니다.
+        this.battleSimulationManager.addUnit({ ...warriorData, currentHp: warriorData.baseStats.hp }, warriorImage, 5, 4);
 
         const mockEnemyUnitData = {
             id: 'unit_skeleton_001',
@@ -190,11 +192,14 @@ export class GameEngine {
             spriteId: 'sprite_skeleton_default'
         };
         await this.idManager.addOrUpdateId(mockEnemyUnitData.id, mockEnemyUnitData);
-        await this.assetLoaderManager.loadImage(mockEnemyUnitData.spriteId, 'assets/images/archer.png');
+        // 업로드된 skeleton.png 이미지를 사용합니다.
+        await this.assetLoaderManager.loadImage(mockEnemyUnitData.spriteId, 'assets/images/skeleton.png');
 
         const enemyData = await this.idManager.get(mockEnemyUnitData.id);
         const enemyImage = this.assetLoaderManager.getImage(mockEnemyUnitData.spriteId);
         this.battleSimulationManager.addUnit({ ...enemyData, currentHp: enemyData.baseStats.hp }, enemyImage, 5, 4);
+        // 적 유닛은 아군보다 오른쪽에 배치합니다.
+        this.battleSimulationManager.addUnit({ ...enemyData, currentHp: enemyData.baseStats.hp }, enemyImage, 7, 4);
     }
 
     _update(deltaTime) {


### PR DESCRIPTION
## Summary
- add mirrored warrior and skeleton units in `GameEngine`
- load new `skeleton.png` asset for enemy unit

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871dcb6e1088327a580c391c1bf7569