### PR TITLE
Add floating damage VFX and canvas bridge manager

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -56,6 +56,19 @@
             border: 2px solid #fff;
             background-color: #000;
         }
+        #gameContainer {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        #mercenaryPanelCanvas {
+            margin-bottom: 10px;
+            border: 2px solid #00f;
+        }
+        #combatLogCanvas {
+            margin-top: 10px;
+            border: 2px solid #f00;
+        }
     </style>
 </head>
 <body>
@@ -89,7 +102,11 @@
         <h4>전투 계산 테스트</h4>
         <button id="testDamageCalculationBtn">대미지 계산 테스트 (전사 -> 해골)</button>
     </div>
-    <canvas id="gameCanvas"></canvas>
+    <div id="gameContainer">
+        <canvas id="mercenaryPanelCanvas"></canvas>
+        <canvas id="gameCanvas"></canvas>
+        <canvas id="combatLogCanvas"></canvas>
+    </div>
     <script type="module">
         import { GameEngine } from './js/GameEngine.js'; // <-- GameEngine 불러오기
         import { 

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -17,6 +17,7 @@ import { AssetLoaderManager } from './managers/AssetLoaderManager.js';
 import { BattleSimulationManager } from './managers/BattleSimulationManager.js';
 import { AnimationManager } from './managers/AnimationManager.js';
 import { VFXManager } from './managers/VFXManager.js';
+import { CanvasBridgeManager } from './managers/CanvasBridgeManager.js'; // ✨ CanvasBridgeManager 추가
 import { BindingManager } from './managers/BindingManager.js';
 import { BattleCalculationManager } from './managers/BattleCalculationManager.js';
 import { MercenaryPanelManager } from './managers/MercenaryPanelManager.js'; // ✨ MercenaryPanelManager 추가
@@ -134,6 +135,15 @@ export class GameEngine {
         this.cameraEngine = new CameraEngine(this.renderer, this.logicManager, this.sceneEngine);
         this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine);
 
+        const mainGameCanvasElement = document.getElementById(canvasId);
+        this.canvasBridgeManager = new CanvasBridgeManager(
+            mainGameCanvasElement,
+            mercenaryPanelCanvasElement,
+            combatLogCanvasElement,
+            this.eventManager,
+            this.measureManager
+        );
+
         this.layerEngine = new LayerEngine(this.renderer, this.cameraEngine);
 
         this.territoryManager = new TerritoryManager();
@@ -145,7 +155,8 @@ export class GameEngine {
             this.measureManager,
             this.cameraEngine,
             this.battleSimulationManager,
-            this.animationManager // ✨ AnimationManager 추가
+            this.animationManager,
+            this.eventManager // ✨ eventManager 추가
         );
         this.bindingManager = new BindingManager();
         this.battleCalculationManager = new BattleCalculationManager(this.eventManager, this.battleSimulationManager);
@@ -310,6 +321,7 @@ export class GameEngine {
     _update(deltaTime) {
         this.sceneEngine.update(deltaTime);
         this.animationManager.update(deltaTime);
+        this.vfxManager.update(deltaTime);
     }
 
     _draw() {
@@ -361,4 +373,5 @@ export class GameEngine {
     getBasicAIManager() { return this.basicAIManager; }
     getClassAIManager() { return this.classAIManager; }
     getAnimationManager() { return this.animationManager; }
+    getCanvasBridgeManager() { return this.canvasBridgeManager; }
 }

--- a/js/managers/BattleCalculationManager.js
+++ b/js/managers/BattleCalculationManager.js
@@ -23,6 +23,9 @@ export class BattleCalculationManager {
             if (unitToUpdate) {
                 unitToUpdate.currentHp = newHp;
 
+                // ✨ Emit event so VFXManager can display floating damage numbers
+                this.eventManager.emit('displayDamage', { unitId: unitId, damage: damageDealt });
+
                 if (newHp <= 0) {
                     this.eventManager.emit('unitDeath', { unitId: unitId, unitName: unitToUpdate.name, unitType: unitToUpdate.type });
                     console.log(`[BattleCalculationManager] Unit '${unitId}' has died.`);

--- a/js/managers/CanvasBridgeManager.js
+++ b/js/managers/CanvasBridgeManager.js
@@ -1,0 +1,59 @@
+export class CanvasBridgeManager {
+    constructor(gameCanvas, mercenaryPanelCanvas, combatLogCanvas, eventManager, measureManager) {
+        console.log("\ud83c\udf0e CanvasBridgeManager initialized. Ready to bridge canvas interactions. \ud83c\udf0e");
+        this.gameCanvas = gameCanvas;
+        this.mercenaryPanelCanvas = mercenaryPanelCanvas;
+        this.combatLogCanvas = combatLogCanvas;
+        this.eventManager = eventManager;
+        this.measureManager = measureManager;
+
+        this.isDragging = false;
+        this.draggedElement = null;
+        this.dragStartX = 0;
+        this.dragStartY = 0;
+        this.offsetX = 0;
+        this.offsetY = 0;
+
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        [this.gameCanvas, this.mercenaryPanelCanvas, this.combatLogCanvas].forEach(canvas => {
+            if (canvas) {
+                canvas.addEventListener('mousedown', this._onMouseDown.bind(this));
+                canvas.addEventListener('mousemove', this._onMouseMove.bind(this));
+                canvas.addEventListener('mouseup', this._onMouseUp.bind(this));
+                canvas.addEventListener('mouseleave', this._onMouseUp.bind(this));
+            }
+        });
+        console.log("[CanvasBridgeManager] Listening for mouse events on all canvases.");
+    }
+
+    _onMouseDown(event) {
+        if (event.target === this.mercenaryPanelCanvas) {
+            this.isDragging = true;
+            this.dragStartX = event.clientX;
+            this.dragStartY = event.clientY;
+            console.log("[CanvasBridgeManager] Dragging started from Mercenary Panel.");
+            this.eventManager.emit('dragStart', { clientX: event.clientX, clientY: event.clientY, sourceCanvas: event.target.id });
+        }
+    }
+
+    _onMouseMove(event) {
+        if (!this.isDragging) return;
+        this.eventManager.emit('dragMove', { clientX: event.clientX, clientY: event.clientY, currentCanvas: event.target.id });
+    }
+
+    _onMouseUp(event) {
+        if (!this.isDragging) return;
+        this.isDragging = false;
+        if (event.target === this.gameCanvas) {
+            console.log("[CanvasBridgeManager] Dragging ended, dropped on Game Canvas.");
+            this.eventManager.emit('drop', { clientX: event.clientX, clientY: event.clientY, targetCanvas: event.target.id, droppedElement: this.draggedElement });
+        } else {
+            console.log("[CanvasBridgeManager] Dragging ended, no valid drop target.");
+            this.eventManager.emit('dragCancel', {});
+        }
+        this.draggedElement = null;
+    }
+}


### PR DESCRIPTION
## Summary
- emit `displayDamage` event for floating damage numbers
- extend `VFXManager` to render damage numbers and listen for events
- integrate `VFXManager` update call in `GameEngine`
- introduce `CanvasBridgeManager` and wire it into `GameEngine`
- expose `canvasBridgeManager` via getter
- update `debug.html` with new canvases and styles

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6873413682fc8327960bdf55f9e639af