### PR TITLE
UI panel sizing uses MeasureManager ratios

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -181,7 +181,7 @@
                 runCompatibilityManagerUnitTests(compatibilityManager);
                 runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
                 runPanelEngineUnitTests();
-                runBattleLogManagerUnitTests(eventManager);
+                runBattleLogManagerUnitTests(eventManager, measureManager);
                 runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
                 runDelayEngineUnitTests();
                 runTimingEngineUnitTests();
@@ -339,7 +339,7 @@
             runCompatibilityManagerUnitTests(compatibilityManager);
             runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
             runPanelEngineUnitTests();
-            runBattleLogManagerUnitTests(eventManager);
+            runBattleLogManagerUnitTests(eventManager, measureManager);
             runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
             runDelayEngineUnitTests();
             runTimingEngineUnitTests();

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -27,13 +27,18 @@ export class MeasureManager {
                 heightRatio: 1.0, // 논리적으로 캔버스 전체를 채움
                 padding: 40 // 배틀 스테이지 내부 여백 (그리드가 이 여백 안에 그려짐)
             },
-            // ✨ 새로운 설정: 용병 패널 관련 크기
+            // ✨ 용병 패널 관련 설정 업데이트
             mercenaryPanel: {
-                baseSlotSize: 100, // 각 슬롯의 기본 크기 (픽셀)
-                gridRows: 2, // 2줄
-                gridCols: 6, // 6칸
-                width: 600, // 6칸 * 100px/칸 = 600px
-                height: 200 // 2줄 * 100px/줄 = 200px
+                baseSlotSize: 100, // 각 슬롯의 기본 크기 (UI 계산용)
+                gridRows: 2,
+                gridCols: 6,
+                heightRatio: 0.25 // 메인 캔버스 높이의 25% (예시)
+            },
+            // ✨ 전투 로그 관련 설정 추가
+            combatLog: {
+                heightRatio: 0.15, // 메인 캔버스 높이의 15% (예시)
+                lineHeight: 20, // 한 줄 높이 (px)
+                padding: 10 // 내부 여백 (px)
             }
         };
     }

--- a/js/managers/MercenaryPanelManager.js
+++ b/js/managers/MercenaryPanelManager.js
@@ -17,22 +17,21 @@ export class MercenaryPanelManager {
         this.gridCols = this.measureManager.get('mercenaryPanel.gridCols');
         this.numSlots = this.gridRows * this.gridCols;
 
+        // 초기 패널 치수 재계산 (CompatibilityManager가 캔버스 크기 설정 후 호출할 것임)
         this.recalculatePanelDimensions();
 
-        // ✨ 캔버스 크기가 MeasureManager에 의해 고정되므로, window.resize 이벤트 리스너는 제거합니다.
+        // ✨ window.resize 이벤트 리스너 제거 (CompatibilityManager가 크기 제어)
     }
 
+    /**
+     * 패널의 내부 치수(슬롯 크기 등)를 재계산합니다.
+     * 이 메서드는 CompatibilityManager가 캔버스 크기를 조정한 후 호출해야 합니다.
+     */
     recalculatePanelDimensions() {
-        // ✨ MeasureManager에서 패널의 고정된 너비와 높이를 가져와 캔버스 속성으로 설정
-        const panelWidth = this.measureManager.get('mercenaryPanel.width');
-        const panelHeight = this.measureManager.get('mercenaryPanel.height');
-
-        this.canvas.width = panelWidth; // 캔버스 내부 드로잉 버퍼의 너비 설정
-        this.canvas.height = panelHeight; // 캔버스 내부 드로잉 버퍼의 높이 설정
-
+        // ✨ 캔버스 요소의 현재 크기를 기반으로 내부 슬롯 크기 계산
         this.slotWidth = this.canvas.width / this.gridCols;
         this.slotHeight = this.canvas.height / this.gridRows;
-        console.log(`[MercenaryPanelManager] Panel dimensions recalculated and canvas size set to: ${this.canvas.width}x${this.canvas.height}. Slot size: ${this.slotWidth}x${this.slotHeight}`);
+        console.log(`[MercenaryPanelManager] Panel dimensions recalculated. Canvas size: ${this.canvas.width}x${this.canvas.height}, Slot size: ${this.slotWidth}x${this.slotHeight}`);
     }
 
     /**

--- a/style.css
+++ b/style.css
@@ -22,19 +22,16 @@ canvas {
     display: block; /* 캔버스 아래 추가 공간 방지 */
 }
 
-/* 용병 패널 캔버스 전용 스타일 */
+/* 용병 패널 캔버스 전용 스타일 (JS가 크기 제어) */
 #mercenaryPanelCanvas {
-    /* ✨ width: 100%; 제거 및 고정 값 설정 */
-    width: 600px; /* MeasureManager에 정의된 고정 너비 */
-    height: 200px; /* MeasureManager에 정의된 고정 높이 */
+    /* ✨ width, height 속성 제거 */
     margin-bottom: 10px; /* 패널과 메인 게임 캔버스 사이의 간격 */
     border: 2px solid #00f; /* 구분을 위한 다른 테두리 색상 */
 }
 
-/* ✨ 새로운 전투 로그 캔버스 전용 스타일 */
+/* ✨ 전투 로그 캔버스 전용 스타일 (JS가 크기 제어) */
 #combatLogCanvas {
-    width: 600px; /* 용병 패널과 동일한 너비 */
-    height: 120px; /* 고정 높이 (로그 표시 영역) */
+    /* ✨ width, height 속성 제거 */
     margin-top: 10px; /* 메인 게임 캔버스 위쪽 간격 */
     border: 2px solid #f00; /* 구분을 위한 다른 테두리 색상 (빨간색) */
 }

--- a/tests/unit/battleLogManagerUnitTests.js
+++ b/tests/unit/battleLogManagerUnitTests.js
@@ -2,7 +2,7 @@
 
 import { BattleLogManager } from '../../js/managers/BattleLogManager.js';
 
-export function runBattleLogManagerUnitTests(eventManager) {
+export function runBattleLogManagerUnitTests(eventManager, measureManager) {
     console.log("--- BattleLogManager Unit Test Start ---");
 
     let testCount = 0;
@@ -17,7 +17,7 @@ export function runBattleLogManagerUnitTests(eventManager) {
     // 테스트 1: 초기화 확인
     testCount++;
     try {
-        const logManager = new BattleLogManager(mockCanvas, eventManager);
+        const logManager = new BattleLogManager(mockCanvas, eventManager, measureManager);
         if (logManager.logMessages instanceof Array && logManager.logMessages.length === 0) {
             console.log("BattleLogManager: Initialized correctly. [PASS]");
             passCount++;
@@ -31,7 +31,7 @@ export function runBattleLogManagerUnitTests(eventManager) {
     // 테스트 2: 로그 메시지 추가
     testCount++;
     try {
-        const logManager = new BattleLogManager(mockCanvas, eventManager);
+        const logManager = new BattleLogManager(mockCanvas, eventManager, measureManager);
         logManager.addLog("Test message 1.");
         if (logManager.logMessages.length === 1 && logManager.logMessages[0].includes("Test message 1.")) {
             console.log("BattleLogManager: Added log message successfully. [PASS]");
@@ -46,7 +46,7 @@ export function runBattleLogManagerUnitTests(eventManager) {
     // 테스트 3: 최대 로그 줄 수 초과 시 오래된 메시지 제거
     testCount++;
     try {
-        const logManager = new BattleLogManager(mockCanvas, eventManager);
+        const logManager = new BattleLogManager(mockCanvas, eventManager, measureManager);
         logManager.maxLogLines = 2;
         logManager.addLog("Oldest message.");
         logManager.addLog("Middle message.");
@@ -67,7 +67,7 @@ export function runBattleLogManagerUnitTests(eventManager) {
     // 테스트 4: draw 메서드 호출 시 캔버스에 그리는지 간접 확인
     testCount++;
     try {
-        const logManager = new BattleLogManager(mockCanvas, eventManager);
+        const logManager = new BattleLogManager(mockCanvas, eventManager, measureManager);
         logManager.addLog("Drawing test message.");
 
         const originalFillText = mockCtx.fillText;


### PR DESCRIPTION
## Summary
- set mercenary panel and combat log sizes relative to main canvas
- allow CSS to only handle visual borders and margins
- let MercenaryPanelManager and BattleLogManager recalc internals using canvas size
- resize all canvases through CompatibilityManager and recalc panel/log dimensions
- wire managers together in GameEngine and update debug page & tests

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68726eee602c8327b0fd0832664fd005