### PR TITLE
Include classId in units for AI

### DIFF
--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -26,6 +26,7 @@ export class BattleSimulationManager {
             name: fullUnitData.name,
             spriteId: fullUnitData.spriteId,
             image: unitImage, // ✨ 로드된 이미지 객체를 직접 저장합니다.
+            classId: fullUnitData.classId,
             gridX,
             gridY,
             // 필요한 경우 다른 데이터도 여기에 추가할 수 있습니다.


### PR DESCRIPTION
## Summary
- store `classId` when adding units in `BattleSimulationManager`

## Testing
- `npm test --silent`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687272e2b9388327b71fb1796e38fbff