### PR TITLE
Add turn order and AI movement

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -17,7 +17,8 @@ export const CLASSES = {
         name: '전사',
         role: CLASS_ROLES.MELEE_DPS,
         description: '강력한 근접 공격과 방어력을 겸비한 병종.',
-        skills: ['skill_melee_attack', 'skill_shield_block']
+        skills: ['skill_melee_attack', 'skill_shield_block'],
+        moveRange: 3 // 전사의 이동 거리
     }
     // 다른 클래스들이 여기에 추가됩니다.
     // MAGE: { id: 'class_mage', ... }

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -25,6 +25,8 @@ import { TurnEngine } from './managers/TurnEngine.js'; // ✨ TurnEngine 추가
 import { DelayEngine } from './managers/DelayEngine.js'; // ✨ DelayEngine 추가
 import { TimingEngine } from './managers/TimingEngine.js'; // ✨ TimingEngine 추가
 import { BattleLogManager } from './managers/BattleLogManager.js'; // ✨ 새롭게 추가
+import { TurnOrderManager } from './managers/TurnOrderManager.js'; // ✨ 새롭게 추가
+import { ClassAIManager } from './managers/ClassAIManager.js';   // ✨ 새롭게 추가
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
@@ -127,7 +129,20 @@ export class GameEngine {
         // ✨ 새로운 엔진들 초기화
         this.delayEngine = new DelayEngine();
         this.timingEngine = new TimingEngine(this.delayEngine);
-        this.turnEngine = new TurnEngine(this.eventManager, this.battleSimulationManager); // BattleSimulationManager를 TurnEngine에 전달
+
+        // ✨ 새로운 매니저 초기화
+        this.turnOrderManager = new TurnOrderManager(this.eventManager, this.battleSimulationManager);
+        this.classAIManager = new ClassAIManager(this.idManager, this.battleSimulationManager, this.measureManager);
+
+        // ✨ TurnEngine에 새로운 의존성 전달
+        this.turnEngine = new TurnEngine(
+            this.eventManager,
+            this.battleSimulationManager,
+            this.turnOrderManager,
+            this.classAIManager,
+            this.delayEngine,
+            this.timingEngine
+        );
 
         this.sceneEngine.registerScene('territoryScene', [this.territoryManager]);
         this.sceneEngine.registerScene('battleScene', [

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -39,6 +39,35 @@ export class BattleSimulationManager {
     }
 
     /**
+     * 유닛의 그리드 위치를 업데이트합니다.
+     * @param {string} unitId - 이동할 유닛의 ID
+     * @param {number} newGridX - 새로운 그리드 X 좌표
+     * @param {number} newGridY - 새로운 그리드 Y 좌표
+     * @returns {boolean} 이동 성공 여부
+     */
+    moveUnit(unitId, newGridX, newGridY) {
+        const unit = this.unitsOnGrid.find(u => u.id === unitId);
+        if (unit) {
+            const oldX = unit.gridX;
+            const oldY = unit.gridY;
+
+            if (newGridX >= 0 && newGridX < this.gridCols &&
+                newGridY >= 0 && newGridY < this.gridRows) {
+                unit.gridX = newGridX;
+                unit.gridY = newGridY;
+                console.log(`[BattleSimulationManager] Unit '${unitId}' moved from (${oldX}, ${oldY}) to (${newGridX}, ${newGridY}).`);
+                return true;
+            } else {
+                console.warn(`[BattleSimulationManager] Unit '${unitId}' attempted to move out of bounds to (${newGridX}, ${newGridY}).`);
+                return false;
+            }
+        } else {
+            console.warn(`[BattleSimulationManager] Cannot move unit '${unitId}'. Unit not found.`);
+            return false;
+        }
+    }
+
+    /**
      * 배틀 그리드에 배치된 모든 유닛을 그립니다.
      * @param {CanvasRenderingContext2D} ctx
      */

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -1,7 +1,126 @@
 // js/managers/ClassAIManager.js
 
 export class ClassAIManager {
-    constructor() {
-        console.log("\ud83d\udcbb ClassAIManager initialized. Handling class-specific AI. \ud83d\udcbb");
+    constructor(idManager, battleSimulationManager, measureManager) {
+        console.log("\ud83d\udcbb ClassAIManager initialized. Ready to define class-based AI. \ud83d\udcbb");
+        this.idManager = idManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.measureManager = measureManager;
+    }
+
+    /**
+     * 주어진 유닛의 클래스에 따른 기본 행동을 결정합니다.
+     * @param {object} unit - 현재 턴을 진행하는 유닛 (fullUnitData 포함)
+     * @param {object[]} allUnits - 현재 전장에 있는 모든 유닛
+     * @returns {{actionType: string, targetId?: string, moveTargetX?: number, moveTargetY?: number} | null}
+     */
+    async getBasicClassAction(unit, allUnits) {
+        const unitClass = await this.idManager.get(unit.classId);
+        if (!unitClass) {
+            console.warn(`[ClassAIManager] Class data not found for unit ${unit.name} (${unit.classId}). Cannot determine action.`);
+            return null;
+        }
+
+        switch (unitClass.id) {
+            case 'class_warrior':
+                return this._getWarriorAction(unit, allUnits, unitClass);
+            default:
+                console.warn(`[ClassAIManager] No specific AI defined for class: ${unitClass.name} (${unitClass.id}).`);
+                return null;
+        }
+    }
+
+    /**
+     * 전사 클래스의 AI 로직을 구현합니다. 가까운 적에게 근접하여 공격합니다.
+     * @param {object} warriorUnit
+     * @param {object[]} allUnits
+     * @param {object} warriorClassData
+     * @returns {{actionType: string, targetId?: string, moveTargetX?: number, moveTargetY?: number}}
+     */
+    _getWarriorAction(warriorUnit, allUnits, warriorClassData) {
+        const enemies = allUnits.filter(u => u.type === 'enemy' && u.currentHp > 0);
+        if (enemies.length === 0) {
+            console.log(`[ClassAIManager] Warrior ${warriorUnit.name}: No enemies to attack.`);
+            return null;
+        }
+
+        let closestEnemy = null;
+        let minDistance = Infinity;
+
+        for (const enemy of enemies) {
+            const dist = Math.abs(warriorUnit.gridX - enemy.gridX) + Math.abs(warriorUnit.gridY - enemy.gridY);
+            if (dist < minDistance) {
+                minDistance = dist;
+                closestEnemy = enemy;
+            }
+        }
+
+        if (!closestEnemy) {
+            return null;
+        }
+
+        const attackRange = 1;
+        const dx = Math.abs(warriorUnit.gridX - closestEnemy.gridX);
+        const dy = Math.abs(warriorUnit.gridY - closestEnemy.gridY);
+
+        if (dx <= attackRange && dy <= attackRange && dx + dy <= attackRange * 2) {
+            console.log(`[ClassAIManager] Warrior ${warriorUnit.name}: Enemy ${closestEnemy.name} is in attack range.`);
+            return {
+                actionType: 'attack',
+                targetId: closestEnemy.id
+            };
+        } else {
+            console.log(`[ClassAIManager] Warrior ${warriorUnit.name}: Moving towards ${closestEnemy.name}.`);
+            let targetMoveX = warriorUnit.gridX;
+            let targetMoveY = warriorUnit.gridY;
+
+            const moveRange = warriorClassData.moveRange || 1;
+            let remainingMoves = moveRange;
+
+            while (remainingMoves > 0 && (Math.abs(targetMoveX - closestEnemy.gridX) > 0 || Math.abs(targetMoveY - closestEnemy.gridY) > 0)) {
+                let moved = false;
+                if (targetMoveX < closestEnemy.gridX) {
+                    targetMoveX++;
+                    moved = true;
+                } else if (targetMoveX > closestEnemy.gridX) {
+                    targetMoveX--;
+                    moved = true;
+                }
+
+                if (remainingMoves > 0 && !moved) {
+                    if (targetMoveY < closestEnemy.gridY) {
+                        targetMoveY++;
+                        moved = true;
+                    } else if (targetMoveY > closestEnemy.gridY) {
+                        targetMoveY--;
+                        moved = true;
+                    }
+                }
+
+                if (moved) {
+                    remainingMoves--;
+                    const currentDx = Math.abs(targetMoveX - closestEnemy.gridX);
+                    const currentDy = Math.abs(targetMoveY - closestEnemy.gridY);
+                    if (currentDx <= attackRange && currentDy <= attackRange && currentDx + currentDy <= attackRange * 2) {
+                        console.log(`[ClassAIManager] Warrior ${warriorUnit.name}: Moved to (${targetMoveX},${targetMoveY}) and now in attack range.`);
+                        return {
+                            actionType: 'moveAndAttack',
+                            targetId: closestEnemy.id,
+                            moveTargetX: targetMoveX,
+                            moveTargetY: targetMoveY
+                        };
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            console.log(`[ClassAIManager] Warrior ${warriorUnit.name}: Only moved to (${targetMoveX},${targetMoveY}), not in attack range.`);
+            return {
+                actionType: 'move',
+                moveTargetX: targetMoveX,
+                moveTargetY: targetMoveY
+            };
+        }
     }
 }

--- a/js/managers/RuleManager.js
+++ b/js/managers/RuleManager.js
@@ -3,5 +3,35 @@
 export class RuleManager {
     constructor() {
         console.log("\uD83D\uDCD6 RuleManager initialized. Enforcing game rules. \uD83D\uDCD6");
+        this.rules = new Map();
+        this._loadBasicRules();
+    }
+
+    _loadBasicRules() {
+        // 기본 규칙을 정의합니다.
+        this.addRule('unitActionPerTurn', '유닛은 한 턴 당 [이동 + 공격 or 스킬]을 할 수 있다.');
+        console.log("[RuleManager] Basic rules loaded.");
+    }
+
+    /**
+     * 새로운 게임 규칙을 추가합니다.
+     * @param {string} ruleId - 규칙의 고유 ID
+     * @param {string} description - 규칙에 대한 설명
+     */
+    addRule(ruleId, description) {
+        if (this.rules.has(ruleId)) {
+            console.warn(`[RuleManager] Rule '${ruleId}' already exists. Overwriting.`);
+        }
+        this.rules.set(ruleId, description);
+        console.log(`[RuleManager] Added rule: ${ruleId} - "${description}"`);
+    }
+
+    /**
+     * 특정 규칙의 설명을 가져옵니다.
+     * @param {string} ruleId - 가져올 규칙의 ID
+     * @returns {string | undefined} 규칙 설명 또는 undefined
+     */
+    getRule(ruleId) {
+        return this.rules.get(ruleId);
     }
 }

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -1,31 +1,35 @@
 // js/managers/TurnEngine.js
 
 export class TurnEngine {
-    constructor(eventManager, battleSimulationManager) {
+    constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine) {
         console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
         this.eventManager = eventManager;
-        this.battleSimulationManager = battleSimulationManager; // 턴에 참여하는 유닛 정보 등에 접근할 수 있도록
+        this.battleSimulationManager = battleSimulationManager;
+        this.turnOrderManager = turnOrderManager;
+        this.classAIManager = classAIManager;
+        this.delayEngine = delayEngine;
+        this.timingEngine = timingEngine;
 
         this.currentTurn = 0;
         this.activeUnitIndex = -1;
-        this.turnOrder = []; // 유닛들의 턴 순서 배열
+        this.turnOrder = [];
 
-        // 턴 시작 시 실행할 콜백 큐 (예: 유닛의 턴 로직)
         this.turnPhaseCallbacks = {
             startOfTurn: [],
             unitActions: [],
             endOfTurn: []
         };
+
+        this.eventManager.subscribe('unitDeath', (data) => {
+            this.turnOrderManager.removeUnitFromOrder(data.unitId);
+        });
     }
 
     /**
-     * 턴 순서를 초기화하거나 재계산합니다. (예: 속도 스탯 기반)
+     * 턴 순서를 초기화하거나 재계산합니다.
      */
     initializeTurnOrder() {
-        // 실제 게임에서는 유닛들의 속도, 상태 등에 따라 동적으로 턴 순서를 결정합니다.
-        // 여기서는 BattleSimulationManager에 등록된 유닛들을 기준으로 임시 턴 순서를 생성합니다.
-        // 현재는 단순히 unitsOnGrid 배열의 순서를 따릅니다.
-        this.turnOrder = [...this.battleSimulationManager.unitsOnGrid];
+        this.turnOrder = this.turnOrderManager.calculateTurnOrder();
         console.log("[TurnEngine] Turn order initialized:", this.turnOrder.map(unit => unit.name));
     }
 
@@ -35,59 +39,82 @@ export class TurnEngine {
     async startBattleTurns() {
         console.log("[TurnEngine] Battle turns are starting!");
         this.currentTurn = 0;
-        this.initializeTurnOrder(); // 새로운 전투 시작 시 턴 순서 초기화
+        this.initializeTurnOrder();
         this.nextTurn();
     }
 
-    /**
-     * 다음 턴으로 진행합니다.
-     */
     async nextTurn() {
-        if (this.turnOrder.length === 0) {
-            console.warn("[TurnEngine] No units in turn order. Ending turn sequence.");
-            this.eventManager.emit('battleEnd', { reason: 'noUnits' });
+        const livingMercenaries = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === 'mercenary' && u.currentHp > 0);
+        const livingEnemies = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === 'enemy' && u.currentHp > 0);
+
+        if (livingMercenaries.length === 0) {
+            console.log("[TurnEngine] All mercenaries defeated! Battle Over.");
+            this.eventManager.emit('battleEnd', { reason: 'allMercenariesDefeated' });
+            this.eventManager.setGameRunningState(false);
+            return;
+        }
+        if (livingEnemies.length === 0) {
+            console.log("[TurnEngine] All enemies defeated! Battle Over.");
+            this.eventManager.emit('battleEnd', { reason: 'allEnemiesDefeated' });
+            this.eventManager.setGameRunningState(false);
             return;
         }
 
         this.currentTurn++;
         console.log(`\n--- Turn ${this.currentTurn} Starts ---`);
         this.eventManager.emit('turnStart', { turn: this.currentTurn });
+        this.timingEngine.clearActions();
 
-        // 1. 턴 시작 단계 콜백 실행
         for (const callback of this.turnPhaseCallbacks.startOfTurn) {
-            await callback(); // 비동기 콜백을 기다립니다.
+            await callback();
         }
 
-        // 2. 각 유닛의 행동 처리
-        for (let i = 0; i < this.turnOrder.length; i++) {
-            const unit = this.turnOrder[i];
+        const currentTurnUnits = this.turnOrderManager.getTurnOrder();
+        for (let i = 0; i < currentTurnUnits.length; i++) {
+            const unit = currentTurnUnits[i];
+            if (unit.currentHp <= 0) {
+                console.log(`[TurnEngine] Unit ${unit.name} is already dead. Skipping turn.`);
+                continue;
+            }
+
             this.activeUnitIndex = i;
             console.log(`[TurnEngine] Processing turn for unit: ${unit.name} (ID: ${unit.id})`);
             this.eventManager.emit('unitTurnStart', { unitId: unit.id, unitName: unit.name });
 
-            // 유닛의 행동 로직을 여기에 추가하거나, 별도 매니저에 위임할 수 있습니다.
-            // 임시로, 첫 번째 유닛이 두 번째 유닛을 공격하는 시뮬레이션
-            if (unit.type === 'mercenary' && this.turnOrder.find(u => u.type === 'enemy')) {
-                const targetEnemy = this.turnOrder.find(u => u.type === 'enemy');
-                if (targetEnemy) {
-                    console.log(`[TurnEngine] ${unit.name} attacks ${targetEnemy.name}!`);
-                    // BattleCalculationManager에 대미지 계산 요청
-                    this.eventManager.emit('unitAttackAttempt', {
-                        attackerId: unit.id,
-                        targetId: targetEnemy.id,
-                        attackType: 'melee'
-                    });
-                }
-            } else if (unit.type === 'enemy' && this.turnOrder.find(u => u.type === 'mercenary')) {
-                const targetAlly = this.turnOrder.find(u => u.type === 'mercenary');
-                if (targetAlly) {
-                    console.log(`[TurnEngine] ${unit.name} attacks ${targetAlly.name}!`);
-                    this.eventManager.emit('unitAttackAttempt', {
-                        attackerId: unit.id,
-                        targetId: targetAlly.id,
-                        attackType: 'melee'
-                    });
-                }
+            const action = await this.classAIManager.getBasicClassAction(unit, this.battleSimulationManager.unitsOnGrid);
+
+            if (action) {
+                this.timingEngine.addTimedAction(async () => {
+                    if (action.actionType === 'move' || action.actionType === 'moveAndAttack') {
+                        console.log(`[TurnEngine] Unit ${unit.name} attempts to move to (${action.moveTargetX}, ${action.moveTargetY}).`);
+                        const moved = this.battleSimulationManager.moveUnit(unit.id, action.moveTargetX, action.moveTargetY);
+                        if (moved) {
+                            await this.delayEngine.waitFor(300);
+                        }
+                    }
+
+                    if (action.actionType === 'attack' || action.actionType === 'moveAndAttack') {
+                        if (action.targetId) {
+                            const targetUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === action.targetId);
+                            if (targetUnit && targetUnit.currentHp > 0) {
+                                console.log(`[TurnEngine] Unit ${unit.name} attacks ${targetUnit.name}!`);
+                                this.eventManager.emit('unitAttackAttempt', {
+                                    attackerId: unit.id,
+                                    targetId: targetUnit.id,
+                                    attackType: 'melee'
+                                });
+                                await this.delayEngine.waitFor(500);
+                            } else {
+                                console.log(`[TurnEngine] Target ${action.targetId} is no longer valid for attack.`);
+                            }
+                        }
+                    } else if (action.actionType === 'skill') {
+                        console.log(`[TurnEngine] Unit ${unit.name} attempts to use skill.`);
+                        await this.delayEngine.waitFor(800);
+                    }
+                }, 10, `${unit.name}'s Primary Action`);
+            } else {
+                console.log(`[TurnEngine] Unit ${unit.name} has no determined action for this turn.`);
             }
 
             for (const callback of this.turnPhaseCallbacks.unitActions) {
@@ -95,37 +122,25 @@ export class TurnEngine {
             }
             this.eventManager.emit('unitTurnEnd', { unitId: unit.id, unitName: unit.name });
 
-            // 유닛 사망 처리 (간단화)
-            this.turnOrder = this.turnOrder.filter(u => u.currentHp > 0);
-            if (this.turnOrder.length === 0) {
-                console.log("[TurnEngine] All units defeated! Battle Over.");
-                this.eventManager.emit('battleEnd', { reason: 'allUnitsDefeated' });
-                return;
-            }
+            await this.timingEngine.processActions();
+            this.timingEngine.clearActions();
         }
 
-        // 3. 턴 종료 단계 콜백 실행
         for (const callback of this.turnPhaseCallbacks.endOfTurn) {
             await callback();
         }
 
         console.log(`--- Turn ${this.currentTurn} Ends ---\n`);
 
-        // 다음 턴을 예약 (예: 짧은 지연 후)
-        setTimeout(() => {
-            if (this.eventManager.getGameRunningState()) { // 게임이 계속 실행 중일 때만 다음 턴 진행
-                this.nextTurn();
-            } else {
-                console.log("[TurnEngine] Game is paused or ended, not proceeding to next turn.");
-            }
-        }, 1000); // 각 턴 사이에 1초 지연
+        await this.delayEngine.waitFor(1000);
+
+        if (this.eventManager.getGameRunningState()) {
+            this.nextTurn();
+        } else {
+            console.log("[TurnEngine] Game is paused or ended, not proceeding to next turn.");
+        }
     }
 
-    /**
-     * 특정 턴 단계에 실행될 콜백 함수를 등록합니다.
-     * @param {'startOfTurn'|'unitActions'|'endOfTurn'} phase - 턴 단계
-     * @param {function} callback - 실행할 콜백 함수
-     */
     addTurnPhaseCallback(phase, callback) {
         if (this.turnPhaseCallbacks[phase]) {
             this.turnPhaseCallbacks[phase].push(callback);

--- a/js/managers/TurnOrderManager.js
+++ b/js/managers/TurnOrderManager.js
@@ -1,0 +1,54 @@
+// js/managers/TurnOrderManager.js
+
+export class TurnOrderManager {
+    constructor(eventManager, battleSimulationManager) {
+        console.log("\uD83D\uDCDC TurnOrderManager initialized. Ready to compute turn sequences. \uD83D\uDCDC");
+        this.eventManager = eventManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.currentTurnOrder = [];
+    }
+
+    /**
+     * 현재 전장에 있는 유닛들의 턴 순서를 계산하여 설정합니다.
+     * (예: 속도 스탯 기반으로 정렬)
+     * @returns {object[]} 계산된 턴 순서 유닛 배열
+     */
+    calculateTurnOrder() {
+        const units = this.battleSimulationManager.unitsOnGrid;
+        this.currentTurnOrder = [...units].sort((a, b) => {
+            const speedA = a.baseStats ? a.baseStats.speed : 0;
+            const speedB = b.baseStats ? b.baseStats.speed : 0;
+            return speedB - speedA;
+        });
+        console.log("[TurnOrderManager] Calculated turn order:", this.currentTurnOrder.map(unit => unit.name));
+        return this.currentTurnOrder;
+    }
+
+    /**
+     * 현재 활성화된 턴 순서 배열을 반환합니다.
+     * @returns {object[]}
+     */
+    getTurnOrder() {
+        return this.currentTurnOrder;
+    }
+
+    /**
+     * 특정 유닛을 턴 순서에서 제거합니다. (예: 유닛 사망 시)
+     * @param {string} unitId - 제거할 유닛의 ID
+     */
+    removeUnitFromOrder(unitId) {
+        const initialLength = this.currentTurnOrder.length;
+        this.currentTurnOrder = this.currentTurnOrder.filter(unit => unit.id !== unitId);
+        if (this.currentTurnOrder.length < initialLength) {
+            console.log(`[TurnOrderManager] Unit '${unitId}' removed from turn order.`);
+        }
+    }
+
+    /**
+     * 턴 순서를 초기화합니다.
+     */
+    clearTurnOrder() {
+        this.currentTurnOrder = [];
+        console.log("[TurnOrderManager] Turn order cleared.");
+    }
+}


### PR DESCRIPTION
## Summary
- expand warrior class info with `moveRange`
- remember basic gameplay rules
- implement warrior AI logic
- track and manage unit turn order
- let battle units move on the grid
- orchestrate turns using `TurnOrderManager` and `ClassAIManager`
- hook new managers into `GameEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68725f61a7748327b3ac0813c9d98d62