### PR TITLE
Add battle log canvas and manager

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -262,6 +262,11 @@
                     gameEngine.mercenaryPanelManager.draw(gameEngine.mercenaryPanelManager.ctx);
                 }
 
+                // ✨ 전투 로그 패널 그리기 호출 추가
+                if (gameEngine.battleLogManager) {
+                    gameEngine.battleLogManager.draw(gameEngine.battleLogManager.ctx);
+                }
+
                 // FPS 카운터 업데이트
                 frameCount++;
                 const currentTime = performance.now();

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div id="gameContainer">
         <canvas id="mercenaryPanelCanvas"></canvas>
         <canvas id="gameCanvas"></canvas>
+        <canvas id="combatLogCanvas"></canvas>
     </div>
     <script type="module" src="js/main.js"></script>
 </body>

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -24,6 +24,7 @@ import { PanelEngine } from './managers/PanelEngine.js'; // ✨ PanelEngine 추�
 import { TurnEngine } from './managers/TurnEngine.js'; // ✨ TurnEngine 추가
 import { DelayEngine } from './managers/DelayEngine.js'; // ✨ DelayEngine 추가
 import { TimingEngine } from './managers/TimingEngine.js'; // ✨ TimingEngine 추가
+import { BattleLogManager } from './managers/BattleLogManager.js'; // ✨ 새롭게 추가
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
@@ -111,6 +112,17 @@ export class GameEngine {
         );
         // PanelEngine에 용병 패널 등록
         this.panelEngine.registerPanel('mercenaryPanel', this.mercenaryPanelManager);
+
+        // ✨ 전투 로그 캔버스 요소 가져오기 및 BattleLogManager 초기화
+        const combatLogCanvasElement = document.getElementById('combatLogCanvas');
+        if (!combatLogCanvasElement) {
+            console.error("GameEngine: Combat Log Canvas not found. Game cannot proceed without it.");
+            throw new Error("Combat Log Canvas initialization failed.");
+        }
+        this.battleLogManager = new BattleLogManager(
+            combatLogCanvasElement,
+            this.eventManager
+        );
 
         // ✨ 새로운 엔진들 초기화
         this.delayEngine = new DelayEngine();
@@ -244,6 +256,9 @@ export class GameEngine {
         if (this.panelEngine) {
             this.panelEngine.drawPanel('mercenaryPanel', this.mercenaryPanelManager.ctx);
         }
+        if (this.battleLogManager) {
+            this.battleLogManager.draw(this.battleLogManager.ctx);
+        }
     }
 
     start() {
@@ -268,6 +283,7 @@ export class GameEngine {
     getBattleSimulationManager() { return this.battleSimulationManager; }
     getBattleCalculationManager() { return this.battleCalculationManager; }
     getMercenaryPanelManager() { return this.mercenaryPanelManager; }
+    getBattleLogManager() { return this.battleLogManager; }
     getBindingManager() { return this.bindingManager; }
 
     // 새로운 엔진들에 대한 getter 메서드

--- a/js/managers/BattleLogManager.js
+++ b/js/managers/BattleLogManager.js
@@ -1,0 +1,63 @@
+// js/managers/BattleLogManager.js
+
+export class BattleLogManager {
+    constructor(canvasElement, eventManager) {
+        console.log("\uD83D\uDCDC BattleLogManager initialized. Ready to record battle events. \uD83D\uDCDC");
+        this.canvas = canvasElement;
+        this.ctx = this.canvas.getContext('2d');
+        this.eventManager = eventManager;
+
+        this.logMessages = [];
+        this.maxLogLines = 5;
+        this.lineHeight = 20;
+        this.padding = 10;
+
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        this.eventManager.subscribe('unitAttackAttempt', (data) => {
+            this.addLog(`${data.attackerId}\uAC00 ${data.targetId}\uB97C \uACF5\uACA9 \uC2DC\uB3C4!`);
+        });
+        this.eventManager.subscribe('DAMAGE_CALCULATED', (data) => {
+            this.addLog(`${data.unitId}\uAC00 ${data.damageDealt} \uD53C\uD574\uB97C \uC785\uACE0 HP ${data.newHp}\uAC00 \uB418\uBA74.`);
+        });
+        this.eventManager.subscribe('unitDeath', (data) => {
+            this.addLog(`${data.unitName} (ID: ${data.unitId})\uC774(\uAC00) \uC4F0\uB7EC\uC84C\uC2B5\uB2C8\uB2E4!`);
+        });
+        this.eventManager.subscribe('turnStart', (data) => {
+            this.addLog(`--- \uD134 ${data.turn} \uC2DC\uC791 ---`);
+        });
+        this.eventManager.subscribe('battleStart', (data) => {
+            this.addLog(`[\uC804\uD22C \uC2DC\uC791] \uB9F5: ${data.mapId}, \uB09C\uC774\uB3C4: ${data.difficulty}`);
+        });
+        this.eventManager.subscribe('battleEnd', (data) => {
+            this.addLog(`[\uC804\uD22C \uC885\uB8CC] \uC774\uC720: ${data.reason}`);
+        });
+    }
+
+    addLog(message) {
+        const timestamp = new Date().toLocaleTimeString();
+        this.logMessages.push(`[${timestamp}] ${message}`);
+        if (this.logMessages.length > this.maxLogLines) {
+            this.logMessages.shift();
+        }
+        console.log(`[BattleLog] ${message}`);
+    }
+
+    draw(ctx) {
+        ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+        ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+
+        ctx.fillStyle = 'white';
+        ctx.font = '14px Arial';
+        ctx.textBaseline = 'top';
+
+        for (let i = 0; i < this.logMessages.length; i++) {
+            const message = this.logMessages[i];
+            const y = this.padding + i * this.lineHeight;
+            ctx.fillText(message, this.padding, y);
+        }
+    }
+}

--- a/style.css
+++ b/style.css
@@ -30,3 +30,11 @@ canvas {
     margin-bottom: 10px; /* 패널과 메인 게임 캔버스 사이의 간격 */
     border: 2px solid #00f; /* 구분을 위한 다른 테두리 색상 */
 }
+
+/* ✨ 새로운 전투 로그 캔버스 전용 스타일 */
+#combatLogCanvas {
+    width: 600px; /* 용병 패널과 동일한 너비 */
+    height: 120px; /* 고정 높이 (로그 표시 영역) */
+    margin-top: 10px; /* 메인 게임 캔버스 위쪽 간격 */
+    border: 2px solid #f00; /* 구분을 위한 다른 테두리 색상 (빨간색) */
+}


### PR DESCRIPTION
## Summary
- add new combat log canvas element for battle events
- style combat log canvas
- implement `BattleLogManager` to render log messages
- integrate manager into `GameEngine`
- draw combat log in debug mode

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68725921d1948327b364b2b539136a01