### PR TITLE
Implement BasicAIManager and refactor AI workflow

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -27,6 +27,7 @@ import { TimingEngine } from './managers/TimingEngine.js'; // ✨ TimingEngine �
 import { BattleLogManager } from './managers/BattleLogManager.js'; // ✨ 새롭게 추가
 import { TurnOrderManager } from './managers/TurnOrderManager.js'; // ✨ 새롭게 추가
 import { ClassAIManager } from './managers/ClassAIManager.js';   // ✨ 새롭게 추가
+import { BasicAIManager } from './managers/BasicAIManager.js'; // ✨ 새롭게 추가
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
@@ -130,9 +131,12 @@ export class GameEngine {
         this.delayEngine = new DelayEngine();
         this.timingEngine = new TimingEngine(this.delayEngine);
 
+        // ✨ BasicAIManager 초기화
+        this.basicAIManager = new BasicAIManager(this.battleSimulationManager);
+
         // ✨ 새로운 매니저 초기화
         this.turnOrderManager = new TurnOrderManager(this.eventManager, this.battleSimulationManager);
-        this.classAIManager = new ClassAIManager(this.idManager, this.battleSimulationManager, this.measureManager);
+        this.classAIManager = new ClassAIManager(this.idManager, this.battleSimulationManager, this.measureManager, this.basicAIManager);
 
         // ✨ TurnEngine에 새로운 의존성 전달
         this.turnEngine = new TurnEngine(

--- a/js/managers/BasicAIManager.js
+++ b/js/managers/BasicAIManager.js
@@ -1,0 +1,116 @@
+// js/managers/BasicAIManager.js
+
+export class BasicAIManager {
+    constructor(battleSimulationManager) {
+        console.log("\ud83c\udfa5 BasicAIManager initialized. Ready to provide fundamental AI behaviors. \ud83c\udfa5");
+        this.battleSimulationManager = battleSimulationManager;
+    }
+
+    /**
+     * \uc720\ub2c8\ud2b8\uc758 \uae30\ubcf8\uc801\uc778 \uc774\ub3d9 \ubc0f \uacf5\uaca9/\uc2a4\ud0ac \ubaa9\ud45c\ub97c \uacb0\uc815\ud569\ub2c8\ub2e4.
+     * \uba38\ub9ac \ud074\ub798\uc2a4 AI\uac00 \uacf5\ud1b5\uc73c\ub85c \uc0ac\uc6a9\ud560 \uc218 \uc788\ub294 \ub85c\uc9c1\uc785\ub2c8\ub2e4.
+     * @param {object} unit - \ud604\uc7ac \ud130\ub110 \uc9c4\ud589\uc911\uc778 \uc720\ub2c8\ud2b8 (fullUnitData \ud3ec\ud568)
+     * @param {object[]} allUnits - \ud604\uc7ac \uc804\uc7c1\uc5d0 \uc788\ub294 \ubaa8\ub4e0 \uc720\ub2c8\ud2b8
+     * @param {number} moveRange - \uc720\ub2c8\ud2b8\uc758 \uc774\ub3d9 \uac00\ub2a5 \uac70\ub9ac
+     * @param {number} attackRange - \uc720\ub2c8\ud2b8\uc758 \uacf5\uaca9 \uc0ac\uac70\ub9ac
+     * @returns {{actionType: string, targetId?: string, moveTargetX?: number, moveTargetY?: number} | null}
+     */
+    determineMoveAndTarget(unit, allUnits, moveRange, attackRange) {
+        const enemies = allUnits.filter(u => u.type !== unit.type && u.currentHp > 0);
+        if (enemies.length === 0) {
+            console.log(`[BasicAIManager] Unit ${unit.name}: No valid targets to attack.`);
+            return null;
+        }
+
+        let closestEnemy = null;
+        let minDistance = Infinity;
+
+        for (const enemy of enemies) {
+            const dist = Math.abs(unit.gridX - enemy.gridX) + Math.abs(unit.gridY - enemy.gridY);
+            if (dist < minDistance) {
+                minDistance = dist;
+                closestEnemy = enemy;
+            }
+        }
+
+        if (!closestEnemy) {
+            return null;
+        }
+
+        const isTargetInAttackRange = (unitX, unitY, targetX, targetY, range) => {
+            const dx = Math.abs(unitX - targetX);
+            const dy = Math.abs(unitY - targetY);
+            return (dx <= range && dy <= range && dx + dy <= range * 2);
+        };
+
+        if (isTargetInAttackRange(unit.gridX, unit.gridY, closestEnemy.gridX, closestEnemy.gridY, attackRange)) {
+            console.log(`[BasicAIManager] Unit ${unit.name}: Target ${closestEnemy.name} is in attack range.`);
+            return { actionType: 'attack', targetId: closestEnemy.id };
+        } else {
+            console.log(`[BasicAIManager] Unit ${unit.name}: Moving towards ${closestEnemy.name}.`);
+            let currentX = unit.gridX;
+            let currentY = unit.gridY;
+
+            let finalMoveX = currentX;
+            let finalMoveY = currentY;
+
+            for (let i = 0; i < moveRange; i++) {
+                let movedThisStep = false;
+                let nextX = finalMoveX;
+                let nextY = finalMoveY;
+
+                const dxToTarget = closestEnemy.gridX - finalMoveX;
+                const dyToTarget = closestEnemy.gridY - finalMoveY;
+
+                let preferredXMove = 0;
+                if (dxToTarget > 0) preferredXMove = 1;
+                else if (dxToTarget < 0) preferredXMove = -1;
+
+                let preferredYMove = 0;
+                if (dyToTarget > 0) preferredYMove = 1;
+                else if (dyToTarget < 0) preferredYMove = -1;
+
+                if (preferredXMove !== 0) {
+                    const potentialX = finalMoveX + preferredXMove;
+                    if (!this.battleSimulationManager.isTileOccupied(potentialX, finalMoveY, unit.id)) {
+                        nextX = potentialX;
+                        movedThisStep = true;
+                    }
+                }
+
+                if (!movedThisStep && preferredYMove !== 0) {
+                    const potentialY = finalMoveY + preferredYMove;
+                    if (!this.battleSimulationManager.isTileOccupied(finalMoveX, potentialY, unit.id)) {
+                        nextY = potentialY;
+                        movedThisStep = true;
+                    }
+                } else if (movedThisStep && preferredYMove !== 0) {
+                    const potentialY = finalMoveY + preferredYMove;
+                    if (!this.battleSimulationManager.isTileOccupied(nextX, potentialY, unit.id)) {
+                        nextY = potentialY;
+                    }
+                }
+
+                if (movedThisStep) {
+                    finalMoveX = nextX;
+                    finalMoveY = nextY;
+                } else {
+                    break;
+                }
+
+                if (isTargetInAttackRange(finalMoveX, finalMoveY, closestEnemy.gridX, closestEnemy.gridY, attackRange)) {
+                    console.log(`[BasicAIManager] Unit ${unit.name}: Moved to (${finalMoveX},${finalMoveY}) and now in attack range.`);
+                    return { actionType: 'moveAndAttack', targetId: closestEnemy.id, moveTargetX: finalMoveX, moveTargetY: finalMoveY };
+                }
+            }
+
+            if (finalMoveX !== unit.gridX || finalMoveY !== unit.gridY) {
+                console.log(`[BasicAIManager] Unit ${unit.name}: Only moved to (${finalMoveX},${finalMoveY}), not in attack range.`);
+                return { actionType: 'move', moveTargetX: finalMoveX, moveTargetY: finalMoveY };
+            } else {
+                console.log(`[BasicAIManager] Unit ${unit.name}: Could not move closer to enemy.`);
+                return null;
+            }
+        }
+    }
+}

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -53,6 +53,10 @@ export class BattleSimulationManager {
 
             if (newGridX >= 0 && newGridX < this.gridCols &&
                 newGridY >= 0 && newGridY < this.gridRows) {
+                if (this.isTileOccupied(newGridX, newGridY, unitId)) {
+                    console.warn(`[BattleSimulationManager] Destination tile (${newGridX}, ${newGridY}) is occupied. Move cancelled.`);
+                    return false;
+                }
                 unit.gridX = newGridX;
                 unit.gridY = newGridY;
                 console.log(`[BattleSimulationManager] Unit '${unitId}' moved from (${oldX}, ${oldY}) to (${newGridX}, ${newGridY}).`);
@@ -65,6 +69,22 @@ export class BattleSimulationManager {
             console.warn(`[BattleSimulationManager] Cannot move unit '${unitId}'. Unit not found.`);
             return false;
         }
+    }
+
+    /**
+     * 특정 타일이 다른 유닛에 의해 점유되어 있는지 확인합니다.
+     * @param {number} gridX
+     * @param {number} gridY
+     * @param {string} [ignoreUnitId] - 점유 여부 확인에서 제외할 유닛 ID
+     * @returns {boolean} 타일 점유 여부
+     */
+    isTileOccupied(gridX, gridY, ignoreUnitId = null) {
+        return this.unitsOnGrid.some(u =>
+            u.gridX === gridX &&
+            u.gridY === gridY &&
+            u.id !== ignoreUnitId &&
+            u.currentHp > 0
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- add new `BasicAIManager` to handle common movement/target logic
- integrate collision check via new `isTileOccupied` in `BattleSimulationManager`
- refactor `ClassAIManager` to use `BasicAIManager`
- instantiate `BasicAIManager` inside `GameEngine` and pass to `ClassAIManager`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687264247a4c8327a1966c0be946ba0b