### PR TITLE
Add barrier gauge and weight-based turn order

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -70,13 +70,17 @@ export class GameEngine {
         // AnimationManager는 BattleSimulationManager의 렌더링에 사용됩니다.
         this.animationManager = new AnimationManager(this.measureManager);
 
+        // ✨ ValorEngine을 먼저 초기화하여 BattleSimulationManager에 전달합니다.
+        this.valorEngine = new ValorEngine();
+
         // 전투 시뮬레이션 매니저 초기화
         this.battleSimulationManager = new BattleSimulationManager(
             this.measureManager,
             this.assetLoaderManager,
             this.idManager,
             this.logicManager,
-            this.animationManager
+            this.animationManager,
+            this.valorEngine // ✨ valorEngine 추가
         );
         // 생성 후 상호 참조 설정
         this.animationManager.battleSimulationManager = this.battleSimulationManager;
@@ -164,7 +168,6 @@ export class GameEngine {
         // ✨ 새로운 엔진들 초기화
         this.delayEngine = new DelayEngine();
         this.timingEngine = new TimingEngine(this.delayEngine);
-        this.valorEngine = new ValorEngine();   // ✨ ValorEngine 초기화
         this.weightEngine = new WeightEngine(); // ✨ WeightEngine 초기화
         this.statManager = new StatManager(this.valorEngine, this.weightEngine); // ✨ StatManager 초기화
 
@@ -172,7 +175,11 @@ export class GameEngine {
         this.basicAIManager = new BasicAIManager(this.battleSimulationManager);
 
         // ✨ 새로운 매니저 초기화
-        this.turnOrderManager = new TurnOrderManager(this.eventManager, this.battleSimulationManager);
+        this.turnOrderManager = new TurnOrderManager(
+            this.eventManager,
+            this.battleSimulationManager,
+            this.weightEngine // ✨ weightEngine 추가
+        );
         this.classAIManager = new ClassAIManager(this.idManager, this.battleSimulationManager, this.measureManager, this.basicAIManager);
 
         // ✨ TurnEngine에 새로운 의존성 전달

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -1,13 +1,14 @@
 // js/managers/BattleSimulationManager.js
 
 export class BattleSimulationManager {
-    constructor(measureManager, assetLoaderManager, idManager, logicManager, animationManager) {
+    constructor(measureManager, assetLoaderManager, idManager, logicManager, animationManager, valorEngine) {
         console.log("\u2694\ufe0f BattleSimulationManager initialized. Preparing units for battle. \u2694\ufe0f");
         this.measureManager = measureManager;
         this.assetLoaderManager = assetLoaderManager;
         this.idManager = idManager; // Keep for other potential uses, though not directly in draw
         this.logicManager = logicManager;
         this.animationManager = animationManager;
+        this.valorEngine = valorEngine;
         this.unitsOnGrid = [];
         this.gridRows = 10; // BattleGridManager와 동일한 그리드 차원
         this.gridCols = 15;
@@ -21,7 +22,9 @@ export class BattleSimulationManager {
      * @param {number} gridY
      */
     addUnit(fullUnitData, unitImage, gridX, gridY) {
-        // 유닛의 모든 필요한 데이터를 한 번에 저장합니다.
+        // ✨ 유닛의 용맹 스탯에 기반하여 초기 배리어를 계산합니다.
+        const initialBarrier = this.valorEngine.calculateInitialBarrier(fullUnitData.baseStats.valor || 0);
+
         const unitInstance = {
             id: fullUnitData.id,
             name: fullUnitData.name,
@@ -34,10 +37,12 @@ export class BattleSimulationManager {
             baseStats: fullUnitData.baseStats,
             type: fullUnitData.type,
             fullUnitData: fullUnitData,
-            currentHp: fullUnitData.currentHp !== undefined ? fullUnitData.currentHp : fullUnitData.baseStats.hp
+            currentHp: fullUnitData.currentHp !== undefined ? fullUnitData.currentHp : fullUnitData.baseStats.hp,
+            currentBarrier: initialBarrier, // ✨ 현재 배리어 설정
+            maxBarrier: initialBarrier // ✨ 최대 배리어는 초기 배리어와 동일
         };
         this.unitsOnGrid.push(unitInstance);
-        console.log(`[BattleSimulationManager] Added unit '${unitInstance.id}' at (${gridX}, ${gridY}).`);
+        console.log(`[BattleSimulationManager] Added unit '${unitInstance.id}' at (${gridX}, ${gridY}) with initial barrier ${initialBarrier}.`);
     }
 
     /**

--- a/js/managers/TurnOrderManager.js
+++ b/js/managers/TurnOrderManager.js
@@ -1,10 +1,11 @@
 // js/managers/TurnOrderManager.js
 
 export class TurnOrderManager {
-    constructor(eventManager, battleSimulationManager) {
+    constructor(eventManager, battleSimulationManager, weightEngine) {
         console.log("\uD83D\uDCDC TurnOrderManager initialized. Ready to compute turn sequences. \uD83D\uDCDC");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
+        this.weightEngine = weightEngine;
         this.currentTurnOrder = [];
     }
 
@@ -18,9 +19,20 @@ export class TurnOrderManager {
         this.currentTurnOrder = [...units].sort((a, b) => {
             const speedA = a.baseStats ? a.baseStats.speed : 0;
             const speedB = b.baseStats ? b.baseStats.speed : 0;
-            return speedB - speedA;
+
+            const penaltyA = this.weightEngine.getTurnWeightPenalty(
+                this.weightEngine.calculateTotalWeight(a, [])
+            );
+            const penaltyB = this.weightEngine.getTurnWeightPenalty(
+                this.weightEngine.calculateTotalWeight(b, [])
+            );
+
+            const initiativeA = speedA - penaltyA;
+            const initiativeB = speedB - penaltyB;
+
+            return initiativeB - initiativeA;
         });
-        console.log("[TurnOrderManager] Calculated turn order:", this.currentTurnOrder.map(unit => unit.name));
+        console.log("[TurnOrderManager] Calculated turn order:", this.currentTurnOrder.map(unit => `${unit.name} (Initiative: ${( (unit.baseStats.speed || 0) - this.weightEngine.getTurnWeightPenalty(this.weightEngine.calculateTotalWeight(unit, []))).toFixed(2)})`));
         return this.currentTurnOrder;
     }
 

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -90,6 +90,41 @@ export class VFXManager {
     }
 
     /**
+     * ✨ 특정 유닛의 배리어 바를 그립니다 (HP 바 아래에 노란색 게이지).
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
+     * @param {object} unit - 배리어 바를 그릴 유닛 객체
+     * @param {number} effectiveTileSize - 유닛이 그려지는 타일의 유효 크기
+     * @param {number} actualDrawX - 유닛의 실제 렌더링 x 좌표 (애니메이션이 적용된)
+     * @param {number} actualDrawY - 유닛의 실제 렌더링 y 좌표 (애니메이션이 적용된)
+     */
+    drawBarrierBar(ctx, unit, effectiveTileSize, actualDrawX, actualDrawY) {
+        if (!unit || unit.currentBarrier === undefined || unit.maxBarrier === undefined) {
+            return;
+        }
+
+        const currentBarrier = unit.currentBarrier;
+        const maxBarrier = unit.maxBarrier;
+        const barrierRatio = maxBarrier > 0 ? currentBarrier / maxBarrier : 0;
+
+        const barWidth = effectiveTileSize * 0.8;
+        const barHeight = effectiveTileSize * 0.05;
+        const barOffsetY = effectiveTileSize * 0.1 + 8;
+
+        const barrierBarDrawX = actualDrawX + (effectiveTileSize - barWidth) / 2;
+        const barrierBarDrawY = actualDrawY + barOffsetY;
+
+        ctx.fillStyle = 'rgba(50, 50, 50, 0.8)';
+        ctx.fillRect(barrierBarDrawX, barrierBarDrawY, barWidth, barHeight);
+
+        ctx.fillStyle = '#FFFF00';
+        ctx.fillRect(barrierBarDrawX, barrierBarDrawY, barWidth * barrierRatio, barHeight);
+
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(barrierBarDrawX, barrierBarDrawY, barWidth, barHeight);
+    }
+
+    /**
      * 모든 활성 시각 효과를 그립니다. 이 메서드는 LayerEngine에 의해 호출됩니다.
      * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
      */
@@ -125,6 +160,7 @@ export class VFXManager {
                 gridOffsetY
             );
             this.drawHpBar(ctx, unit, effectiveTileSize, drawX, drawY);
+            this.drawBarrierBar(ctx, unit, effectiveTileSize, drawX, drawY); // ✨ 배리어 바 그리기 호출
         }
 
         // ✨ 데미지 숫자 그리기


### PR DESCRIPTION
## Summary
- use ValorEngine when creating units to initialize barrier stats
- show yellow barrier bar below HP via VFXManager
- calculate turn order using WeightEngine penalties
- pass ValorEngine and WeightEngine to appropriate managers

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68734306b86483279fdae3001d60406b