### PR TITLE
Add StatManager and extend unit stats

### DIFF
--- a/data/unit.js
+++ b/data/unit.js
@@ -20,7 +20,15 @@ export const UNITS = {
             hp: 100,
             attack: 20,
             defense: 10,
-            speed: 5
+            speed: 5,
+            valor: 50,
+            strength: 25,
+            endurance: 20,
+            agility: 10,
+            intelligence: 5,
+            wisdom: 10,
+            luck: 15,
+            weight: 30
         },
         spriteId: 'sprite_warrior_default'
     }

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -32,6 +32,7 @@ import { ClassAIManager } from './managers/ClassAIManager.js';   // ✨ 새롭�
 import { BasicAIManager } from './managers/BasicAIManager.js'; // ✨ 새롭게 추가
 import { ValorEngine } from './managers/ValorEngine.js';   // ✨ ValorEngine 추가
 import { WeightEngine } from './managers/WeightEngine.js'; // ✨ WeightEngine 추가
+import { StatManager } from './managers/StatManager.js'; // ✨ StatManager 추가
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
@@ -154,6 +155,7 @@ export class GameEngine {
         this.timingEngine = new TimingEngine(this.delayEngine);
         this.valorEngine = new ValorEngine();   // ✨ ValorEngine 초기화
         this.weightEngine = new WeightEngine(); // ✨ WeightEngine 초기화
+        this.statManager = new StatManager(this.valorEngine, this.weightEngine); // ✨ StatManager 초기화
 
         // ✨ BasicAIManager 초기화
         this.basicAIManager = new BasicAIManager(this.battleSimulationManager);
@@ -280,7 +282,20 @@ export class GameEngine {
             name: '해골 병사',
             classId: 'class_skeleton',
             type: 'enemy',
-            baseStats: { hp: 80, attack: 15, defense: 5, speed: 30 },
+            baseStats: {
+                hp: 80,
+                attack: 15,
+                defense: 5,
+                speed: 30,
+                valor: 10,
+                strength: 10,
+                endurance: 8,
+                agility: 12,
+                intelligence: 5,
+                wisdom: 5,
+                luck: 15,
+                weight: 10
+            },
             spriteId: 'sprite_skeleton_default'
         };
         await this.idManager.addOrUpdateId(mockEnemyUnitData.id, mockEnemyUnitData);
@@ -340,6 +355,7 @@ export class GameEngine {
     getTimingEngine() { return this.timingEngine; }
     getValorEngine() { return this.valorEngine; }
     getWeightEngine() { return this.weightEngine; }
+    getStatManager() { return this.statManager; }
     getTurnEngine() { return this.turnEngine; }
     getTurnOrderManager() { return this.turnOrderManager; }
     getBasicAIManager() { return this.basicAIManager; }

--- a/js/managers/RuleManager.js
+++ b/js/managers/RuleManager.js
@@ -17,6 +17,31 @@ export class RuleManager {
         this.addRule('weightTurnOrderImpact', '유닛의 총 무게(유닛 자체 무게 + 장착 아이템 무게)가 클수록 행동 순서가 느려집니다.');
         this.addRule('strengthWeightEffect', '힘 스탯이 높을수록 유닛의 무게 가중치가 증가합니다.');
         this.addRule('itemWeightInfluence', '아이템마다 고유 무게가 존재하며, 무게 총합이 턴 순서에 영향을 줍니다.');
+
+        // ✨ 새로운 기본 스탯 규칙 추가
+        this.addRule('stat_hp', '체력: 유닛의 생명력을 나타냅니다.');
+        this.addRule('stat_valor', '용맹: 초반 배리어 및 배리어에 기반한 데미지 상승에 영향을 줍니다.');
+        this.addRule('stat_strength', '힘: 물리 근접 공격력 및 무게 가중치에 영향을 줍니다.');
+        this.addRule('stat_endurance', '인내: 물리 방어력 및 각종 상태이상 저항력에 영향을 줍니다.');
+        this.addRule('stat_agility', '민첩: 물리 원거리 공격력, 물리 공격 회피율, 정확도에 영향을 줍니다.');
+        this.addRule('stat_intelligence', '지능: 마법 공격력 및 각종 상태이상 적용률에 영향을 줍니다.');
+        this.addRule('stat_wisdom', '지혜: 마법 방어력 및 각종 속성 저항력에 영향을 줍니다.');
+        this.addRule('stat_luck', '운: 치명타율 및 마법 공격 회피율에 영향을 줍니다.');
+
+        // ✨ 나중에 계산되는 반영 스탯 규칙 추가
+        this.addRule('derived_barrier', '배리어: 용맹에 의해 결정되는 초기 보호막입니다.');
+        this.addRule('derived_weightPenalty', '무게 가중치: 유닛의 총 무게에 따라 턴 순서에 주어지는 페널티입니다.');
+        this.addRule('derived_physicalAttack', '물리 공격력: 힘 스탯에 의해 계산되는 근접 및 원거리 공격력입니다.');
+        this.addRule('derived_physicalDefense', '물리 방어력: 인내 스탯에 의해 계산되는 방어력입니다.');
+        this.addRule('derived_magicAttack', '마법 공격력: 지능 스탯에 의해 계산되는 공격력입니다.');
+        this.addRule('derived_magicDefense', '마법 방어력: 지혜 스탯에 의해 계산되는 방어력입니다.');
+        this.addRule('derived_accuracy', '정확도: 민첩 스탯에 의해 계산되는 공격 명중률입니다.');
+        this.addRule('derived_physicalEvade', '물리 공격 회피율: 민첩 스탯에 의해 계산되는 물리 공격 회피 확률입니다.');
+        this.addRule('derived_magicEvade', '마법 공격 회피율: 운 스탯에 의해 계산되는 마법 공격 회피 확률입니다.');
+        this.addRule('derived_criticalChance', '치명타율: 운 스탯에 의해 계산되는 치명타 발생 확률입니다.');
+        this.addRule('derived_criticalDamageMultiplier', '치명타 피해 배율: 치명타 발생 시 추가되는 피해 배율입니다.');
+        this.addRule('derived_statusEffectApplication', '상태이상 적용률: 지능 스탯에 의해 계산되는 상태이상 적용 성공률입니다.');
+        this.addRule('derived_statusEffectResistance', '상태이상 저항력: 인내 스탯에 의해 계산되는 상태이상 저항률입니다.');
         console.log("[RuleManager] Basic rules loaded.");
     }
 

--- a/js/managers/StatManager.js
+++ b/js/managers/StatManager.js
@@ -1,0 +1,70 @@
+// js/managers/StatManager.js
+
+export class StatManager {
+    constructor(valorEngine, weightEngine) {
+        console.log("\uD83D\uDCCA StatManager initialized. Ready to calculate unit statistics. \uD83D\uDCCA");
+        this.valorEngine = valorEngine;
+        this.weightEngine = weightEngine;
+    }
+
+    /**
+     * \uC720\uB2DB\uC758 \uAE30\uBCF8 \uC2A4\uD0EF\uACFC \uCD94\uAC00 \uD6A8\uACFC\uB97C \uAE30\uBCF8\uC73C\uB85C \uCD5C\uC885 \uACC4\uC0B0\uB41C \uC2A4\uD0EF\uC744 \uBC18\uD558\uC5EC \uBC18\uD558\uC5EC \uBC30\uB9AC\uC5B4\uC640 \uBB34\uAC8C \uC601\uC5ED\uC744 \uD569\uC131\uD569\uB2C8\uB2E4.
+     * @param {object} unitData - \uC720\uB2DB\uC758 \uC6D0\uBCF8 \uB370\uC774\uD130 (baseStats \uD3EC\uD568)
+     * @param {object[]} [equippedItems=[]] - \uC720\uB2DB\uC774 \uC7A5\uCC29\uD55C \uC544\uC774\uD15C \uBAA9\uB85D
+     * @returns {object} \uACC4\uC0B0\uB41C \uCD5C\uC885 \uC2A4\uD0EF \uAC1D\uCCB4
+     */
+    getCalculatedStats(unitData, equippedItems = []) {
+        const base = unitData.baseStats;
+        if (!base) {
+            console.warn(`[StatManager] No baseStats found for unit ${unitData.id || unitData.name}. Returning empty stats.`);
+            return {};
+        }
+
+        const calculatedStats = {
+            hp: base.hp || 0,
+            valor: base.valor || 0,
+            strength: base.strength || 0,
+            endurance: base.endurance || 0,
+            agility: base.agility || 0,
+            intelligence: base.intelligence || 0,
+            wisdom: base.wisdom || 0,
+            luck: base.luck || 0,
+
+            barrier: this.valorEngine.calculateInitialBarrier(base.valor || 0),
+            damageAmplification: 1.0,
+
+            totalWeight: this.weightEngine.calculateTotalWeight(unitData, equippedItems),
+            turnWeightPenalty: 0,
+
+            physicalAttack: (base.strength || 0) * 1.5,
+            physicalDefense: (base.endurance || 0) * 1.2,
+            magicAttack: (base.intelligence || 0) * 1.5,
+            magicDefense: (base.wisdom || 0) * 1.2,
+
+            physicalEvadeChance: (base.agility || 0) * 0.2,
+            accuracy: (base.agility || 0) * 0.15,
+            magicEvadeChance: (base.luck || 0) * 0.1,
+
+            criticalChance: (base.luck || 0) * 0.05,
+            criticalDamageMultiplier: 1.5,
+
+            statusEffectResistance: (base.endurance || 0) * 0.1,
+            statusEffectApplication: (base.intelligence || 0) * 0.1
+        };
+
+        calculatedStats.turnWeightPenalty = this.weightEngine.getTurnWeightPenalty(calculatedStats.totalWeight);
+
+        console.log(`[StatManager] Calculated stats for ${unitData.name || unitData.id}:`, calculatedStats);
+        return calculatedStats;
+    }
+
+    /**
+     * \uC720\uB2DB\uC758 \uD604\uC7AC \uBC30\uB9AC\uC5B4 \uC591\uC5D0 \uB530\uB77C \uB370\uBBF8\uC9C0 \uC99D\uD3ED\uB960\uC744 \uC5C5\uB370\uC774\uD2B8\uD569\uB2C8\uB2E4.
+     * @param {number} currentBarrier - \uC720\uB2DB\uC758 \uD604\uC7AC \uBC30\uB9AC\uC5B4 \uC591
+     * @param {number} maxBarrier - \uC720\uB2DB\uC758 \uCD5C\uB300 \uBC30\uB9AC\uC5B4 (\uCD5C\uB300 HP)
+     * @returns {number} \uC5C5\uB370\uC774\uD2B8\uB41C \uB370\uBBF8\uC9C0 \uC99D\uD3ED\uB960
+     */
+    updateDamageAmplification(currentBarrier, maxBarrier) {
+        return this.valorEngine.calculateDamageAmplification(currentBarrier, maxBarrier);
+    }
+}


### PR DESCRIPTION
## Summary
- create new `StatManager` to calculate full unit stats
- initialize `StatManager` in `GameEngine`
- expand warrior base stats
- add skeleton enemy stats directly in `GameEngine`
- document stat rules in `RuleManager`

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl`

------
https://chatgpt.com/codex/tasks/task_e_68733f820e348327800ce9f6a8b28716