### PR TITLE
Add basic AI and Rule managers

### DIFF
--- a/js/managers/AIEngine.js
+++ b/js/managers/AIEngine.js
@@ -1,0 +1,7 @@
+// js/managers/AIEngine.js
+
+export class AIEngine {
+    constructor() {
+        console.log("\u2699\ufe0f AIEngine initialized. Ready to compute strategies. \u2699\ufe0f");
+    }
+}

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -1,0 +1,7 @@
+// js/managers/ClassAIManager.js
+
+export class ClassAIManager {
+    constructor() {
+        console.log("\ud83d\udcbb ClassAIManager initialized. Handling class-specific AI. \ud83d\udcbb");
+    }
+}

--- a/js/managers/MetaAIManager.js
+++ b/js/managers/MetaAIManager.js
@@ -1,0 +1,7 @@
+// js/managers/MetaAIManager.js
+
+export class MetaAIManager {
+    constructor() {
+        console.log("\ud83e\udde0 MetaAIManager initialized. Overseeing AI behaviors. \ud83e\udde0");
+    }
+}

--- a/js/managers/RuleManager.js
+++ b/js/managers/RuleManager.js
@@ -1,0 +1,7 @@
+// js/managers/RuleManager.js
+
+export class RuleManager {
+    constructor() {
+        console.log("\uD83D\uDCD6 RuleManager initialized. Enforcing game rules. \uD83D\uDCD6");
+    }
+}

--- a/js/managers/SkillAIManager.js
+++ b/js/managers/SkillAIManager.js
@@ -1,0 +1,7 @@
+// js/managers/SkillAIManager.js
+
+export class SkillAIManager {
+    constructor() {
+        console.log("\u2728 SkillAIManager initialized. Managing unit skills. \u2728");
+    }
+}


### PR DESCRIPTION
## Summary
- add skeleton manager classes for future AI and rule systems
- add `AIEngine`, `MetaAIManager`, `SkillAIManager`, `ClassAIManager`, and `RuleManager`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68725c718cd88327b2f1a77bd2d97f3e