### PR TITLE
Fix mercenary panel sizing

### DIFF
--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -26,6 +26,14 @@ export class MeasureManager {
                 widthRatio: 1.0, // 논리적으로 캔버스 전체를 채움
                 heightRatio: 1.0, // 논리적으로 캔버스 전체를 채움
                 padding: 40 // 배틀 스테이지 내부 여백 (그리드가 이 여백 안에 그려짐)
+            },
+            // ✨ 새로운 설정: 용병 패널 관련 크기
+            mercenaryPanel: {
+                baseSlotSize: 100, // 각 슬롯의 기본 크기 (픽셀)
+                gridRows: 2, // 2줄
+                gridCols: 6, // 6칸
+                width: 600, // 6칸 * 100px/칸 = 600px
+                height: 200 // 2줄 * 100px/줄 = 200px
             }
         };
     }

--- a/js/managers/MercenaryPanelManager.js
+++ b/js/managers/MercenaryPanelManager.js
@@ -4,7 +4,7 @@
 
 export class MercenaryPanelManager {
     // 생성자에서 캔버스 ID 대신 캔버스 요소를 직접 받도록 변경합니다.
-    constructor(mercenaryCanvasElement, measureManager, battleSimulationManager, logicManager) { // ✨ logicManager 추가
+    constructor(mercenaryCanvasElement, measureManager, battleSimulationManager, logicManager) {
         console.log("\uD83D\uDC65 MercenaryPanelManager initialized. Ready to display mercenary details. \uD83D\uDC65");
         this.canvas = mercenaryCanvasElement; // ✨ 캔버스 요소를 직접 받습니다.
         this.ctx = this.canvas.getContext('2d'); // ✨ 컨텍스트를 직접 얻습니다.
@@ -12,22 +12,27 @@ export class MercenaryPanelManager {
         this.battleSimulationManager = battleSimulationManager; // 유닛 데이터를 가져오기 위함
         this.logicManager = logicManager; // ✨ LogicManager 추가
 
-        this.gridRows = 2; // 세로로 2줄
-        this.gridCols = 6; // 가로로 6칸
-        this.numSlots = this.gridRows * this.gridCols; // 총 12칸
+        // ✨ MeasureManager에서 그리드 행/열 정보를 가져옴
+        this.gridRows = this.measureManager.get('mercenaryPanel.gridRows');
+        this.gridCols = this.measureManager.get('mercenaryPanel.gridCols');
+        this.numSlots = this.gridRows * this.gridCols;
 
         this.recalculatePanelDimensions();
 
-        // 창 크기 변경 시 치수 조정 (패널 캔버스 자체의 크기는 HTML/CSS에 의해 조정됩니다.)
-        // 따라서 여기서는 내부 그리드 계산만 다시 하면 됩니다.
-        window.addEventListener('resize', this.recalculatePanelDimensions.bind(this));
+        // ✨ 캔버스 크기가 MeasureManager에 의해 고정되므로, window.resize 이벤트 리스너는 제거합니다.
     }
 
     recalculatePanelDimensions() {
-        // 실제 캔버스 요소의 현재 크기를 기반으로 계산
+        // ✨ MeasureManager에서 패널의 고정된 너비와 높이를 가져와 캔버스 속성으로 설정
+        const panelWidth = this.measureManager.get('mercenaryPanel.width');
+        const panelHeight = this.measureManager.get('mercenaryPanel.height');
+
+        this.canvas.width = panelWidth; // 캔버스 내부 드로잉 버퍼의 너비 설정
+        this.canvas.height = panelHeight; // 캔버스 내부 드로잉 버퍼의 높이 설정
+
         this.slotWidth = this.canvas.width / this.gridCols;
         this.slotHeight = this.canvas.height / this.gridRows;
-        console.log(`[MercenaryPanelManager] Panel dimensions recalculated. Slot size: ${this.slotWidth}x${this.slotHeight}`);
+        console.log(`[MercenaryPanelManager] Panel dimensions recalculated and canvas size set to: ${this.canvas.width}x${this.canvas.height}. Slot size: ${this.slotWidth}x${this.slotHeight}`);
     }
 
     /**

--- a/style.css
+++ b/style.css
@@ -24,8 +24,9 @@ canvas {
 
 /* 용병 패널 캔버스 전용 스타일 */
 #mercenaryPanelCanvas {
-    width: 100%; /* 컨테이너(gameContainer)의 전체 너비 사용 */
-    height: 150px; /* 패널의 고정 높이 */
+    /* ✨ width: 100%; 제거 및 고정 값 설정 */
+    width: 600px; /* MeasureManager에 정의된 고정 너비 */
+    height: 200px; /* MeasureManager에 정의된 고정 높이 */
     margin-bottom: 10px; /* 패널과 메인 게임 캔버스 사이의 간격 */
     border: 2px solid #00f; /* 구분을 위한 다른 테두리 색상 */
 }


### PR DESCRIPTION
## Summary
- define mercenary panel dimensions in `MeasureManager`
- use fixed size from `MeasureManager` for mercenary panel canvas
- update stylesheet with the new static sizes

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687251d47f2c8327bacc5196debd7b9b