### PR TITLE
Add turn and timing engines

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -116,6 +116,7 @@
 
             try {
                 gameEngine = new GameEngine('gameCanvas'); // GameEngine 인스턴스 생성
+                gameEngine.eventManager.setGameRunningState(true); // ✨ 디버그 모드에서도 게임 시작 시 상태 설정
                 gameEngine.start(); // 게임 엔진 시작
             } catch (error) {
                 console.error("Fatal Error in Debug Mode: Game Engine failed to start.", error);
@@ -256,9 +257,9 @@
             gameEngine._draw = function() { // GameEngine의 _draw를 오버라이드하여 FPS 로직 추가
                 originalDraw.apply(this, arguments); // 원래 _draw 함수 호출
 
-                // ✨ 용병 패널 캔버스도 그리기
-                if (this.mercenaryPanelManager) {
-                    this.mercenaryPanelManager.draw(this.mercenaryPanelManager.ctx);
+                // ✨ 용병 패널 그리기 호출
+                if (gameEngine.mercenaryPanelManager) {
+                    gameEngine.mercenaryPanelManager.draw(gameEngine.mercenaryPanelManager.ctx);
                 }
 
                 // FPS 카운터 업데이트

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,7 @@ import { GameEngine } from './GameEngine.js';
 document.addEventListener('DOMContentLoaded', () => {
     try {
         const gameEngine = new GameEngine('gameCanvas');
+        gameEngine.eventManager.setGameRunningState(true); // ✨ 게임 시작 시 상태 설정
         gameEngine.start();
     } catch (error) {
         console.error("Fatal Error: Game Engine failed to start.", error);

--- a/js/managers/DelayEngine.js
+++ b/js/managers/DelayEngine.js
@@ -1,0 +1,58 @@
+// js/managers/DelayEngine.js
+
+export class DelayEngine {
+    constructor() {
+        console.log("\u23F1\uFE0F DelayEngine initialized. Ready to manage time. \u23F1\uFE0F");
+        this.delayQueue = [];
+        this.isProcessing = false;
+    }
+
+    /**
+     * 특정 시간만큼 게임 진행을 지연시킵니다.
+     * @param {number} ms - 지연할 시간 (밀리초)
+     * @returns {Promise<void>} - 지연이 완료되면 resolve되는 Promise
+     */
+    async waitFor(ms) {
+        console.log(`[DelayEngine] Waiting for ${ms}ms...`);
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    /**
+     * 프로미스 기반의 작업을 큐에 추가하고 순차적으로 실행합니다.
+     * 여러 애니메이션이나 이벤트가 순서대로 발생해야 할 때 유용합니다.
+     * @param {Function} task - 실행할 비동기 함수 (Promise를 반환해야 함)
+     */
+    queueDelayTask(task) {
+        this.delayQueue.push(task);
+        if (!this.isProcessing) {
+            this._processQueue();
+        }
+    }
+
+    /**
+     * 큐에 있는 작업을 순차적으로 처리합니다.
+     * @private
+     */
+    async _processQueue() {
+        this.isProcessing = true;
+        while (this.delayQueue.length > 0) {
+            const task = this.delayQueue.shift();
+            try {
+                await task();
+            } catch (error) {
+                console.error("[DelayEngine] Error processing delay task:", error);
+            }
+        }
+        this.isProcessing = false;
+        console.log("[DelayEngine] All delay tasks processed.");
+    }
+
+    /**
+     * 현재 지연 큐가 비어있는지 여부를 반환합니다.
+     * 턴 엔진이 다음 행동으로 넘어가기 전에 대기할지 결정하는 데 사용될 수 있습니다.
+     * @returns {boolean}
+     */
+    isQueueEmpty() {
+        return this.delayQueue.length === 0 && !this.isProcessing;
+    }
+}

--- a/js/managers/EventManager.js
+++ b/js/managers/EventManager.js
@@ -6,6 +6,7 @@ export class EventManager {
         // '../workers/eventWorker.js' 경로는 이 파일(EventManager.js) 기준으로 workers 폴더 안의 eventWorker.js를 의미합니다.
         this.worker = new Worker('./js/workers/eventWorker.js'); // main.js에서 EventManager를 불러올 때의 상대 경로
         this.subscribers = new Map(); // 메인 스레드에서 이벤트 구독자를 관리할 Map
+        this._isGameRunning = false; // ✨ 게임 실행 상태 플래그 추가
 
         // Web Worker로부터 메시지를 받을 때 실행될 콜백 설정
         this.worker.onmessage = this.handleWorkerMessage.bind(this);
@@ -86,5 +87,21 @@ export class EventManager {
             this.worker.terminate();
             console.log("[EventManager] Web Worker terminated.");
         }
+    }
+
+    /**
+     * ✨ 게임 실행 상태를 설정합니다.
+     * @param {boolean} isRunning
+     */
+    setGameRunningState(isRunning) {
+        this._isGameRunning = isRunning;
+    }
+
+    /**
+     * ✨ 게임 실행 상태를 반환합니다.
+     * @returns {boolean}
+     */
+    getGameRunningState() {
+        return this._isGameRunning;
     }
 }

--- a/js/managers/TimingEngine.js
+++ b/js/managers/TimingEngine.js
@@ -1,0 +1,56 @@
+// js/managers/TimingEngine.js
+
+export class TimingEngine {
+    constructor(delayEngine) {
+        console.log("\u23F1\uFE0F TimingEngine initialized. Ready to orchestrate turn events. \u23F1\uFE0F");
+        this.delayEngine = delayEngine;
+        this.actionQueue = []; // 현재 턴에서 처리할 액션 큐
+        this.isProcessingActions = false;
+    }
+
+    /**
+     * 턴 내에서 순서대로 처리해야 할 액션을 추가합니다.
+     * @param {Function} actionFunction - 실행할 비동기 함수 (Promise를 반환할 수 있음)
+     * @param {number} priority - 액션의 우선순위 (낮을수록 먼저 실행)
+     * @param {string} name - 액션의 설명 (디버깅용)
+     */
+    addTimedAction(actionFunction, priority = 0, name = "Unnamed Action") {
+        this.actionQueue.push({ actionFunction, priority, name });
+        this.actionQueue.sort((a, b) => a.priority - b.priority);
+        console.log(`[TimingEngine] Added action '${name}' with priority ${priority}. Current queue size: ${this.actionQueue.length}`);
+    }
+
+    /**
+     * 큐에 있는 모든 액션을 우선순위에 따라 순차적으로 실행합니다.
+     */
+    async processActions() {
+        if (this.isProcessingActions) {
+            console.warn("[TimingEngine] Already processing actions. Call ignored.");
+            return;
+        }
+
+        this.isProcessingActions = true;
+        console.log(`[TimingEngine] Processing ${this.actionQueue.length} actions in order...`);
+
+        while (this.actionQueue.length > 0) {
+            const action = this.actionQueue.shift();
+            console.log(`[TimingEngine] Executing action: '${action.name}' (Priority: ${action.priority})`);
+            try {
+                await action.actionFunction();
+            } catch (error) {
+                console.error(`[TimingEngine] Error executing action '${action.name}':`, error);
+            }
+        }
+        this.isProcessingActions = false;
+        console.log("[TimingEngine] All actions processed for this turn.");
+    }
+
+    /**
+     * 현재 액션 큐를 비웁니다. 다음 턴 시작 시 호출될 수 있습니다.
+     */
+    clearActions() {
+        this.actionQueue = [];
+        this.isProcessingActions = false;
+        console.log("[TimingEngine] Action queue cleared.");
+    }
+}

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -1,0 +1,137 @@
+// js/managers/TurnEngine.js
+
+export class TurnEngine {
+    constructor(eventManager, battleSimulationManager) {
+        console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
+        this.eventManager = eventManager;
+        this.battleSimulationManager = battleSimulationManager; // 턴에 참여하는 유닛 정보 등에 접근할 수 있도록
+
+        this.currentTurn = 0;
+        this.activeUnitIndex = -1;
+        this.turnOrder = []; // 유닛들의 턴 순서 배열
+
+        // 턴 시작 시 실행할 콜백 큐 (예: 유닛의 턴 로직)
+        this.turnPhaseCallbacks = {
+            startOfTurn: [],
+            unitActions: [],
+            endOfTurn: []
+        };
+    }
+
+    /**
+     * 턴 순서를 초기화하거나 재계산합니다. (예: 속도 스탯 기반)
+     */
+    initializeTurnOrder() {
+        // 실제 게임에서는 유닛들의 속도, 상태 등에 따라 동적으로 턴 순서를 결정합니다.
+        // 여기서는 BattleSimulationManager에 등록된 유닛들을 기준으로 임시 턴 순서를 생성합니다.
+        // 현재는 단순히 unitsOnGrid 배열의 순서를 따릅니다.
+        this.turnOrder = [...this.battleSimulationManager.unitsOnGrid];
+        console.log("[TurnEngine] Turn order initialized:", this.turnOrder.map(unit => unit.name));
+    }
+
+    /**
+     * 턴 진행을 시작합니다.
+     */
+    async startBattleTurns() {
+        console.log("[TurnEngine] Battle turns are starting!");
+        this.currentTurn = 0;
+        this.initializeTurnOrder(); // 새로운 전투 시작 시 턴 순서 초기화
+        this.nextTurn();
+    }
+
+    /**
+     * 다음 턴으로 진행합니다.
+     */
+    async nextTurn() {
+        if (this.turnOrder.length === 0) {
+            console.warn("[TurnEngine] No units in turn order. Ending turn sequence.");
+            this.eventManager.emit('battleEnd', { reason: 'noUnits' });
+            return;
+        }
+
+        this.currentTurn++;
+        console.log(`\n--- Turn ${this.currentTurn} Starts ---`);
+        this.eventManager.emit('turnStart', { turn: this.currentTurn });
+
+        // 1. 턴 시작 단계 콜백 실행
+        for (const callback of this.turnPhaseCallbacks.startOfTurn) {
+            await callback(); // 비동기 콜백을 기다립니다.
+        }
+
+        // 2. 각 유닛의 행동 처리
+        for (let i = 0; i < this.turnOrder.length; i++) {
+            const unit = this.turnOrder[i];
+            this.activeUnitIndex = i;
+            console.log(`[TurnEngine] Processing turn for unit: ${unit.name} (ID: ${unit.id})`);
+            this.eventManager.emit('unitTurnStart', { unitId: unit.id, unitName: unit.name });
+
+            // 유닛의 행동 로직을 여기에 추가하거나, 별도 매니저에 위임할 수 있습니다.
+            // 임시로, 첫 번째 유닛이 두 번째 유닛을 공격하는 시뮬레이션
+            if (unit.type === 'mercenary' && this.turnOrder.find(u => u.type === 'enemy')) {
+                const targetEnemy = this.turnOrder.find(u => u.type === 'enemy');
+                if (targetEnemy) {
+                    console.log(`[TurnEngine] ${unit.name} attacks ${targetEnemy.name}!`);
+                    // BattleCalculationManager에 대미지 계산 요청
+                    this.eventManager.emit('unitAttackAttempt', {
+                        attackerId: unit.id,
+                        targetId: targetEnemy.id,
+                        attackType: 'melee'
+                    });
+                }
+            } else if (unit.type === 'enemy' && this.turnOrder.find(u => u.type === 'mercenary')) {
+                const targetAlly = this.turnOrder.find(u => u.type === 'mercenary');
+                if (targetAlly) {
+                    console.log(`[TurnEngine] ${unit.name} attacks ${targetAlly.name}!`);
+                    this.eventManager.emit('unitAttackAttempt', {
+                        attackerId: unit.id,
+                        targetId: targetAlly.id,
+                        attackType: 'melee'
+                    });
+                }
+            }
+
+            for (const callback of this.turnPhaseCallbacks.unitActions) {
+                await callback(unit);
+            }
+            this.eventManager.emit('unitTurnEnd', { unitId: unit.id, unitName: unit.name });
+
+            // 유닛 사망 처리 (간단화)
+            this.turnOrder = this.turnOrder.filter(u => u.currentHp > 0);
+            if (this.turnOrder.length === 0) {
+                console.log("[TurnEngine] All units defeated! Battle Over.");
+                this.eventManager.emit('battleEnd', { reason: 'allUnitsDefeated' });
+                return;
+            }
+        }
+
+        // 3. 턴 종료 단계 콜백 실행
+        for (const callback of this.turnPhaseCallbacks.endOfTurn) {
+            await callback();
+        }
+
+        console.log(`--- Turn ${this.currentTurn} Ends ---\n`);
+
+        // 다음 턴을 예약 (예: 짧은 지연 후)
+        setTimeout(() => {
+            if (this.eventManager.getGameRunningState()) { // 게임이 계속 실행 중일 때만 다음 턴 진행
+                this.nextTurn();
+            } else {
+                console.log("[TurnEngine] Game is paused or ended, not proceeding to next turn.");
+            }
+        }, 1000); // 각 턴 사이에 1초 지연
+    }
+
+    /**
+     * 특정 턴 단계에 실행될 콜백 함수를 등록합니다.
+     * @param {'startOfTurn'|'unitActions'|'endOfTurn'} phase - 턴 단계
+     * @param {function} callback - 실행할 콜백 함수
+     */
+    addTurnPhaseCallback(phase, callback) {
+        if (this.turnPhaseCallbacks[phase]) {
+            this.turnPhaseCallbacks[phase].push(callback);
+            console.log(`[TurnEngine] Registered callback for '${phase}' phase.`);
+        } else {
+            console.warn(`[TurnEngine] Invalid turn phase: ${phase}`);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TurnEngine`, `DelayEngine`, and `TimingEngine`
- integrate new engines in `GameEngine`
- extend `EventManager` with game running state
- update entry points to set running state
- expose mercenary panel drawing and start turns from debug page

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6872553514a0832789fe9e912c48f36f