### PR TITLE
Add unit tests for new managers

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -108,7 +108,18 @@
             runLogicManagerUnitTests,
             injectLogicManagerFaults,
             runCompatibilityManagerUnitTests,
-            injectCompatibilityManagerFaults
+            injectCompatibilityManagerFaults,
+            runMercenaryPanelManagerUnitTests,
+            runPanelEngineUnitTests,
+            runBattleLogManagerUnitTests,
+            runTurnEngineUnitTests,
+            runDelayEngineUnitTests,
+            runTimingEngineUnitTests,
+            runRuleManagerUnitTests,
+            runTurnOrderManagerUnitTests,
+            runBasicAIManagerUnitTests,
+            runClassAIManagerUnitTests,
+            runBattleSimulationManagerUnitTests
         } from './tests/index.js';
 
         document.addEventListener('DOMContentLoaded', () => {
@@ -134,6 +145,14 @@
             const logicManager = gameEngine.getLogicManager();
             const compatibilityManager = gameEngine.getCompatibilityManager();
             const battleCalculationManager = gameEngine.getBattleCalculationManager();
+            const measureManager = gameEngine.getMeasureManager();
+            const battleSimulationManager = gameEngine.getBattleSimulationManager();
+            const turnOrderManager = gameEngine.getTurnOrderManager();
+            const classAIManager = gameEngine.getClassAIManager();
+            const delayEngine = gameEngine.getDelayEngine();
+            const timingEngine = gameEngine.getTimingEngine();
+            const idManager = gameEngine.getIdManager();
+            const basicAIManager = gameEngine.getBasicAIManager();
 
 
             // 테스트용 EventManager 구독 (debug.html에서만 필요)
@@ -160,6 +179,17 @@
                 runSceneEngineUnitTests(sceneEngine);
                 runLogicManagerUnitTests(logicManager);
                 runCompatibilityManagerUnitTests(compatibilityManager);
+                runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
+                runPanelEngineUnitTests();
+                runBattleLogManagerUnitTests(eventManager);
+                runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+                runDelayEngineUnitTests();
+                runTimingEngineUnitTests();
+                runRuleManagerUnitTests();
+                runTurnOrderManagerUnitTests(eventManager, battleSimulationManager);
+                runBasicAIManagerUnitTests(battleSimulationManager);
+                runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager);
+                runBattleSimulationManagerUnitTests(measureManager, gameEngine.getAssetLoaderManager(), idManager, logicManager);
             });
 
             document.getElementById('runMeasureManagerIntegrationTestBtn').addEventListener('click', () => {
@@ -307,6 +337,17 @@
             runSceneEngineUnitTests(sceneEngine);
             runLogicManagerUnitTests(logicManager);
             runCompatibilityManagerUnitTests(compatibilityManager);
+            runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
+            runPanelEngineUnitTests();
+            runBattleLogManagerUnitTests(eventManager);
+            runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+            runDelayEngineUnitTests();
+            runTimingEngineUnitTests();
+            runRuleManagerUnitTests();
+            runTurnOrderManagerUnitTests(eventManager, battleSimulationManager);
+            runBasicAIManagerUnitTests(battleSimulationManager);
+            runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager);
+            runBattleSimulationManagerUnitTests(measureManager, gameEngine.getAssetLoaderManager(), idManager, logicManager);
         });
     </script>
 </body>

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -302,6 +302,7 @@ export class GameEngine {
     getBattleSimulationManager() { return this.battleSimulationManager; }
     getBattleCalculationManager() { return this.battleCalculationManager; }
     getMercenaryPanelManager() { return this.mercenaryPanelManager; }
+    getPanelEngine() { return this.panelEngine; }
     getBattleLogManager() { return this.battleLogManager; }
     getBindingManager() { return this.bindingManager; }
 
@@ -309,4 +310,7 @@ export class GameEngine {
     getDelayEngine() { return this.delayEngine; }
     getTimingEngine() { return this.timingEngine; }
     getTurnEngine() { return this.turnEngine; }
+    getTurnOrderManager() { return this.turnOrderManager; }
+    getBasicAIManager() { return this.basicAIManager; }
+    getClassAIManager() { return this.classAIManager; }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -10,6 +10,17 @@ export { runUIEngineUnitTests } from './unit/uiEngineUnitTests.js';
 export { runSceneEngineUnitTests } from './unit/sceneEngineUnitTests.js';
 export { runLogicManagerUnitTests } from './unit/logicManagerUnitTests.js';
 export { runCompatibilityManagerUnitTests } from './unit/compatibilityManagerUnitTests.js';
+export { runMercenaryPanelManagerUnitTests } from './unit/mercenaryPanelManagerUnitTests.js';
+export { runPanelEngineUnitTests } from './unit/panelEngineUnitTests.js';
+export { runBattleLogManagerUnitTests } from './unit/battleLogManagerUnitTests.js';
+export { runTurnEngineUnitTests } from './unit/turnEngineUnitTests.js';
+export { runDelayEngineUnitTests } from './unit/delayEngineUnitTests.js';
+export { runTimingEngineUnitTests } from './unit/timingEngineUnitTests.js';
+export { runRuleManagerUnitTests } from './unit/ruleManagerUnitTests.js';
+export { runTurnOrderManagerUnitTests } from './unit/turnOrderManagerUnitTests.js';
+export { runBasicAIManagerUnitTests } from './unit/basicAIManagerUnitTests.js';
+export { runClassAIManagerUnitTests } from './unit/classAIManagerUnitTests.js';
+export { runBattleSimulationManagerUnitTests } from './unit/battleSimulationManagerUnitTests.js';
 
 export { runMeasureManagerIntegrationTest } from './integration/measureManagerIntegrationTests.js';
 

--- a/tests/unit/basicAIManagerUnitTests.js
+++ b/tests/unit/basicAIManagerUnitTests.js
@@ -1,0 +1,143 @@
+// tests/unit/basicAIManagerUnitTests.js
+
+import { BasicAIManager } from '../../js/managers/BasicAIManager.js';
+
+export function runBasicAIManagerUnitTests(battleSimulationManager) {
+    console.log("--- BasicAIManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockWarrior = { id: 'w1', name: 'Warrior', type: 'mercenary', gridX: 0, gridY: 0, currentHp: 100 };
+    const mockEnemy1 = { id: 'e1', name: 'Enemy1', type: 'enemy', gridX: 3, gridY: 0, currentHp: 50 };
+    const mockEnemy2 = { id: 'e2', name: 'Enemy2', type: 'enemy', gridX: 0, gridY: 5, currentHp: 50 };
+    const mockObstacle = { id: 'o1', name: 'Obstacle', type: 'obstacle', gridX: 1, gridY: 0, currentHp: 100 };
+
+    const originalUnitsOnGrid = battleSimulationManager.unitsOnGrid;
+    const originalIsTileOccupied = battleSimulationManager.isTileOccupied;
+    const originalGridCols = battleSimulationManager.gridCols;
+    const originalGridRows = battleSimulationManager.gridRows;
+
+    function setupTestEnvironment(units, gridCols = 15, gridRows = 10) {
+        battleSimulationManager.unitsOnGrid = [...units];
+        battleSimulationManager.gridCols = gridCols;
+        battleSimulationManager.gridRows = gridRows;
+        battleSimulationManager.isTileOccupied = (x, y, excludeId) => {
+            return battleSimulationManager.unitsOnGrid.some(u => u.id !== excludeId && u.gridX === x && u.gridY === y && u.currentHp > 0);
+        };
+    }
+
+    function teardownTestEnvironment() {
+        battleSimulationManager.unitsOnGrid = originalUnitsOnGrid;
+        battleSimulationManager.isTileOccupied = originalIsTileOccupied;
+        battleSimulationManager.gridCols = originalGridCols;
+        battleSimulationManager.gridRows = originalGridRows;
+    }
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const basicAIManager = new BasicAIManager(battleSimulationManager);
+        if (basicAIManager.battleSimulationManager === battleSimulationManager) {
+            console.log("BasicAIManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("BasicAIManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BasicAIManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: 적이 공격 범위 내에 있을 때 (공격)
+    testCount++;
+    setupTestEnvironment([mockWarrior, { ...mockEnemy1, gridX: 1, gridY: 0 }]);
+    try {
+        const basicAIManager = new BasicAIManager(battleSimulationManager);
+        const action = basicAIManager.determineMoveAndTarget(mockWarrior, battleSimulationManager.unitsOnGrid, 3, 1);
+        if (action && action.actionType === 'attack' && action.targetId === 'e1') {
+            console.log("BasicAIManager: Determined 'attack' when target in range. [PASS]");
+            passCount++;
+        } else {
+            console.error("BasicAIManager: Failed to determine 'attack' when target in range. [FAIL]", action);
+        }
+    } catch (e) {
+        console.error("BasicAIManager: Error during attack range test. [FAIL]", e);
+    } finally {
+        teardownTestEnvironment();
+    }
+
+    // 테스트 3: 적이 멀리 있을 때 (이동)
+    testCount++;
+    setupTestEnvironment([mockWarrior, mockEnemy1]);
+    try {
+        const basicAIManager = new BasicAIManager(battleSimulationManager);
+        const action = basicAIManager.determineMoveAndTarget(mockWarrior, battleSimulationManager.unitsOnGrid, 3, 1);
+        if (action && action.actionType === 'move' && action.moveTargetX === 3 && action.moveTargetY === 0) {
+            console.log("BasicAIManager: Determined 'move' towards distant target. [PASS]");
+            passCount++;
+        } else {
+            console.error("BasicAIManager: Failed to determine 'move' towards distant target. [FAIL]", action);
+        }
+    } catch (e) {
+        console.error("BasicAIManager: Error during distant target move test. [FAIL]", e);
+    } finally {
+        teardownTestEnvironment();
+    }
+
+    // 테스트 4: 이동 후 공격 범위에 들어올 때 (이동 + 공격)
+    testCount++;
+    setupTestEnvironment([mockWarrior, { ...mockEnemy1, gridX: 3, gridY: 0 }]);
+    try {
+        const basicAIManager = new BasicAIManager(battleSimulationManager);
+        const action = basicAIManager.determineMoveAndTarget(mockWarrior, battleSimulationManager.unitsOnGrid, 3, 1);
+        if (action && action.actionType === 'moveAndAttack' && action.targetId === 'e1' &&
+            action.moveTargetX === 2 && action.moveTargetY === 0) {
+            console.log("BasicAIManager: Determined 'moveAndAttack' when in range after move. [PASS]");
+            passCount++;
+        } else {
+            console.error("BasicAIManager: Failed to determine 'moveAndAttack'. [FAIL]", action);
+        }
+    } catch (e) {
+        console.error("BasicAIManager: Error during moveAndAttack test. [FAIL]", e);
+    } finally {
+        teardownTestEnvironment();
+    }
+
+    // 테스트 5: 이동 경로가 다른 유닛에 의해 막혔을 때 (충돌 회피)
+    testCount++;
+    setupTestEnvironment([mockWarrior, mockEnemy1, mockObstacle]);
+    try {
+        const basicAIManager = new BasicAIManager(battleSimulationManager);
+        const action = basicAIManager.determineMoveAndTarget(mockWarrior, battleSimulationManager.unitsOnGrid, 3, 1);
+        if (action && action.actionType === 'move' && action.moveTargetX === 0 && action.moveTargetY === 1) {
+            console.log("BasicAIManager: Avoided obstacle and attempted alternative move. [PASS]");
+            passCount++;
+        } else {
+            console.error("BasicAIManager: Failed to avoid obstacle or determine alternative move. [FAIL]", action);
+        }
+    } catch (e) {
+        console.error("BasicAIManager: Error during obstacle avoidance test. [FAIL]", e);
+    } finally {
+        teardownTestEnvironment();
+    }
+
+    // 테스트 6: 타겟이 없을 때 null 반환
+    testCount++;
+    setupTestEnvironment([mockWarrior]);
+    try {
+        const basicAIManager = new BasicAIManager(battleSimulationManager);
+        const action = basicAIManager.determineMoveAndTarget(mockWarrior, battleSimulationManager.unitsOnGrid, 3, 1);
+        if (action === null) {
+            console.log("BasicAIManager: Returns null when no targets available. [PASS]");
+            passCount++;
+        } else {
+            console.error("BasicAIManager: Did not return null when no targets available. [FAIL]", action);
+        }
+    } catch (e) {
+        console.error("BasicAIManager: Error when no targets available. [FAIL]", e);
+    } finally {
+        teardownTestEnvironment();
+    }
+
+    console.log(`--- BasicAIManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/battleLogManagerUnitTests.js
+++ b/tests/unit/battleLogManagerUnitTests.js
@@ -1,0 +1,103 @@
+// tests/unit/battleLogManagerUnitTests.js
+
+import { BattleLogManager } from '../../js/managers/BattleLogManager.js';
+
+export function runBattleLogManagerUnitTests(eventManager) {
+    console.log("--- BattleLogManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // Mock 캔버스 요소 및 컨텍스트 생성
+    const mockCanvas = document.createElement('canvas');
+    mockCanvas.width = 600;
+    mockCanvas.height = 120;
+    const mockCtx = mockCanvas.getContext('2d');
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const logManager = new BattleLogManager(mockCanvas, eventManager);
+        if (logManager.logMessages instanceof Array && logManager.logMessages.length === 0) {
+            console.log("BattleLogManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleLogManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleLogManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: 로그 메시지 추가
+    testCount++;
+    try {
+        const logManager = new BattleLogManager(mockCanvas, eventManager);
+        logManager.addLog("Test message 1.");
+        if (logManager.logMessages.length === 1 && logManager.logMessages[0].includes("Test message 1.")) {
+            console.log("BattleLogManager: Added log message successfully. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleLogManager: Failed to add log message. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleLogManager: Error adding log. [FAIL]", e);
+    }
+
+    // 테스트 3: 최대 로그 줄 수 초과 시 오래된 메시지 제거
+    testCount++;
+    try {
+        const logManager = new BattleLogManager(mockCanvas, eventManager);
+        logManager.maxLogLines = 2;
+        logManager.addLog("Oldest message.");
+        logManager.addLog("Middle message.");
+        logManager.addLog("Newest message.");
+
+        if (logManager.logMessages.length === 2 &&
+            logManager.logMessages[0].includes("Middle message.") &&
+            logManager.logMessages[1].includes("Newest message.")) {
+            console.log("BattleLogManager: Managed max log lines correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleLogManager: Failed to manage max log lines. [FAIL]", logManager.logMessages);
+        }
+    } catch (e) {
+        console.error("BattleLogManager: Error managing log lines. [FAIL]", e);
+    }
+
+    // 테스트 4: draw 메서드 호출 시 캔버스에 그리는지 간접 확인
+    testCount++;
+    try {
+        const logManager = new BattleLogManager(mockCanvas, eventManager);
+        logManager.addLog("Drawing test message.");
+
+        const originalFillText = mockCtx.fillText;
+        let fillTextCalled = false;
+        mockCtx.fillText = function(text, ...args) {
+            if (text.includes("Drawing test message.")) {
+                fillTextCalled = true;
+            }
+            originalFillText.apply(this, args);
+        };
+        const originalFillRect = mockCtx.fillRect;
+        let fillRectCalled = false;
+        mockCtx.fillRect = function(...args) {
+            fillRectCalled = true;
+            originalFillRect.apply(this, args);
+        };
+
+        logManager.draw(mockCtx);
+
+        if (fillTextCalled && fillRectCalled) {
+            console.log("BattleLogManager: Draw method called and performed basic drawing operations. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleLogManager: Draw method failed to perform expected drawing operations. [FAIL]");
+        }
+        mockCtx.fillText = originalFillText;
+        mockCtx.fillRect = originalFillRect;
+    } catch (e) {
+        console.error("BattleLogManager: Error during draw. [FAIL]", e);
+    }
+
+    console.log(`--- BattleLogManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/battleSimulationManagerUnitTests.js
+++ b/tests/unit/battleSimulationManagerUnitTests.js
@@ -1,0 +1,150 @@
+// tests/unit/battleSimulationManagerUnitTests.js
+
+import { BattleSimulationManager } from '../../js/managers/BattleSimulationManager.js';
+
+export function runBattleSimulationManagerUnitTests(measureManager, assetLoaderManager, idManager, logicManager) {
+    console.log("--- BattleSimulationManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockUnit1 = { id: 'u1', name: 'Test Unit 1', gridX: 0, gridY: 0, currentHp: 100, baseStats: { hp: 100 }, type: 'mercenary' };
+    const mockUnit2 = { id: 'u2', name: 'Test Unit 2', gridX: 1, gridY: 1, currentHp: 80, baseStats: { hp: 100 }, type: 'enemy' };
+    const mockUnit3 = { id: 'u3', name: 'Test Unit 3', gridX: 0, gridY: 0, currentHp: 0, baseStats: { hp: 100 }, type: 'mercenary' };
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        if (bsm.unitsOnGrid instanceof Array && bsm.unitsOnGrid.length === 0) {
+            console.log("BattleSimulationManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: addUnit 메서드
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        const mockImage = new Image();
+        bsm.addUnit(mockUnit1, mockImage, mockUnit1.gridX, mockUnit1.gridY);
+        if (bsm.unitsOnGrid.length === 1 && bsm.unitsOnGrid[0].id === 'u1' && bsm.unitsOnGrid[0].image === mockImage) {
+            console.log("BattleSimulationManager: addUnit added unit correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: addUnit failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during addUnit. [FAIL]", e);
+    }
+
+    // 테스트 3: moveUnit 메서드 - 성공
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        const mockImage = new Image();
+        bsm.addUnit(mockUnit1, mockImage, 0, 0);
+        const moved = bsm.moveUnit('u1', 2, 3);
+        if (moved && bsm.unitsOnGrid[0].gridX === 2 && bsm.unitsOnGrid[0].gridY === 3) {
+            console.log("BattleSimulationManager: moveUnit succeeded. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: moveUnit failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during moveUnit success. [FAIL]", e);
+    }
+
+    // 테스트 4: moveUnit 메서드 - 충돌
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        const mockImage = new Image();
+        bsm.addUnit(mockUnit1, mockImage, 0, 0);
+        bsm.addUnit(mockUnit2, mockImage, 1, 0);
+
+        const moved = bsm.moveUnit('u1', 1, 0);
+
+        if (!moved && bsm.unitsOnGrid[0].gridX === 0 && bsm.unitsOnGrid[0].gridY === 0) {
+            console.log("BattleSimulationManager: moveUnit failed due to collision. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: moveUnit succeeded despite collision. [FAIL]", bsm.unitsOnGrid[0]);
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during moveUnit collision. [FAIL]", e);
+    }
+
+    // 테스트 5: isTileOccupied - 점유된 타일
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        const mockImage = new Image();
+        bsm.addUnit(mockUnit1, mockImage, 5, 5);
+        const occupied = bsm.isTileOccupied(5, 5);
+        if (occupied) {
+            console.log("BattleSimulationManager: isTileOccupied correctly identified occupied tile. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: isTileOccupied failed to identify occupied tile. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during isTileOccupied (occupied). [FAIL]", e);
+    }
+
+    // 테스트 6: isTileOccupied - 빈 타일
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        bsm.unitsOnGrid = [];
+        const occupied = bsm.isTileOccupied(5, 5);
+        if (!occupied) {
+            console.log("BattleSimulationManager: isTileOccupied correctly identified empty tile. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: isTileOccupied failed to identify empty tile. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during isTileOccupied (empty). [FAIL]", e);
+    }
+
+    // 테스트 7: isTileOccupied - 제외 유닛 ID
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        const mockImage = new Image();
+        bsm.addUnit(mockUnit1, mockImage, 5, 5);
+        const occupied = bsm.isTileOccupied(5, 5, 'u1');
+        if (!occupied) {
+            console.log("BattleSimulationManager: isTileOccupied correctly excluded unit. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: isTileOccupied failed to exclude unit. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during isTileOccupied (exclude). [FAIL]", e);
+    }
+
+    // 테스트 8: isTileOccupied - 죽은 유닛은 점유로 간주하지 않음
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        const mockImage = new Image();
+        bsm.addUnit(mockUnit3, mockImage, 2, 2);
+        const occupied = bsm.isTileOccupied(2, 2);
+        if (!occupied) {
+            console.log("BattleSimulationManager: isTileOccupied correctly ignores dead units. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: isTileOccupied failed to ignore dead units. [FAIL]");
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during isTileOccupied (dead unit). [FAIL]", e);
+    }
+
+    console.log(`--- BattleSimulationManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/classAIManagerUnitTests.js
+++ b/tests/unit/classAIManagerUnitTests.js
@@ -1,0 +1,130 @@
+// tests/unit/classAIManagerUnitTests.js
+
+import { ClassAIManager } from '../../js/managers/ClassAIManager.js';
+
+export function runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager) {
+    console.log("--- ClassAIManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockWarriorUnit = {
+        id: 'mockWarrior1', name: 'Warrior Test', type: 'mercenary',
+        gridX: 0, gridY: 0, currentHp: 100, classId: 'class_warrior'
+    };
+    const mockWarriorClassData = {
+        id: 'class_warrior', name: 'Warrior', moveRange: 3, attackRange: 1
+    };
+    const mockEnemyUnit = {
+        id: 'mockEnemy1', name: 'Enemy Test', type: 'enemy',
+        gridX: 5, gridY: 0, currentHp: 50
+    };
+    const mockUnknownClassUnit = {
+        id: 'mockUnknown1', name: 'Unknown Unit', type: 'mercenary',
+        gridX: 0, gridY: 0, currentHp: 100, classId: 'class_unknown'
+    };
+    const mockUnknownClassData = {
+        id: 'class_unknown', name: 'Unknown', moveRange: 1, attackRange: 1
+    };
+
+    idManager.get = async (id) => {
+        if (id === 'class_warrior') return mockWarriorClassData;
+        if (id === 'class_unknown') return mockUnknownClassData;
+        return undefined;
+    };
+
+    let basicAIManagerCalled = false;
+    basicAIManager.determineMoveAndTarget = (unit, allUnits, moveRange, attackRange) => {
+        basicAIManagerCalled = true;
+        if (unit.id === 'mockWarrior1' && allUnits.includes(mockEnemyUnit)) {
+            return { actionType: 'moveAndAttack', targetId: mockEnemyUnit.id, moveTargetX: 2, moveTargetY: 0 };
+        }
+        return null;
+    };
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager);
+        if (classAIManager.basicAIManager === basicAIManager) {
+            console.log("ClassAIManager: Initialized correctly with BasicAIManager. [PASS]");
+            passCount++;
+        } else {
+            console.error("ClassAIManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("ClassAIManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: 전사 유닛 행동 결정 (BasicAIManager 위임 확인)
+    testCount++;
+    basicAIManagerCalled = false;
+    try {
+        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager);
+        battleSimulationManager.unitsOnGrid = [mockWarriorUnit, mockEnemyUnit];
+        const action = await classAIManager.getBasicClassAction(mockWarriorUnit, battleSimulationManager.unitsOnGrid);
+
+        if (basicAIManagerCalled && action && action.actionType === 'moveAndAttack') {
+            console.log("ClassAIManager: Warrior action delegated to BasicAIManager correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("ClassAIManager: Warrior action delegation failed. [FAIL]", action);
+        }
+    } catch (e) {
+        console.error("ClassAIManager: Error during warrior action delegation test. [FAIL]", e);
+    }
+
+    // 테스트 3: 알 수 없는 클래스 유닛 행동 결정
+    testCount++;
+    basicAIManagerCalled = false;
+    try {
+        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager);
+        battleSimulationManager.unitsOnGrid = [mockUnknownClassUnit, mockEnemyUnit];
+        const action = await classAIManager.getBasicClassAction(mockUnknownClassUnit, battleSimulationManager.unitsOnGrid);
+
+        if (basicAIManagerCalled && action === null) {
+            console.log("ClassAIManager: Unknown class action delegated to BasicAIManager as default. [PASS]");
+            passCount++;
+        } else {
+            console.error("ClassAIManager: Unknown class action delegation failed or returned unexpected. [FAIL]", action);
+        }
+    } catch (e) {
+        console.error("ClassAIManager: Error during unknown class action test. [FAIL]", e);
+    }
+
+    // 테스트 4: 클래스 데이터 없을 때 경고 및 null 반환
+    testCount++;
+    const originalWarn = console.warn;
+    let warnCalled = false;
+    idManager.get = async (id) => {
+        if (id === 'class_nonexistent') {
+            return undefined;
+        }
+        return mockWarriorClassData;
+    };
+    console.warn = (message) => {
+        if (message.includes("Class data not found for unit")) {
+            warnCalled = true;
+        }
+        originalWarn(message);
+    };
+
+    try {
+        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager);
+        const mockUnitNoClass = { ...mockWarriorUnit, classId: 'class_nonexistent' };
+        const action = await classAIManager.getBasicClassAction(mockUnitNoClass, battleSimulationManager.unitsOnGrid);
+
+        if (warnCalled && action === null) {
+            console.log("ClassAIManager: Handles missing class data gracefully with warning. [PASS]");
+            passCount++;
+        } else {
+            console.error("ClassAIManager: Failed to handle missing class data. [FAIL]", action);
+        }
+    } catch (e) {
+        console.error("ClassAIManager: Error during missing class data test. [FAIL]", e);
+    } finally {
+        console.warn = originalWarn;
+    }
+
+    console.log(`--- ClassAIManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/delayEngineUnitTests.js
+++ b/tests/unit/delayEngineUnitTests.js
@@ -1,0 +1,113 @@
+// tests/unit/delayEngineUnitTests.js
+
+import { DelayEngine } from '../../js/managers/DelayEngine.js';
+
+export function runDelayEngineUnitTests() {
+    console.log("--- DelayEngine Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const delayEngine = new DelayEngine();
+        if (delayEngine.delayQueue instanceof Array && !delayEngine.isProcessing) {
+            console.log("DelayEngine: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("DelayEngine: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("DelayEngine: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: waitFor 메서드 (비동기)
+    testCount++;
+    try {
+        const delayEngine = new DelayEngine();
+        const startTime = performance.now();
+        const delayTime = 50;
+
+        delayEngine.waitFor(delayTime).then(() => {
+            const endTime = performance.now();
+            const elapsed = endTime - startTime;
+            if (elapsed >= delayTime * 0.8 && elapsed <= delayTime * 1.5) {
+                console.log("DelayEngine: waitFor completed with expected delay. [PASS]");
+                passCount++;
+            } else {
+                console.error("DelayEngine: waitFor completed with unexpected delay. [FAIL]", `Elapsed: ${elapsed}ms`);
+            }
+        });
+    } catch (e) {
+        console.error("DelayEngine: Error during waitFor test. [FAIL]", e);
+    }
+
+    // 테스트 3: queueDelayTask 및 _processQueue (순차적 실행)
+    testCount++;
+    try {
+        const delayEngine = new DelayEngine();
+        let executionOrder = [];
+
+        const task1 = async () => {
+            executionOrder.push(1);
+            await delayEngine.waitFor(10);
+        };
+        const task2 = async () => {
+            executionOrder.push(2);
+            await delayEngine.waitFor(5);
+        };
+        const task3 = async () => {
+            executionOrder.push(3);
+        };
+
+        delayEngine.queueDelayTask(task1);
+        delayEngine.queueDelayTask(task2);
+        delayEngine.queueDelayTask(task3);
+
+        delayEngine._processQueue().then(() => {
+            if (executionOrder[0] === 1 && executionOrder[1] === 2 && executionOrder[2] === 3) {
+                console.log("DelayEngine: Queued tasks processed in correct order. [PASS]");
+                passCount++;
+            } else {
+                console.error("DelayEngine: Queued tasks processed in incorrect order. [FAIL]", executionOrder);
+            }
+        });
+    } catch (e) {
+        console.error("DelayEngine: Error during queueing tasks. [FAIL]", e);
+    }
+
+    // 테스트 4: isQueueEmpty 확인
+    testCount++;
+    try {
+        const delayEngine = new DelayEngine();
+        if (delayEngine.isQueueEmpty()) {
+            console.log("DelayEngine: isQueueEmpty returns true for empty queue. [PASS]");
+            passCount++;
+        } else {
+            console.error("DelayEngine: isQueueEmpty returned false for empty queue. [FAIL]");
+        }
+
+        delayEngine.queueDelayTask(async () => {});
+        if (!delayEngine.isQueueEmpty()) {
+            console.log("DelayEngine: isQueueEmpty returns false for non-empty queue. [PASS]");
+            passCount++;
+        } else {
+            console.error("DelayEngine: isQueueEmpty returned true for non-empty queue. [FAIL]");
+        }
+        delayEngine._processQueue().then(() => {
+            if (delayEngine.isQueueEmpty()) {
+                console.log("DelayEngine: isQueueEmpty returns true after processing. [PASS]");
+                passCount++;
+            } else {
+                console.error("DelayEngine: isQueueEmpty returned false after processing. [FAIL]");
+            }
+        });
+    } catch (e) {
+        console.error("DelayEngine: Error during isQueueEmpty test. [FAIL]", e);
+    }
+
+    setTimeout(() => {
+        console.log(`--- DelayEngine Unit Test End: ${passCount}/${testCount} tests passed ---`);
+    }, 500);
+}

--- a/tests/unit/mercenaryPanelManagerUnitTests.js
+++ b/tests/unit/mercenaryPanelManagerUnitTests.js
@@ -1,0 +1,120 @@
+// tests/unit/mercenaryPanelManagerUnitTests.js
+
+import { MercenaryPanelManager } from '../../js/managers/MercenaryPanelManager.js';
+
+export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager) {
+    console.log("--- MercenaryPanelManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // Mock 캔버스 요소 생성
+    const mockCanvas = document.createElement('canvas');
+    mockCanvas.width = 600;
+    mockCanvas.height = 200;
+    const mockCtx = mockCanvas.getContext('2d');
+
+    // 테스트 1: 초기화 및 캔버스 속성 확인
+    testCount++;
+    try {
+        const panelManager = new MercenaryPanelManager(mockCanvas, measureManager, battleSimulationManager, logicManager);
+        if (panelManager.canvas === mockCanvas && panelManager.ctx === mockCtx &&
+            panelManager.gridRows === 2 && panelManager.gridCols === 6) {
+            console.log("MercenaryPanelManager: Initialized correctly with canvas properties. [PASS]");
+            passCount++;
+        } else {
+            console.error("MercenaryPanelManager: Initialization failed. [FAIL]", panelManager);
+        }
+    } catch (e) {
+        console.error("MercenaryPanelManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: recalculatePanelDimensions 호출 후 슬롯 크기 확인
+    testCount++;
+    try {
+        const panelManager = new MercenaryPanelManager(mockCanvas, measureManager, battleSimulationManager, logicManager);
+        panelManager.recalculatePanelDimensions(); // 수동 호출
+        const expectedSlotWidth = 600 / 6; // 600px / 6 cols
+        const expectedSlotHeight = 200 / 2; // 200px / 2 rows
+
+        if (panelManager.slotWidth === expectedSlotWidth && panelManager.slotHeight === expectedSlotHeight) {
+            console.log("MercenaryPanelManager: Recalculated slot dimensions correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("MercenaryPanelManager: Slot dimensions recalculation failed. [FAIL]", { slotWidth: panelManager.slotWidth, slotHeight: panelManager.slotHeight });
+        }
+    } catch (e) {
+        console.error("MercenaryPanelManager: Error during recalculation. [FAIL]", e);
+    }
+
+    // 테스트 3: draw 메서드가 호출되는지 시각적 확인 (콘솔 로그를 통한 간접 확인)
+    testCount++;
+    try {
+        const panelManager = new MercenaryPanelManager(mockCanvas, measureManager, battleSimulationManager, logicManager);
+        const originalFillRect = mockCtx.fillRect;
+        let fillRectCalled = false;
+        mockCtx.fillRect = function(...args) {
+            fillRectCalled = true;
+            originalFillRect.apply(this, args);
+        };
+
+        panelManager.draw(mockCtx);
+
+        if (fillRectCalled) {
+            console.log("MercenaryPanelManager: Draw method called and performed basic drawing operations. [PASS]");
+            passCount++;
+        } else {
+            console.error("MercenaryPanelManager: Draw method did not perform expected drawing operations. [FAIL]");
+        }
+        mockCtx.fillRect = originalFillRect; // 원본 복원
+    } catch (e) {
+        console.error("MercenaryPanelManager: Error during draw. [FAIL]", e);
+    }
+
+    // 테스트 4: 유닛이 있을 때 draw 메서드가 유닛 정보 그리는지 간접 확인
+    testCount++;
+    try {
+        const mockUnit = {
+            id: 'mockUnit1',
+            name: 'Test Merc',
+            currentHp: 70,
+            baseStats: { hp: 100 },
+            image: new Image()
+        };
+        const originalUnitsOnGrid = battleSimulationManager.unitsOnGrid;
+        battleSimulationManager.unitsOnGrid = [mockUnit];
+
+        const panelManager = new MercenaryPanelManager(mockCanvas, measureManager, battleSimulationManager, logicManager);
+        const originalFillText = mockCtx.fillText;
+        let fillTextCalledForUnit = false;
+        mockCtx.fillText = function(text, ...args) {
+            if (text.includes("Test Merc") || text.includes("HP:")) {
+                fillTextCalledForUnit = true;
+            }
+            originalFillText.apply(this, args);
+        };
+        const originalDrawImage = mockCtx.drawImage;
+        let drawImageCalledForUnit = false;
+        mockCtx.drawImage = function(...args) {
+            drawImageCalledForUnit = true;
+            originalDrawImage.apply(this, args);
+        };
+
+        panelManager.draw(mockCtx);
+
+        if (fillTextCalledForUnit && drawImageCalledForUnit) {
+            console.log("MercenaryPanelManager: Draw method drew unit info and image. [PASS]");
+            passCount++;
+        } else {
+            console.error("MercenaryPanelManager: Draw method failed to draw unit info/image. [FAIL]");
+        }
+        mockCtx.fillText = originalFillText; // 원본 복원
+        mockCtx.drawImage = originalDrawImage; // 원본 복원
+        battleSimulationManager.unitsOnGrid = originalUnitsOnGrid; // 복원
+
+    } catch (e) {
+        console.error("MercenaryPanelManager: Error during unit drawing test. [FAIL]", e);
+    }
+
+    console.log(`--- MercenaryPanelManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/panelEngineUnitTests.js
+++ b/tests/unit/panelEngineUnitTests.js
@@ -1,0 +1,105 @@
+// tests/unit/panelEngineUnitTests.js
+
+import { PanelEngine } from '../../js/managers/PanelEngine.js';
+
+export function runPanelEngineUnitTests() {
+    console.log("--- PanelEngine Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // Mock PanelManager
+    const mockPanelManager = {
+        drawCalled: false,
+        draw: function(ctx) {
+            this.drawCalled = true;
+            ctx.testDrawCalled = true;
+        }
+    };
+
+    // Mock Canvas Context
+    const mockCtx = {
+        testDrawCalled: false,
+        clearRect: () => {},
+        fillRect: () => {},
+        fillText: () => {}
+    };
+
+    // 테스트 1: PanelEngine 초기화
+    testCount++;
+    try {
+        const panelEngine = new PanelEngine();
+        if (panelEngine.panels instanceof Map && panelEngine.panels.size === 0) {
+            console.log("PanelEngine: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("PanelEngine: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("PanelEngine: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: 패널 등록
+    testCount++;
+    try {
+        const panelEngine = new PanelEngine();
+        panelEngine.registerPanel('testPanel', mockPanelManager);
+        if (panelEngine.panels.has('testPanel')) {
+            console.log("PanelEngine: Panel registered successfully. [PASS]");
+            passCount++;
+        } else {
+            console.error("PanelEngine: Panel registration failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("PanelEngine: Error during panel registration. [FAIL]", e);
+    }
+
+    // 테스트 3: 패널 그리기 (등록된 패널)
+    testCount++;
+    try {
+        const panelEngine = new PanelEngine();
+        panelEngine.registerPanel('testPanel', mockPanelManager);
+        mockPanelManager.drawCalled = false;
+        mockCtx.testDrawCalled = false;
+
+        panelEngine.drawPanel('testPanel', mockCtx);
+
+        if (mockPanelManager.drawCalled && mockCtx.testDrawCalled) {
+            console.log("PanelEngine: drawPanel called registered panel's draw method. [PASS]");
+            passCount++;
+        } else {
+            console.error("PanelEngine: drawPanel failed to call registered panel's draw method. [FAIL]");
+        }
+    } catch (e) {
+        console.error("PanelEngine: Error during drawPanel call. [FAIL]", e);
+    }
+
+    // 테스트 4: 패널 그리기 (등록되지 않은 패널)
+    testCount++;
+    const originalWarn = console.warn;
+    let warnCalled = false;
+    console.warn = (message) => {
+        if (message.includes("PanelEngine] Panel 'nonExistentPanel' not found.")) {
+            warnCalled = true;
+        }
+        originalWarn(message);
+    };
+
+    try {
+        const panelEngine = new PanelEngine();
+        mockPanelManager.drawCalled = false;
+        panelEngine.drawPanel('nonExistentPanel', mockCtx);
+        if (warnCalled && !mockPanelManager.drawCalled) {
+            console.log("PanelEngine: drawPanel handled non-existent panel gracefully with warning. [PASS]");
+            passCount++;
+        } else {
+            console.error("PanelEngine: drawPanel failed to handle non-existent panel. [FAIL]");
+        }
+    } catch (e) {
+        console.error("PanelEngine: Error during non-existent panel draw. [FAIL]", e);
+    } finally {
+        console.warn = originalWarn;
+    }
+
+    console.log(`--- PanelEngine Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/ruleManagerUnitTests.js
+++ b/tests/unit/ruleManagerUnitTests.js
@@ -1,0 +1,82 @@
+// tests/unit/ruleManagerUnitTests.js
+
+import { RuleManager } from '../../js/managers/RuleManager.js';
+
+export function runRuleManagerUnitTests() {
+    console.log("--- RuleManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // 테스트 1: 초기화 및 기본 규칙 로드 확인
+    testCount++;
+    try {
+        const ruleManager = new RuleManager();
+        if (ruleManager.rules instanceof Map && ruleManager.rules.has('unitActionPerTurn')) {
+            console.log("RuleManager: Initialized correctly and loaded basic rules. [PASS]");
+            passCount++;
+        } else {
+            console.error("RuleManager: Initialization failed or basic rules not loaded. [FAIL]");
+        }
+    } catch (e) {
+        console.error("RuleManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: 규칙 추가
+    testCount++;
+    try {
+        const ruleManager = new RuleManager();
+        ruleManager.addRule('newRule', 'This is a new test rule.');
+        if (ruleManager.rules.has('newRule') && ruleManager.getRule('newRule') === 'This is a new test rule.') {
+            console.log("RuleManager: Added new rule successfully. [PASS]");
+            passCount++;
+        } else {
+            console.error("RuleManager: Failed to add new rule. [FAIL]");
+        }
+    } catch (e) {
+        console.error("RuleManager: Error adding rule. [FAIL]", e);
+    }
+
+    // 테스트 3: 기존 규칙 덮어쓰기
+    testCount++;
+    const originalWarn = console.warn;
+    let warnCalled = false;
+    console.warn = (message) => {
+        if (message.includes("Rule 'unitActionPerTurn' already exists. Overwriting.")) {
+            warnCalled = true;
+        }
+        originalWarn(message);
+    };
+
+    try {
+        const ruleManager = new RuleManager();
+        ruleManager.addRule('unitActionPerTurn', 'Overwritten rule description.');
+        if (warnCalled && ruleManager.getRule('unitActionPerTurn') === 'Overwritten rule description.') {
+            console.log("RuleManager: Overwrote existing rule successfully with warning. [PASS]");
+            passCount++;
+        } else {
+            console.error("RuleManager: Failed to overwrite rule or warning not emitted. [FAIL]");
+        }
+    } catch (e) {
+        console.error("RuleManager: Error overwriting rule. [FAIL]", e);
+    } finally {
+        console.warn = originalWarn;
+    }
+
+    // 테스트 4: 존재하지 않는 규칙 가져오기
+    testCount++;
+    try {
+        const ruleManager = new RuleManager();
+        const rule = ruleManager.getRule('nonExistentRule');
+        if (rule === undefined) {
+            console.log("RuleManager: getRule for non-existent rule returns undefined. [PASS]");
+            passCount++;
+        } else {
+            console.error("RuleManager: getRule for non-existent rule returned unexpected value. [FAIL]", rule);
+        }
+    } catch (e) {
+        console.error("RuleManager: Error getting non-existent rule. [FAIL]", e);
+    }
+
+    console.log(`--- RuleManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/timingEngineUnitTests.js
+++ b/tests/unit/timingEngineUnitTests.js
@@ -1,0 +1,90 @@
+// tests/unit/timingEngineUnitTests.js
+
+import { TimingEngine } from '../../js/managers/TimingEngine.js';
+import { DelayEngine } from '../../js/managers/DelayEngine.js';
+
+export function runTimingEngineUnitTests() {
+    console.log("--- TimingEngine Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const delayEngine = new DelayEngine();
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const timingEngine = new TimingEngine(delayEngine);
+        if (timingEngine.actionQueue instanceof Array && !timingEngine.isProcessingActions) {
+            console.log("TimingEngine: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TimingEngine: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TimingEngine: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: addTimedAction 및 우선순위 정렬 확인
+    testCount++;
+    try {
+        const timingEngine = new TimingEngine(delayEngine);
+        timingEngine.addTimedAction(async () => {}, 10, "Action C");
+        timingEngine.addTimedAction(async () => {}, 5, "Action B");
+        timingEngine.addTimedAction(async () => {}, 1, "Action A");
+
+        if (timingEngine.actionQueue.length === 3 &&
+            timingEngine.actionQueue[0].name === "Action A" &&
+            timingEngine.actionQueue[1].name === "Action B" &&
+            timingEngine.actionQueue[2].name === "Action C") {
+            console.log("TimingEngine: Actions added and sorted by priority correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TimingEngine: Actions not sorted correctly. [FAIL]", timingEngine.actionQueue.map(a => a.name));
+        }
+    } catch (e) {
+        console.error("TimingEngine: Error during addTimedAction or sorting. [FAIL]", e);
+    }
+
+    // 테스트 3: processActions 순차적 실행 확인
+    testCount++;
+    try {
+        const timingEngine = new TimingEngine(delayEngine);
+        let executionOrder = [];
+
+        timingEngine.addTimedAction(async () => { executionOrder.push(1); await delayEngine.waitFor(5); }, 20, "Task 1");
+        timingEngine.addTimedAction(async () => { executionOrder.push(2); }, 10, "Task 2");
+        timingEngine.addTimedAction(async () => { executionOrder.push(3); await delayEngine.waitFor(10); }, 5, "Task 3");
+
+        timingEngine.processActions().then(() => {
+            if (executionOrder[0] === 3 && executionOrder[1] === 2 && executionOrder[2] === 1) {
+                console.log("TimingEngine: Actions processed in correct priority order. [PASS]");
+                passCount++;
+            } else {
+                console.error("TimingEngine: Actions processed in incorrect priority order. [FAIL]", executionOrder);
+            }
+        });
+    } catch (e) {
+        console.error("TimingEngine: Error during processActions. [FAIL]", e);
+    }
+
+    // 테스트 4: clearActions 확인
+    testCount++;
+    try {
+        const timingEngine = new TimingEngine(delayEngine);
+        timingEngine.addTimedAction(async () => {}, 1, "Action to clear");
+        timingEngine.clearActions();
+        if (timingEngine.actionQueue.length === 0 && !timingEngine.isProcessingActions) {
+            console.log("TimingEngine: clearActions cleared the queue. [PASS]");
+            passCount++;
+        } else {
+            console.error("TimingEngine: clearActions failed to clear queue. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TimingEngine: Error during clearActions test. [FAIL]", e);
+    }
+
+    setTimeout(() => {
+        console.log(`--- TimingEngine Unit Test End: ${passCount}/${testCount} tests passed ---`);
+    }, 200);
+}

--- a/tests/unit/turnEngineUnitTests.js
+++ b/tests/unit/turnEngineUnitTests.js
@@ -1,0 +1,94 @@
+// tests/unit/turnEngineUnitTests.js
+
+import { TurnEngine } from '../../js/managers/TurnEngine.js';
+
+export function runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine) {
+    console.log("--- TurnEngine Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockUnit1 = { id: 'u1', name: 'Hero', currentHp: 50, baseStats: { hp: 50, speed: 10 }, type: 'mercenary', classId: 'class_warrior', gridX: 0, gridY: 0 };
+    const mockUnit2 = { id: 'u2', name: 'Goblin', currentHp: 30, baseStats: { hp: 30, speed: 5 }, type: 'enemy', classId: 'class_goblin', gridX: 5, gridY: 5 };
+
+    battleSimulationManager.unitsOnGrid = [mockUnit1, mockUnit2];
+    turnOrderManager.calculateTurnOrder();
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+        if (turnEngine.currentTurn === 0 && turnEngine.turnPhaseCallbacks.startOfTurn instanceof Array) {
+            console.log("TurnEngine: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnEngine: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnEngine: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: initializeTurnOrder 호출
+    testCount++;
+    try {
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+        turnEngine.initializeTurnOrder();
+        if (turnEngine.turnOrder.length > 0 && turnEngine.turnOrder[0].id === 'u1') {
+            console.log("TurnEngine: initializeTurnOrder called TurnOrderManager. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnEngine: initializeTurnOrder failed. [FAIL]", turnEngine.turnOrder);
+        }
+    } catch (e) {
+        console.error("TurnEngine: Error initializing turn order. [FAIL]", e);
+    }
+
+    // 테스트 3: 턴 단계 콜백 등록
+    testCount++;
+    try {
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+        let callbackCalled = false;
+        const testCallback = async () => { callbackCalled = true; };
+        turnEngine.addTurnPhaseCallback('startOfTurn', testCallback);
+        if (turnEngine.turnPhaseCallbacks.startOfTurn.includes(testCallback)) {
+            console.log("TurnEngine: Added turn phase callback successfully. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnEngine: Failed to add turn phase callback. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnEngine: Error adding turn phase callback. [FAIL]", e);
+    }
+
+    // 테스트 4: startBattleTurns 및 nextTurn 시작
+    testCount++;
+    let originalSetTimeout = window.setTimeout;
+    window.setTimeout = (fn, delay) => fn();
+
+    try {
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+        classAIManager.getBasicClassAction = async (unit, allUnits) => {
+            if (unit.id === 'u1') return { actionType: 'attack', targetId: 'u2' };
+            if (unit.id === 'u2') return { actionType: 'attack', targetId: 'u1' };
+            return null;
+        };
+        let unitAttackAttemptEmitted = false;
+        eventManager.subscribe('unitAttackAttempt', () => { unitAttackAttemptEmitted = true; });
+        eventManager.setGameRunningState(true);
+        await turnEngine.nextTurn();
+
+        if (turnEngine.currentTurn === 1 && unitAttackAttemptEmitted) {
+            console.log("TurnEngine: First turn processed and attack attempted. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnEngine: First turn processing failed or attack not attempted. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnEngine: Error during battle turn simulation. [FAIL]", e);
+    } finally {
+        window.setTimeout = originalSetTimeout;
+        eventManager.setGameRunningState(false);
+    }
+
+    console.log(`--- TurnEngine Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/turnOrderManagerUnitTests.js
+++ b/tests/unit/turnOrderManagerUnitTests.js
@@ -1,0 +1,136 @@
+// tests/unit/turnOrderManagerUnitTests.js
+
+import { TurnOrderManager } from '../../js/managers/TurnOrderManager.js';
+
+export function runTurnOrderManagerUnitTests(eventManager, battleSimulationManager) {
+    console.log("--- TurnOrderManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockUnitFast = { id: 'fast', name: 'Fast Unit', baseStats: { speed: 100 }, currentHp: 1 };
+    const mockUnitNormal = { id: 'normal', name: 'Normal Unit', baseStats: { speed: 50 }, currentHp: 1 };
+    const mockUnitSlow = { id: 'slow', name: 'Slow Unit', baseStats: { speed: 10 }, currentHp: 1 };
+    const mockUnitDead = { id: 'dead', name: 'Dead Unit', baseStats: { speed: 20 }, currentHp: 0 };
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const turnOrderManager = new TurnOrderManager(eventManager, battleSimulationManager);
+        if (turnOrderManager.currentTurnOrder instanceof Array && turnOrderManager.currentTurnOrder.length === 0) {
+            console.log("TurnOrderManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnOrderManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnOrderManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: calculateTurnOrder - 속도 기반 정렬
+    testCount++;
+    try {
+        const turnOrderManager = new TurnOrderManager(eventManager, battleSimulationManager);
+        battleSimulationManager.unitsOnGrid = [mockUnitNormal, mockUnitSlow, mockUnitFast];
+        const order = turnOrderManager.calculateTurnOrder();
+
+        if (order.length === 3 &&
+            order[0].id === 'fast' &&
+            order[1].id === 'normal' &&
+            order[2].id === 'slow') {
+            console.log("TurnOrderManager: Calculated turn order correctly based on speed. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnOrderManager: Failed to calculate turn order correctly. [FAIL]", order.map(u => u.id));
+        }
+    } catch (e) {
+        console.error("TurnOrderManager: Error calculating turn order. [FAIL]", e);
+    }
+
+    // 테스트 3: getTurnOrder
+    testCount++;
+    try {
+        const turnOrderManager = new TurnOrderManager(eventManager, battleSimulationManager);
+        battleSimulationManager.unitsOnGrid = [mockUnitFast, mockUnitNormal];
+        turnOrderManager.calculateTurnOrder();
+        const retrievedOrder = turnOrderManager.getTurnOrder();
+        if (retrievedOrder === turnOrderManager.currentTurnOrder) {
+            console.log("TurnOrderManager: getTurnOrder returns current turn order. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnOrderManager: getTurnOrder returned incorrect or new array. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnOrderManager: Error getting turn order. [FAIL]", e);
+    }
+
+    // 테스트 4: removeUnitFromOrder - 유닛 제거
+    testCount++;
+    try {
+        const turnOrderManager = new TurnOrderManager(eventManager, battleSimulationManager);
+        battleSimulationManager.unitsOnGrid = [mockUnitFast, mockUnitNormal, mockUnitSlow];
+        turnOrderManager.calculateTurnOrder();
+        turnOrderManager.removeUnitFromOrder('normal');
+        const orderAfterRemoval = turnOrderManager.getTurnOrder();
+
+        if (orderAfterRemoval.length === 2 &&
+            orderAfterRemoval[0].id === 'fast' &&
+            orderAfterRemoval[1].id === 'slow') {
+            console.log("TurnOrderManager: Removed unit from order correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnOrderManager: Failed to remove unit from order. [FAIL]", orderAfterRemoval.map(u => u.id));
+        }
+    } catch (e) {
+        console.error("TurnOrderManager: Error removing unit. [FAIL]", e);
+    }
+
+    // 테스트 5: removeUnitFromOrder - 없는 유닛 제거 시도
+    testCount++;
+    const originalLog = console.log;
+    let logCalledForNonExistent = false;
+    console.log = (message) => {
+        if (message.includes("Unit 'nonExistent' removed from turn order.")) {
+            logCalledForNonExistent = true;
+        }
+        originalLog(message);
+    };
+    try {
+        const turnOrderManager = new TurnOrderManager(eventManager, battleSimulationManager);
+        battleSimulationManager.unitsOnGrid = [mockUnitFast];
+        turnOrderManager.calculateTurnOrder();
+        const initialLength = turnOrderManager.getTurnOrder().length;
+        turnOrderManager.removeUnitFromOrder('nonExistent');
+        const orderAfterNonExistentRemoval = turnOrderManager.getTurnOrder();
+
+        if (orderAfterNonExistentRemoval.length === initialLength && !logCalledForNonExistent) {
+            console.log("TurnOrderManager: Attempt to remove non-existent unit handled gracefully. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnOrderManager: Failed to handle non-existent unit removal. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnOrderManager: Error handling non-existent unit removal. [FAIL]", e);
+    } finally {
+        console.log = originalLog;
+    }
+
+    // 테스트 6: clearTurnOrder
+    testCount++;
+    try {
+        const turnOrderManager = new TurnOrderManager(eventManager, battleSimulationManager);
+        battleSimulationManager.unitsOnGrid = [mockUnitFast, mockUnitNormal];
+        turnOrderManager.calculateTurnOrder();
+        turnOrderManager.clearTurnOrder();
+        if (turnOrderManager.getTurnOrder().length === 0) {
+            console.log("TurnOrderManager: clearTurnOrder cleared the order. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnOrderManager: clearTurnOrder failed to clear order. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnOrderManager: Error clearing turn order. [FAIL]", e);
+    }
+
+    console.log(`--- TurnOrderManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}


### PR DESCRIPTION
## Summary
- implement a suite of new unit tests for various managers
- wire up tests in `tests/index.js`
- expose additional getters from `GameEngine`
- update `debug.html` to import and run all new tests

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687266ae01088327bd73c1cab2bee26f