### PR TITLE
Add AnimationManager support in VFXManager

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -136,7 +136,14 @@ export class GameEngine {
         this.territoryManager = new TerritoryManager();
         this.battleStageManager = new BattleStageManager();
         this.battleGridManager = new BattleGridManager(this.measureManager, this.logicManager);
-        this.vfxManager = new VFXManager(this.renderer, this.measureManager, this.cameraEngine, this.battleSimulationManager);
+        // VFXManager에 AnimationManager를 전달하여 HP 바 위치를 애니메이션과 동기화합니다.
+        this.vfxManager = new VFXManager(
+            this.renderer,
+            this.measureManager,
+            this.cameraEngine,
+            this.battleSimulationManager,
+            this.animationManager // ✨ AnimationManager 추가
+        );
         this.bindingManager = new BindingManager();
         this.battleCalculationManager = new BattleCalculationManager(this.eventManager, this.battleSimulationManager);
 


### PR DESCRIPTION
## Summary
- pass `animationManager` into `VFXManager` via `GameEngine`
- store the animation manager in `VFXManager`
- draw HP bars based on animated render position from `AnimationManager`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68733a4fb8508327bba718fd9f144179