### PR TITLE
Add mercenary panel canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <canvas id="gameCanvas"></canvas>
+    <div id="gameContainer">
+        <canvas id="mercenaryPanelCanvas"></canvas>
+        <canvas id="gameCanvas"></canvas>
+    </div>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -18,6 +18,7 @@ import { BattleSimulationManager } from './managers/BattleSimulationManager.js';
 import { VFXManager } from './managers/VFXManager.js';
 import { BindingManager } from './managers/BindingManager.js';
 import { BattleCalculationManager } from './managers/BattleCalculationManager.js';
+import { MercenaryPanelManager } from './managers/MercenaryPanelManager.js'; // ✨ 새롭게 추가
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
@@ -86,6 +87,13 @@ export class GameEngine {
         this.bindingManager = new BindingManager();
         this.battleCalculationManager = new BattleCalculationManager(this.eventManager, this.battleSimulationManager);
 
+        // ✨ MercenaryPanelManager 초기화
+        this.mercenaryPanelManager = new MercenaryPanelManager(
+            'mercenaryPanelCanvas',
+            this.measureManager,
+            this.battleSimulationManager
+        );
+
         this.sceneEngine.registerScene('territoryScene', [this.territoryManager]);
         this.sceneEngine.registerScene('battleScene', [
             this.battleStageManager,
@@ -103,6 +111,11 @@ export class GameEngine {
         this.layerEngine.registerLayer('uiLayer', (ctx) => {
             this.uiEngine.draw(ctx);
         }, 100);
+
+        // ✨ 용병 패널 레이어 등록 (UI 레이어보다 높은 zIndex로 최상단에 표시)
+        this.layerEngine.registerLayer('mercenaryPanelLayer', (ctx) => {
+            this.mercenaryPanelManager.draw(ctx);
+        }, 110);
 
         this._update = this._update.bind(this);
         this._draw = this._draw.bind(this);
@@ -228,5 +241,6 @@ export class GameEngine {
     getAssetLoaderManager() { return this.assetLoaderManager; }
     getBattleSimulationManager() { return this.battleSimulationManager; }
     getBattleCalculationManager() { return this.battleCalculationManager; }
+    getMercenaryPanelManager() { return this.mercenaryPanelManager; }
     getBindingManager() { return this.bindingManager; }
 }

--- a/js/managers/MercenaryPanelManager.js
+++ b/js/managers/MercenaryPanelManager.js
@@ -1,0 +1,85 @@
+// js/managers/MercenaryPanelManager.js
+
+import { Renderer } from '../Renderer.js';
+
+export class MercenaryPanelManager {
+    constructor(mercenaryCanvasId, measureManager, battleSimulationManager) {
+        console.log("\uD83D\uDC65 MercenaryPanelManager initialized. Ready to display mercenary details. \uD83D\uDC65");
+        this.renderer = new Renderer(mercenaryCanvasId);
+        this.canvas = this.renderer.canvas;
+        this.ctx = this.renderer.ctx;
+        this.measureManager = measureManager;
+        this.battleSimulationManager = battleSimulationManager;
+
+        this.gridRows = 2; // 세로로 2줄
+        this.gridCols = 6; // 가로로 6칸
+        this.numSlots = this.gridRows * this.gridCols; // 총 12칸
+
+        this.recalculatePanelDimensions();
+
+        window.addEventListener('resize', this.recalculatePanelDimensions.bind(this));
+    }
+
+    recalculatePanelDimensions() {
+        // CSS 크기와 캔버스 해상도를 동기화
+        this.canvas.width = this.canvas.offsetWidth;
+        this.canvas.height = this.canvas.offsetHeight;
+
+        this.slotWidth = this.canvas.width / this.gridCols;
+        this.slotHeight = this.canvas.height / this.gridRows;
+        console.log(`[MercenaryPanelManager] Panel dimensions recalculated. Slot size: ${this.slotWidth}x${this.slotHeight}`);
+    }
+
+    /**
+     * 용병 패널과 그리드를 그립니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트 (이 매니저의 캔버스 컨텍스트)
+     */
+    draw(ctx) {
+        ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        ctx.fillStyle = '#1A1A1A';
+        ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+
+        ctx.strokeStyle = '#555';
+        ctx.lineWidth = 1;
+
+        for (let i = 0; i <= this.gridCols; i++) {
+            ctx.beginPath();
+            ctx.moveTo(i * this.slotWidth, 0);
+            ctx.lineTo(i * this.slotWidth, this.canvas.height);
+            ctx.stroke();
+        }
+        for (let i = 0; i <= this.gridRows; i++) {
+            ctx.beginPath();
+            ctx.moveTo(0, i * this.slotHeight);
+            ctx.lineTo(this.canvas.width, i * this.slotHeight);
+            ctx.stroke();
+        }
+
+        const units = this.battleSimulationManager ? this.battleSimulationManager.unitsOnGrid : [];
+        ctx.fillStyle = 'white';
+        ctx.font = '14px Arial';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+
+        for (let i = 0; i < this.numSlots; i++) {
+            const row = Math.floor(i / this.gridCols);
+            const col = i % this.gridCols;
+            const x = col * this.slotWidth + this.slotWidth / 2;
+            const y = row * this.slotHeight + this.slotHeight / 2;
+
+            if (units[i]) {
+                const unit = units[i];
+                ctx.fillText(`${unit.name}`, x, y - 10);
+                ctx.fillText(`HP: ${unit.currentHp}/${unit.baseStats.hp}`, x, y + 10);
+                if (unit.image) {
+                    const imgSize = Math.min(this.slotWidth, this.slotHeight) * 0.7;
+                    const imgX = col * this.slotWidth + (this.slotWidth - imgSize) / 2;
+                    const imgY = row * this.slotHeight + (this.slotHeight - imgSize) / 2 - 25;
+                    ctx.drawImage(unit.image, imgX, imgY, imgSize, imgSize);
+                }
+            } else {
+                ctx.fillText(`Slot ${i + 1}`, x, y);
+            }
+        }
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1,14 +1,31 @@
 body {
     margin: 0;
-    overflow: hidden; /* Prevent scrollbar */
+    overflow: hidden; /* 스크롤바 방지 */
     display: flex;
     justify-content: center;
     align-items: center;
     min-height: 100vh;
-    background-color: #333; /* Background color */
+    background-color: #333; /* 배경색 */
+    flex-direction: column; /* 자식 요소들을 세로로 정렬 */
+}
+
+/* 두 캔버스를 담는 컨테이너 */
+#gameContainer {
+    display: flex;
+    flex-direction: column; /* 캔버스들을 세로로 정렬 */
+    align-items: center; /* 컨테이너 내에서 캔버스들을 수평 중앙 정렬 */
 }
 
 canvas {
-    border: 2px solid #fff; /* Canvas border */
-    background-color: #000; /* Canvas background */
+    border: 2px solid #fff; /* 캔버스 테두리 */
+    background-color: #000; /* 캔버스 배경 */
+    display: block; /* 캔버스 아래 추가 공간 방지 */
+}
+
+/* 용병 패널 캔버스 전용 스타일 */
+#mercenaryPanelCanvas {
+    width: 100%; /* 컨테이너(gameContainer)의 전체 너비 사용 */
+    height: 150px; /* 패널의 고정 높이 */
+    margin-bottom: 10px; /* 패널과 메인 게임 캔버스 사이의 간격 */
+    border: 2px solid #00f; /* 구분을 위한 다른 테두리 색상 */
 }


### PR DESCRIPTION
## Summary
- wrap game canvas in a container and add a mercenary panel canvas
- lay out canvases vertically with new styles
- introduce `MercenaryPanelManager` to draw mercenary info
- integrate manager in `GameEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68724a37fba0832789306b923b9557dc