### PR TITLE
Add Valor and Weight engine modules

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -30,6 +30,8 @@ import { BattleLogManager } from './managers/BattleLogManager.js'; // ✨ 새롭
 import { TurnOrderManager } from './managers/TurnOrderManager.js'; // ✨ 새롭게 추가
 import { ClassAIManager } from './managers/ClassAIManager.js';   // ✨ 새롭게 추가
 import { BasicAIManager } from './managers/BasicAIManager.js'; // ✨ 새롭게 추가
+import { ValorEngine } from './managers/ValorEngine.js';   // ✨ ValorEngine 추가
+import { WeightEngine } from './managers/WeightEngine.js'; // ✨ WeightEngine 추가
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
@@ -150,6 +152,8 @@ export class GameEngine {
         // ✨ 새로운 엔진들 초기화
         this.delayEngine = new DelayEngine();
         this.timingEngine = new TimingEngine(this.delayEngine);
+        this.valorEngine = new ValorEngine();   // ✨ ValorEngine 초기화
+        this.weightEngine = new WeightEngine(); // ✨ WeightEngine 초기화
 
         // ✨ BasicAIManager 초기화
         this.basicAIManager = new BasicAIManager(this.battleSimulationManager);
@@ -334,6 +338,8 @@ export class GameEngine {
     // 새로운 엔진들에 대한 getter 메서드
     getDelayEngine() { return this.delayEngine; }
     getTimingEngine() { return this.timingEngine; }
+    getValorEngine() { return this.valorEngine; }
+    getWeightEngine() { return this.weightEngine; }
     getTurnEngine() { return this.turnEngine; }
     getTurnOrderManager() { return this.turnOrderManager; }
     getBasicAIManager() { return this.basicAIManager; }

--- a/js/managers/RuleManager.js
+++ b/js/managers/RuleManager.js
@@ -10,6 +10,13 @@ export class RuleManager {
     _loadBasicRules() {
         // 기본 규칙을 정의합니다.
         this.addRule('unitActionPerTurn', '유닛은 한 턴 당 [이동 + 공격 or 스킬]을 할 수 있다.');
+        // ✨ 용맹 시스템 규칙 추가
+        this.addRule('valorBarrierCalculation', '유닛의 용맹 수치에 따라 전투 시작 시 초기 배리어 양이 결정됩니다.');
+        this.addRule('valorDamageAmplification', '현재 배리어 양이 높을수록 적에게 주는 피해가 증가합니다. 배리어가 깎일수록 데미지가 감소합니다.');
+        // ✨ 무게 시스템 규칙 추가
+        this.addRule('weightTurnOrderImpact', '유닛의 총 무게(유닛 자체 무게 + 장착 아이템 무게)가 클수록 행동 순서가 느려집니다.');
+        this.addRule('strengthWeightEffect', '힘 스탯이 높을수록 유닛의 무게 가중치가 증가합니다.');
+        this.addRule('itemWeightInfluence', '아이템마다 고유 무게가 존재하며, 무게 총합이 턴 순서에 영향을 줍니다.');
         console.log("[RuleManager] Basic rules loaded.");
     }
 

--- a/js/managers/ValorEngine.js
+++ b/js/managers/ValorEngine.js
@@ -1,0 +1,39 @@
+// js/managers/ValorEngine.js
+
+export class ValorEngine {
+    constructor() {
+        console.log("\uD83D\uDEE1\uFE0F ValorEngine initialized. Ready to calculate barriers and damage amplification. \uD83D\uDEE1\uFE0F");
+        // \uC6A9\uBA85\uC5D0 \uB530\uB978 \uBC30\uB9AC\uC5B4 \uBC0F \uB370\uBBF8\uC9C0 \uC99D\uD3ED \uB85C\uC9D1\uC744 \uAD6C\uD604\uD569\uB2C8\uB2E4.
+        // \uD604\uC7AC\uB294 \uCF58\uC194 \uBA54\uC2DC\uC9C0\uB9CC \uCD9C\uB825\uD558\uBA70, \uB098\uC911\uC5D0 RuleManager \uB610\uB294 MeasureManager\uC640 \uC5F0\uB3D9\uB420 \uC218 \uC788\uC2B5\uB2C8\uB2E4.
+    }
+
+    /**
+     * \uC720\uB2DB\uC758 \uC6A9\uBA85 \uC2A4\uD0EF\uC5D0 \uAE30\uBCF8\uD574 \uCD08\uAE30 \uBC30\uB9AC\uC5B4(\uBCF4\uD638\uB9C8\uD06C) \uC591\uC744 \uACC4\uC0B0\uD569\uB2C8\uB2E4.
+     * @param {number} valorStat - \uC720\uB2DB\uC758 \uC6A9\uBA85 \uC2A4\uD0EF
+     * @returns {number} \uACC4\uC0B0\uB41C \uCD08\uAE30 \uBC30\uB9AC\uC5B4 \uC591
+     */
+    calculateInitialBarrier(valorStat) {
+        // \uC608\uC2DC: \uC6A9\uBA85 1\uB2F9 2\uC758 \uBC30\uB9AC\uC5B4 (\uCD94\uD6C4 \uBC30\uB780\uC2DD \uD544\uC694)
+        const barrierAmount = valorStat * 2;
+        console.log(`[ValorEngine] Valor ${valorStat} results in initial barrier of ${barrierAmount}.`);
+        return barrierAmount;
+    }
+
+    /**
+     * \uD604\uC7AC \uBC30\uB9AC\uC5B4 \uC591\uACFC \uCD5C\uB300 \uBC30\uB9AC\uC5B4(\uCD5C\uB300 \uCCB4\uB825)\uC5D0 \uAE30\uBCF8\uD574 \uB370\uBBF8\uC9C0 \uC99D\uD3ED\uC728\uC744 \uACC4\uC0B0\uD569\uB2C8\uB2E4.
+     * \uBC30\uB9AC\uC5B4\uAC00 \uB192\uC744\uC218\uB85D \uB370\uBBF8\uC9C0 \uC99D\uD3ED\uC728\uC774 \uB192\uC544\uC9D1\uB2C8\uB2E4.
+     * @param {number} currentBarrier - \uC720\uB2DB\uC758 \uD604\uC7AC \uBC30\uB9AC\uC5B4 \uC591
+     * @param {number} maxBarrier - \uC720\uB2DB\uC758 \uCD5C\uB300 \uBC30\uB9AC\uC5B4 (\uBCF4\uD1B5 \uC720\uB2DB\uC758 \uCD5C\uB300 HP\uC640 \uC5F0\uB3D9)
+     * @returns {number} \uB370\uBBF8\uC9C0 \uC99D\uD3ED\uC728 (\uC608: 1.0 = 100% \uB370\uBBF8\uC9C0, 1.2 = 120% \uB370\uBBF8\uC9C0)
+     */
+    calculateDamageAmplification(currentBarrier, maxBarrier) {
+        if (maxBarrier <= 0) return 1.0; // 0\uC73C\uB85C \uB098\uB9AC\uB294 \uAC83 \uBC29\uC9C0
+
+        // \uC608\uC2DC: \uBC30\uB9AC\uC5B4 \uBE44\uC728\uC5D0 \uB530\uB77C 1.0 ~ 1.5 \uC0AC\uC774\uB85C \uC99D\uD3ED (\uCD94\uD6C4 \uBC30\uB780\uC2DD \uD544\uC694)
+        // \uBC30\uB9AC\uC5B4 \uBE44\uC728\uC774 0\uC77C \uB54C 1.0, 1\uC77C \uB54C 1.5\uAC00 \uB418\uB3C4\uB85D \uC120\uD615 \uBCF4\uAC78
+        const barrierRatio = currentBarrier / maxBarrier;
+        const amplification = 1.0 + (0.5 * barrierRatio); // 0.5\uB294 \uCD5C\uB300 \uC99D\uD3ED\uB7C9
+        console.log(`[ValorEngine] Barrier ratio ${barrierRatio.toFixed(2)} results in damage amplification of ${amplification.toFixed(2)}.`);
+        return amplification;
+    }
+}

--- a/js/managers/WeightEngine.js
+++ b/js/managers/WeightEngine.js
@@ -1,0 +1,47 @@
+// js/managers/WeightEngine.js
+
+export class WeightEngine {
+    constructor() {
+        console.log("\u2696\uFE0F WeightEngine initialized. Ready to calculate weight and turn order impact. \u2696\uFE0F");
+        // \uBB34\uAC8C \uAC00\uC911\uCE58 \uACC4\uC0B0 \uB85C\uC9D1\uC744 \uAD6C\uD604\uD569\uB2C8\uB2E4.
+    }
+
+    /**
+     * \uC720\uB2DB\uC758 \uAE30\uBCF8 \uC2A4\uD0EF\uACFC \uC7A5\uCC29 \uC544\uC774\uD15C\uC758 \uBB34\uAC8C\uB97C \uD569\uC0B0\uD558\uC5EC \uCD1D \uBB34\uAC8C\uB97C \uACC4\uC0B0\uD569\uB2C8\uB2E4.
+     * \uD604\uC7AC\uB294 \uC544\uC774\uD15C \uC2DC\uC2A4\uD15C\uC774 \uC5C6\uC73C\uBbc0\uB85C, \uC720\uB2DB\uC758 'baseStats.weight'\uB97C \uC0AC\uC6A9\uD558\uAC70\uB098 \uAE30\uBCF8\uAC12\uC744 \uC801\uC6A9\uD569\uB2C8\uB2E4.
+     * \uD798(strength) \uC2A4\uD0EF\uC774 \uB192\uC744\uC218\uB85D \uBB34\uAC8C \uAC00\uC911\uCE58\uAC00 \uC62C\uB77C\uAC00\uB294 \uADDC\uCE59\uC744 \uC801\uC6A9\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4.
+     * @param {object} unitStats - \uC720\uB2DB\uC758 \uAE30\uBCF8 \uC2A4\uD0EF (baseStats \uD3EC\uD568)
+     * @param {object[]} [equippedItems=[]] - \uC720\uB2DB\uC774 \uC7A5\uCC29\uD55C \uC544\uC774\uD15C \uC5F4\uAC04 (\uAC01 \uC544\uC774\uD15C\uC5D0 weight \uC18D\uC131\uC774 \uC788\uB2E4\uACE0 \uAC00\uC815)
+     * @returns {number} \uC720\uB2DB\uC758 \uCD1D \uBB34\uAC8C
+     */
+    calculateTotalWeight(unitStats, equippedItems = []) {
+        let baseWeight = unitStats.baseStats && unitStats.baseStats.weight ? unitStats.baseStats.weight : 0;
+        let strength = unitStats.baseStats && unitStats.baseStats.strength ? unitStats.baseStats.strength : 0;
+
+        // \uC608\uC2DC: \uD798 \uC2A4\uD0EF\uC774 \uB192\uC744\uC218\uB85D \uBB34\uAC8C \uAC00\uC911\uCE58\uAC00 '\uC62C\uB77C\uAC00\uB294\uB2E4' (\uB354 \uBB34\uAC8C\uC6B4 \uC0C1\uD0DC\uB85C \uACF5\uC815)
+        // \uD798 10\uB2F9 \uBB34\uAC8C 1 \uC99D\uAC00 (\uCD94\uD6C4 \uBC30\uB780\uC2DD \uD544\uC694)
+        baseWeight += Math.floor(strength / 10);
+
+        let itemWeight = 0;
+        for (const item of equippedItems) {
+            itemWeight += item.weight || 0;
+        }
+
+        const totalWeight = baseWeight + itemWeight;
+        console.log(`[WeightEngine] Unit's total weight calculated: ${totalWeight} (Base: ${baseWeight}, Items: ${itemWeight}).`);
+        return totalWeight;
+    }
+
+    /**
+     * \uC720\uB2DB\uC758 \uCD1D \uBB34\uAC8C\uC5D0 \uAE30\uBCF8\uD574 \uD130\uC758 \uC21C\uC11C \uACB0\uC815\uC5D0 \uC0AC\uC6A9\uB420 \uD398\uB110\uD2F0 \uAC12\uC744 \uBC18\uD658\uD569\uB2C8\uB2E4.
+     * \uBB34\uAC8C\uAC00 \uD070 \uC218\uB85D \uD398\uB110\uD2F0\uAC00 \uCEE4\uC838 \uD130\uC758 \uC21C\uC11C\uAC00 \uB290\uB9AC\uC9C0\uB9CC \uB354 \uB290\uB9AC\uBA74 \uC548\uB429\uB2C8\uB2E4.
+     * (\uC774 \uAC12\uC740 TurnOrderManager\uC5D0\uC11C \uC720\uB2DB\uC758 \uC18D\uB3C4\uC640 \uD568\uAED8 \uC0AC\uC6A9\uB429\uB2C8\uB2E4.)
+     * @param {number} totalWeight - \uC720\uB2DB\uC758 \uCD1D \uBB34\uAC8C
+     * @returns {number} \uD130\uC704 \uC9C0\uC218 \uD398\uB110\uD2F0 (\uB192\uC744\uC218\uB85D \uD130\uC758 \uC21C\uC11C\uAC00 \uB290\uB9AC\uC9C0\uB9CC)
+     */
+    getTurnWeightPenalty(totalWeight) {
+        const penalty = totalWeight * 0.5;
+        console.log(`[WeightEngine] Total weight ${totalWeight} results in turn penalty of ${penalty}.`);
+        return penalty;
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ValorEngine` and `WeightEngine` classes
- integrate the engines in `GameEngine`
- document valor and weight rules in `RuleManager`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68733c0d740c83278fff5c8aa744e93b