### PR TITLE
Add movement animation manager

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -153,6 +153,7 @@
             const timingEngine = gameEngine.getTimingEngine();
             const idManager = gameEngine.getIdManager();
             const basicAIManager = gameEngine.getBasicAIManager();
+            const animationManager = gameEngine.getAnimationManager();
 
 
             // 테스트용 EventManager 구독 (debug.html에서만 필요)
@@ -182,7 +183,7 @@
                 runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
                 runPanelEngineUnitTests();
                 runBattleLogManagerUnitTests(eventManager, measureManager);
-                runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+                runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
                 runDelayEngineUnitTests();
                 runTimingEngineUnitTests();
                 runRuleManagerUnitTests();
@@ -340,7 +341,7 @@
             runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
             runPanelEngineUnitTests();
             runBattleLogManagerUnitTests(eventManager, measureManager);
-            runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+            runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
             runDelayEngineUnitTests();
             runTimingEngineUnitTests();
             runRuleManagerUnitTests();

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -15,6 +15,7 @@ import { CompatibilityManager } from './managers/CompatibilityManager.js';
 import { IdManager } from './managers/IdManager.js';
 import { AssetLoaderManager } from './managers/AssetLoaderManager.js';
 import { BattleSimulationManager } from './managers/BattleSimulationManager.js';
+import { AnimationManager } from './managers/AnimationManager.js';
 import { VFXManager } from './managers/VFXManager.js';
 import { BindingManager } from './managers/BindingManager.js';
 import { BattleCalculationManager } from './managers/BattleCalculationManager.js';
@@ -62,13 +63,19 @@ export class GameEngine {
         this.idManager = new IdManager();
         this.assetLoaderManager = new AssetLoaderManager();
 
-        // 전투 시뮬레이션 매니저는 패널 및 로그 매니저가 필요하므로 먼저 초기화합니다.
+        // AnimationManager는 BattleSimulationManager의 렌더링에 사용됩니다.
+        this.animationManager = new AnimationManager(this.measureManager);
+
+        // 전투 시뮬레이션 매니저 초기화
         this.battleSimulationManager = new BattleSimulationManager(
             this.measureManager,
             this.assetLoaderManager,
             this.idManager,
-            this.logicManager
+            this.logicManager,
+            this.animationManager
         );
+        // 생성 후 상호 참조 설정
+        this.animationManager.battleSimulationManager = this.battleSimulationManager;
 
         // 패널과 로그 캔버스 요소 준비 및 매니저 초기화
         const mercenaryPanelCanvasElement = document.getElementById('mercenaryPanelCanvas');
@@ -151,7 +158,8 @@ export class GameEngine {
             this.turnOrderManager,
             this.classAIManager,
             this.delayEngine,
-            this.timingEngine
+            this.timingEngine,
+            this.animationManager
         );
 
         this.sceneEngine.registerScene('territoryScene', [this.territoryManager]);
@@ -275,6 +283,7 @@ export class GameEngine {
 
     _update(deltaTime) {
         this.sceneEngine.update(deltaTime);
+        this.animationManager.update(deltaTime);
     }
 
     _draw() {
@@ -322,4 +331,5 @@ export class GameEngine {
     getTurnOrderManager() { return this.turnOrderManager; }
     getBasicAIManager() { return this.basicAIManager; }
     getClassAIManager() { return this.classAIManager; }
+    getAnimationManager() { return this.animationManager; }
 }

--- a/js/managers/AnimationManager.js
+++ b/js/managers/AnimationManager.js
@@ -1,0 +1,119 @@
+// js/managers/AnimationManager.js
+
+export class AnimationManager {
+    constructor(measureManager, battleSimulationManager = null) {
+        console.log("\uD83C\uDFC3 AnimationManager initialized. Ready to animate movements. \uD83C\uDFC3");
+        this.measureManager = measureManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.activeAnimations = new Map(); // { unitId: { startPixelX, startPixelY, endPixelX, endPixelY, startTime, duration, resolve, currentPixelX, currentPixelY } }
+        this.animationSpeed = 0.005; // Tiles per millisecond
+    }
+
+    /**
+     * Add a move animation to the queue.
+     * @param {string} unitId
+     * @param {number} startGridX
+     * @param {number} startGridY
+     * @param {number} endGridX
+     * @param {number} endGridY
+     * @returns {Promise<void>} Resolves when the animation completes
+     */
+    queueMoveAnimation(unitId, startGridX, startGridY, endGridX, endGridY) {
+        return new Promise(resolve => {
+            const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions();
+            const contentWidth = sceneContentDimensions.width;
+            const contentHeight = sceneContentDimensions.height;
+            const stagePadding = this.measureManager.get('battleStage.padding');
+            const gridDrawableWidth = contentWidth - 2 * stagePadding;
+            const gridDrawableHeight = contentHeight - 2 * stagePadding;
+            const effectiveTileSize = Math.min(
+                gridDrawableWidth / this.battleSimulationManager.gridCols,
+                gridDrawableHeight / this.battleSimulationManager.gridRows
+            );
+            const totalGridWidth = this.battleSimulationManager.gridCols * effectiveTileSize;
+            const totalGridHeight = this.battleSimulationManager.gridRows * effectiveTileSize;
+            const gridOffsetX = stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
+            const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+            const startPixelX = gridOffsetX + startGridX * effectiveTileSize;
+            const startPixelY = gridOffsetY + startGridY * effectiveTileSize;
+            const endPixelX = gridOffsetX + endGridX * effectiveTileSize;
+            const endPixelY = gridOffsetY + endGridY * effectiveTileSize;
+
+            const dist = Math.sqrt(
+                Math.pow(endGridX - startGridX, 2) +
+                Math.pow(endGridY - startGridY, 2)
+            );
+            const duration = dist / this.animationSpeed;
+
+            this.activeAnimations.set(unitId, {
+                startPixelX,
+                startPixelY,
+                endPixelX,
+                endPixelY,
+                startTime: performance.now(),
+                duration,
+                resolve,
+                currentPixelX: startPixelX,
+                currentPixelY: startPixelY
+            });
+            console.log(`[AnimationManager] Queued move animation for unit ${unitId} from (${startGridX},${startGridY}) to (${endGridX},${endGridY}) with duration ${duration.toFixed(0)}ms.`);
+        });
+    }
+
+    /**
+     * Update animation states each frame.
+     * @param {number} deltaTime
+     */
+    update(deltaTime) {
+        const currentTime = performance.now();
+        for (const [unitId, animation] of this.activeAnimations.entries()) {
+            const elapsed = currentTime - animation.startTime;
+            const progress = Math.min(1, elapsed / animation.duration);
+
+            if (progress >= 1) {
+                animation.currentPixelX = animation.endPixelX;
+                animation.currentPixelY = animation.endPixelY;
+                console.log(`[AnimationManager] Animation for unit ${unitId} completed.`);
+                this.activeAnimations.delete(unitId);
+                if (animation.resolve) {
+                    animation.resolve();
+                }
+            } else {
+                animation.currentPixelX = animation.startPixelX + (animation.endPixelX - animation.startPixelX) * progress;
+                animation.currentPixelY = animation.startPixelY + (animation.endPixelY - animation.startPixelY) * progress;
+            }
+        }
+    }
+
+    /**
+     * Get the current render position for a unit.
+     * @param {string} unitId
+     * @param {number} currentGridX
+     * @param {number} currentGridY
+     * @param {number} effectiveTileSize
+     * @param {number} gridOffsetX
+     * @param {number} gridOffsetY
+     * @returns {{drawX:number, drawY:number}}
+     */
+    getRenderPosition(unitId, currentGridX, currentGridY, effectiveTileSize, gridOffsetX, gridOffsetY) {
+        const animation = this.activeAnimations.get(unitId);
+        if (animation) {
+            return {
+                drawX: animation.currentPixelX,
+                drawY: animation.currentPixelY
+            };
+        }
+        return {
+            drawX: gridOffsetX + currentGridX * effectiveTileSize,
+            drawY: gridOffsetY + currentGridY * effectiveTileSize
+        };
+    }
+
+    /**
+     * Check if any animations are active.
+     * @returns {boolean}
+     */
+    hasActiveAnimations() {
+        return this.activeAnimations.size > 0;
+    }
+}

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -1,12 +1,13 @@
 // js/managers/BattleSimulationManager.js
 
 export class BattleSimulationManager {
-    constructor(measureManager, assetLoaderManager, idManager, logicManager) {
+    constructor(measureManager, assetLoaderManager, idManager, logicManager, animationManager) {
         console.log("\u2694\ufe0f BattleSimulationManager initialized. Preparing units for battle. \u2694\ufe0f");
         this.measureManager = measureManager;
         this.assetLoaderManager = assetLoaderManager;
         this.idManager = idManager; // Keep for other potential uses, though not directly in draw
         this.logicManager = logicManager;
+        this.animationManager = animationManager;
         this.unitsOnGrid = [];
         this.gridRows = 10; // BattleGridManager와 동일한 그리드 차원
         this.gridCols = 15;
@@ -114,15 +115,20 @@ export class BattleSimulationManager {
         const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
 
         for (const unit of this.unitsOnGrid) {
-            // ✨ 이제 unit 객체에 이미지 자체가 포함되어 있으므로 비동기 호출 없이 바로 사용합니다.
             const image = unit.image;
             if (!image) {
                 console.warn(`[BattleSimulationManager] Image not available for unit '${unit.id}'. Skipping draw.`);
                 continue;
             }
 
-            const drawX = gridOffsetX + unit.gridX * effectiveTileSize;
-            const drawY = gridOffsetY + unit.gridY * effectiveTileSize;
+            const { drawX, drawY } = this.animationManager.getRenderPosition(
+                unit.id,
+                unit.gridX,
+                unit.gridY,
+                effectiveTileSize,
+                gridOffsetX,
+                gridOffsetY
+            );
 
             const imageSize = effectiveTileSize;
             const imgOffsetX = (effectiveTileSize - imageSize) / 2;

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -1,7 +1,7 @@
 // js/managers/TurnEngine.js
 
 export class TurnEngine {
-    constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine) {
+    constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager) {
         console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
@@ -9,6 +9,7 @@ export class TurnEngine {
         this.classAIManager = classAIManager;
         this.delayEngine = delayEngine;
         this.timingEngine = timingEngine;
+        this.animationManager = animationManager;
 
         this.currentTurn = 0;
         this.activeUnitIndex = -1;
@@ -86,10 +87,19 @@ export class TurnEngine {
             if (action) {
                 this.timingEngine.addTimedAction(async () => {
                     if (action.actionType === 'move' || action.actionType === 'moveAndAttack') {
-                        console.log(`[TurnEngine] Unit ${unit.name} attempts to move to (${action.moveTargetX}, ${action.moveTargetY}).`);
+                        const startGridX = unit.gridX;
+                        const startGridY = unit.gridY;
+                        console.log(`[TurnEngine] Unit ${unit.name} attempts to move from (${startGridX},${startGridY}) to (${action.moveTargetX}, ${action.moveTargetY}).`);
+
                         const moved = this.battleSimulationManager.moveUnit(unit.id, action.moveTargetX, action.moveTargetY);
                         if (moved) {
-                            await this.delayEngine.waitFor(300);
+                            await this.animationManager.queueMoveAnimation(
+                                unit.id,
+                                startGridX,
+                                startGridY,
+                                action.moveTargetX,
+                                action.moveTargetY
+                            );
                         }
                     }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -21,6 +21,7 @@ export { runTurnOrderManagerUnitTests } from './unit/turnOrderManagerUnitTests.j
 export { runBasicAIManagerUnitTests } from './unit/basicAIManagerUnitTests.js';
 export { runClassAIManagerUnitTests } from './unit/classAIManagerUnitTests.js';
 export { runBattleSimulationManagerUnitTests } from './unit/battleSimulationManagerUnitTests.js';
+export { runAnimationManagerUnitTests } from './unit/animationManagerUnitTests.js';
 
 export { runMeasureManagerIntegrationTest } from './integration/measureManagerIntegrationTests.js';
 

--- a/tests/unit/animationManagerUnitTests.js
+++ b/tests/unit/animationManagerUnitTests.js
@@ -1,0 +1,80 @@
+// tests/unit/animationManagerUnitTests.js
+import { AnimationManager } from '../../js/managers/AnimationManager.js';
+
+export function runAnimationManagerUnitTests() {
+    console.log('--- AnimationManager Unit Test Start ---');
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockMeasureManager = {
+        get: (key) => {
+            if (key === 'battleStage.padding') return 0;
+            return undefined;
+        }
+    };
+
+    const mockLogicManager = {
+        getCurrentSceneContentDimensions: () => ({ width: 1000, height: 1000 })
+    };
+
+    const mockBattleSimulationManager = {
+        gridCols: 10,
+        gridRows: 10,
+        logicManager: mockLogicManager
+    };
+
+    // Test 1: Initialization
+    testCount++;
+    try {
+        const am = new AnimationManager(mockMeasureManager, mockBattleSimulationManager);
+        if (am.activeAnimations instanceof Map && am.animationSpeed > 0) {
+            console.log('AnimationManager: Initialized correctly. [PASS]');
+            passCount++;
+        } else {
+            console.error('AnimationManager: Initialization failed. [FAIL]');
+        }
+    } catch (e) {
+        console.error('AnimationManager: Error during initialization. [FAIL]', e);
+    }
+
+    // Test 2: queueMoveAnimation and completion
+    testCount++;
+    try {
+        const am = new AnimationManager(mockMeasureManager, mockBattleSimulationManager);
+        let resolved = false;
+        const promise = am.queueMoveAnimation('u1', 0, 0, 1, 0).then(() => { resolved = true; });
+        const anim = am.activeAnimations.get('u1');
+        anim.startTime = performance.now() - anim.duration - 1;
+        am.update(0);
+        promise.then(() => {
+            if (resolved && !am.hasActiveAnimations()) {
+                console.log('AnimationManager: queueMoveAnimation resolves after update. [PASS]');
+                passCount++;
+            } else {
+                console.error('AnimationManager: Animation did not resolve correctly. [FAIL]');
+            }
+        });
+    } catch (e) {
+        console.error('AnimationManager: Error during queueMoveAnimation. [FAIL]', e);
+    }
+
+    // Test 3: getRenderPosition without animation
+    testCount++;
+    try {
+        const am = new AnimationManager(mockMeasureManager, mockBattleSimulationManager);
+        const pos = am.getRenderPosition('u1', 2, 3, 100, 0, 0);
+        if (pos.drawX === 200 && pos.drawY === 300) {
+            console.log('AnimationManager: getRenderPosition returns grid position when idle. [PASS]');
+            passCount++;
+        } else {
+            console.error('AnimationManager: getRenderPosition returned unexpected value. [FAIL]', pos);
+        }
+    } catch (e) {
+        console.error('AnimationManager: Error during getRenderPosition. [FAIL]', e);
+    }
+
+    setTimeout(() => {
+        console.log(`--- AnimationManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+    }, 50);
+}

--- a/tests/unit/turnEngineUnitTests.js
+++ b/tests/unit/turnEngineUnitTests.js
@@ -2,7 +2,7 @@
 
 import { TurnEngine } from '../../js/managers/TurnEngine.js';
 
-export function runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine) {
+export function runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager) {
     console.log("--- TurnEngine Unit Test Start ---");
 
     let testCount = 0;
@@ -17,7 +17,7 @@ export function runTurnEngineUnitTests(eventManager, battleSimulationManager, tu
     // 테스트 1: 초기화 확인
     testCount++;
     try {
-        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
         if (turnEngine.currentTurn === 0 && turnEngine.turnPhaseCallbacks.startOfTurn instanceof Array) {
             console.log("TurnEngine: Initialized correctly. [PASS]");
             passCount++;
@@ -31,7 +31,7 @@ export function runTurnEngineUnitTests(eventManager, battleSimulationManager, tu
     // 테스트 2: initializeTurnOrder 호출
     testCount++;
     try {
-        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
         turnEngine.initializeTurnOrder();
         if (turnEngine.turnOrder.length > 0 && turnEngine.turnOrder[0].id === 'u1') {
             console.log("TurnEngine: initializeTurnOrder called TurnOrderManager. [PASS]");
@@ -46,7 +46,7 @@ export function runTurnEngineUnitTests(eventManager, battleSimulationManager, tu
     // 테스트 3: 턴 단계 콜백 등록
     testCount++;
     try {
-        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
         let callbackCalled = false;
         const testCallback = async () => { callbackCalled = true; };
         turnEngine.addTurnPhaseCallback('startOfTurn', testCallback);
@@ -66,7 +66,7 @@ export function runTurnEngineUnitTests(eventManager, battleSimulationManager, tu
     window.setTimeout = (fn, delay) => fn();
 
     try {
-        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine);
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
         classAIManager.getBasicClassAction = async (unit, allUnits) => {
             if (unit.id === 'u1') return { actionType: 'attack', targetId: 'u2' };
             if (unit.id === 'u2') return { actionType: 'attack', targetId: 'u1' };


### PR DESCRIPTION
## Summary
- animate unit movement with new AnimationManager
- integrate AnimationManager into GameEngine, TurnEngine, and BattleSimulationManager
- update debug page and tests for new dependencies
- provide unit tests for AnimationManager

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6872767de4bc8327ad2c1d35e3c493d9