### PR TITLE
Add VFX manager and battle calculation worker

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -85,6 +85,9 @@
         <button id="injectCompatibilityManagerFaultsBtn" class="fault-btn">CompatibilityManager 결함 주입</button>
         <h4>이벤트 발생 시뮬레이션</h4>
         <button id="simulateEventsBtn">이벤트 시뮬레이션 시작/정지</button>
+
+        <h4>전투 계산 테스트</h4>
+        <button id="testDamageCalculationBtn">대미지 계산 테스트 (전사 -> 해골)</button>
     </div>
     <canvas id="gameCanvas"></canvas>
     <script type="module">
@@ -129,6 +132,7 @@
             const sceneEngine = gameEngine.getSceneEngine();
             const logicManager = gameEngine.getLogicManager();
             const compatibilityManager = gameEngine.getCompatibilityManager();
+            const battleCalculationManager = gameEngine.getBattleCalculationManager();
 
 
             // 테스트용 EventManager 구독 (debug.html에서만 필요)
@@ -211,6 +215,22 @@
             });
             document.getElementById('injectCompatibilityManagerFaultsBtn').addEventListener('click', () => {
                 injectCompatibilityManagerFaults(compatibilityManager);
+            });
+
+            document.getElementById('testDamageCalculationBtn').addEventListener('click', () => {
+                gameEngine.getSceneEngine().setCurrentScene('battleScene');
+                gameEngine.getUIEngine().setUIState('combatScreen');
+                gameEngine.getCameraEngine().reset();
+
+                setTimeout(() => {
+                    console.log("[Debug Main] Requesting damage calculation: WARRIOR attacks SKELETON");
+                    battleCalculationManager.requestDamageCalculation('unit_warrior_001', 'unit_skeleton_001');
+                }, 2000);
+
+                setTimeout(() => {
+                    console.log("[Debug Main] Requesting damage calculation again: WARRIOR attacks SKELETON");
+                    battleCalculationManager.requestDamageCalculation('unit_warrior_001', 'unit_skeleton_001');
+                }, 4000);
             });
 
             let isSimulatingEvents = false;

--- a/js/managers/BattleCalculationManager.js
+++ b/js/managers/BattleCalculationManager.js
@@ -1,0 +1,63 @@
+// js/managers/BattleCalculationManager.js
+
+export class BattleCalculationManager {
+    constructor(eventManager, battleSimulationManager) {
+        console.log("\ud83d\udcca BattleCalculationManager initialized. Delegating heavy calculations to worker. \ud83d\udcca");
+        this.eventManager = eventManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.worker = new Worker('./js/workers/battleCalculationWorker.js');
+
+        this.worker.onmessage = this._handleWorkerMessage.bind(this);
+        this.worker.onerror = (e) => {
+            console.error("[BattleCalculationManager] Worker Error:", e);
+        };
+    }
+
+    _handleWorkerMessage(event) {
+        const { type, unitId, newHp, damageDealt } = event.data;
+
+        if (type === 'DAMAGE_CALCULATED') {
+            console.log(`[BattleCalculationManager] Received damage calculation result for ${unitId}: New HP = ${newHp}, Damage = ${damageDealt}`);
+
+            const unitToUpdate = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+            if (unitToUpdate) {
+                unitToUpdate.currentHp = newHp;
+
+                if (newHp <= 0) {
+                    this.eventManager.emit('unitDeath', { unitId: unitId, unitName: unitToUpdate.name, unitType: unitToUpdate.type });
+                    console.log(`[BattleCalculationManager] Unit '${unitId}' has died.`);
+                }
+            } else {
+                console.warn(`[BattleCalculationManager] Could not find unit '${unitId}' to update HP.`);
+            }
+        }
+    }
+
+    requestDamageCalculation(attackerUnitId, targetUnitId, skillData = null) {
+        const attackerUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === attackerUnitId);
+        const targetUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === targetUnitId);
+
+        if (!attackerUnit || !targetUnit) {
+            console.error("[BattleCalculationManager] Cannot request damage calculation: Attacker or target unit not found.");
+            return;
+        }
+
+        const payload = {
+            attackerStats: attackerUnit.fullUnitData ? attackerUnit.fullUnitData.baseStats : attackerUnit.baseStats,
+            targetStats: targetUnit.fullUnitData ? targetUnit.fullUnitData.baseStats : targetUnit.baseStats,
+            currentTargetHp: targetUnit.currentHp,
+            skillData: skillData,
+            targetUnitId: targetUnitId
+        };
+
+        this.worker.postMessage({ type: 'CALCULATE_DAMAGE', payload });
+        console.log(`[BattleCalculationManager] Requested damage calculation: ${attackerUnitId} attacks ${targetUnitId}.`);
+    }
+
+    terminateWorker() {
+        if (this.worker) {
+            this.worker.terminate();
+            console.log("[BattleCalculationManager] Worker terminated.");
+        }
+    }
+}

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -30,7 +30,9 @@ export class BattleSimulationManager {
             gridY,
             // 필요한 경우 다른 데이터도 여기에 추가할 수 있습니다.
             baseStats: fullUnitData.baseStats,
-            type: fullUnitData.type
+            type: fullUnitData.type,
+            fullUnitData: fullUnitData,
+            currentHp: fullUnitData.currentHp !== undefined ? fullUnitData.currentHp : fullUnitData.baseStats.hp
         };
         this.unitsOnGrid.push(unitInstance);
         console.log(`[BattleSimulationManager] Added unit '${unitInstance.id}' at (${gridX}, ${gridY}).`);

--- a/js/managers/BindingManager.js
+++ b/js/managers/BindingManager.js
@@ -1,0 +1,53 @@
+// js/managers/BindingManager.js
+
+export class BindingManager {
+    constructor() {
+        console.log("\ud83d\udd17 BindingManager initialized. Ready to bind visual components to units. \ud83d\udd17");
+        this.unitBindings = new Map();
+    }
+
+    /**
+     * 유닛과 해당 유닛에 연결된 시각적/애니메이션 컴포넌트들을 바인딩합니다.
+     * @param {string} unitId
+     * @param {object} components
+     */
+    bindUnit(unitId, components) {
+        if (this.unitBindings.has(unitId)) {
+            console.warn(`[BindingManager] Unit '${unitId}' already has existing bindings. Overwriting.`);
+        }
+        this.unitBindings.set(unitId, components);
+        console.log(`[BindingManager] Bound components to unit '${unitId}'.`);
+    }
+
+    /**
+     * 특정 유닛의 바인딩된 컴포넌트를 가져옵니다.
+     * @param {string} unitId
+     * @returns {object | undefined}
+     */
+    getBindings(unitId) {
+        return this.unitBindings.get(unitId);
+    }
+
+    /**
+     * 특정 유닛의 바인딩을 해제합니다.
+     * @param {string} unitId
+     * @returns {boolean}
+     */
+    unbindUnit(unitId) {
+        if (this.unitBindings.has(unitId)) {
+            this.unitBindings.delete(unitId);
+            console.log(`[BindingManager] Unbound components from unit '${unitId}'.`);
+            return true;
+        }
+        console.warn(`[BindingManager] No bindings found for unit '${unitId}'.`);
+        return false;
+    }
+
+    /**
+     * 모든 유닛의 바인딩을 해제합니다.
+     */
+    clearAllBindings() {
+        this.unitBindings.clear();
+        console.log("[BindingManager] All unit bindings cleared.");
+    }
+}

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -1,0 +1,80 @@
+// js/managers/VFXManager.js
+
+export class VFXManager {
+    constructor(renderer, measureManager, cameraEngine, battleSimulationManager) {
+        console.log("\u2728 VFXManager initialized. Ready to render visual effects. \u2728");
+        this.renderer = renderer;
+        this.measureManager = measureManager;
+        this.cameraEngine = cameraEngine;
+        this.battleSimulationManager = battleSimulationManager; // 유닛 데이터를 가져오기 위함
+    }
+
+    /**
+     * 특정 유닛의 HP 바를 그립니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
+     * @param {object} unit - HP 바를 그릴 유닛 객체
+     * @param {number} effectiveTileSize - 유닛이 그려지는 타일의 유효 크기
+     * @param {number} gridOffsetX - 그리드 전체의 x 오프셋
+     * @param {number} gridOffsetY - 그리드 전체의 y 오프셋
+     */
+    drawHpBar(ctx, unit, effectiveTileSize, gridOffsetX, gridOffsetY) {
+        if (!unit || !unit.baseStats) {
+            console.warn("[VFXManager] Cannot draw HP bar: unit data is missing.", unit);
+            return;
+        }
+
+        const maxHp = unit.baseStats.hp;
+        const currentHp = unit.currentHp !== undefined ? unit.currentHp : maxHp;
+        const hpRatio = currentHp / maxHp;
+
+        const barWidth = effectiveTileSize * 0.8;
+        const barHeight = effectiveTileSize * 0.1;
+        const barOffsetY = -barHeight - 5;
+
+        const drawX = gridOffsetX + unit.gridX * effectiveTileSize;
+        const drawY = gridOffsetY + unit.gridY * effectiveTileSize;
+
+        const hpBarDrawX = drawX + (effectiveTileSize - barWidth) / 2;
+        const hpBarDrawY = drawY + barOffsetY;
+
+        ctx.fillStyle = 'rgba(50, 50, 50, 0.8)';
+        ctx.fillRect(hpBarDrawX, hpBarDrawY, barWidth, barHeight);
+
+        ctx.fillStyle = hpRatio > 0.5 ? 'lightgreen' : hpRatio > 0.2 ? 'yellow' : 'red';
+        ctx.fillRect(hpBarDrawX, hpBarDrawY, barWidth * hpRatio, barHeight);
+
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(hpBarDrawX, hpBarDrawY, barWidth, barHeight);
+    }
+
+    /**
+     * 모든 활성 시각 효과를 그립니다. 이 메서드는 LayerEngine에 의해 호출됩니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
+     */
+    draw(ctx) {
+        const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions();
+        const contentWidth = sceneContentDimensions.width;
+        const contentHeight = sceneContentDimensions.height;
+
+        const stagePadding = this.measureManager.get('battleStage.padding');
+
+        const gridDrawableWidth = contentWidth - 2 * stagePadding;
+        const gridDrawableHeight = contentHeight - 2 * stagePadding;
+
+        const effectiveTileSize = Math.min(
+            gridDrawableWidth / this.battleSimulationManager.gridCols,
+            gridDrawableHeight / this.battleSimulationManager.gridRows
+        );
+
+        const totalGridWidth = this.battleSimulationManager.gridCols * effectiveTileSize;
+        const totalGridHeight = this.battleSimulationManager.gridRows * effectiveTileSize;
+
+        const gridOffsetX = stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
+        const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+
+        for (const unit of this.battleSimulationManager.unitsOnGrid) {
+            this.drawHpBar(ctx, unit, effectiveTileSize, gridOffsetX, gridOffsetY);
+        }
+    }
+}

--- a/js/workers/battleCalculationWorker.js
+++ b/js/workers/battleCalculationWorker.js
@@ -1,0 +1,32 @@
+// js/workers/battleCalculationWorker.js
+
+self.onmessage = (event) => {
+    const { type, payload } = event.data;
+
+    switch (type) {
+        case 'CALCULATE_DAMAGE': {
+            const { attackerStats, targetStats, skillData, currentTargetHp } = payload;
+
+            let damage = attackerStats.attack - targetStats.defense;
+            if (damage < 0) damage = 0;
+
+            if (skillData && skillData.type === 'magic') {
+                damage += attackerStats.magic;
+            }
+
+            const newTargetHp = Math.max(0, currentTargetHp - damage);
+
+            self.postMessage({
+                type: 'DAMAGE_CALCULATED',
+                unitId: payload.targetUnitId,
+                newHp: newTargetHp,
+                damageDealt: damage
+            });
+            break;
+        }
+        default:
+            console.warn(`[BattleCalculationWorker] Unknown message type received: ${type}`);
+    }
+};
+
+console.log("[Worker] BattleCalculationWorker initialized. Ready for heavy calculations.");


### PR DESCRIPTION
## Summary
- draw HP bars using new `VFXManager`
- manage unit bindings via `BindingManager`
- compute battle damage in a worker through `BattleCalculationManager`
- update `BattleSimulationManager` to track HP and store full unit data
- extend `GameEngine` with new managers and extra enemy for testing
- expose new debug button to trigger damage calculations

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871ee3746a08327b7b2090d1c8400e9