### PR TITLE
Add extensive unit tests

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -86,6 +86,14 @@
         <button id="runCompatibilityManagerUnitTestsBtn">CompatibilityManager 유닛 테스트</button>
         <button id="runEventManagerUnitTestsBtn">EventManager 유닛 테스트</button>
         <button id="runGuardianManagerUnitTestsBtn">GuardianManager 유닛 테스트</button>
+        <button id="runValorEngineUnitTestsBtn">ValorEngine 유닛 테스트</button>
+        <button id="runWeightEngineUnitTestsBtn">WeightEngine 유닛 테스트</button>
+        <button id="runStatManagerUnitTestsBtn">StatManager 유닛 테스트</button>
+        <button id="runVFXManagerUnitTestsBtn">VFXManager 유닛 테스트</button>
+        <button id="runCanvasBridgeManagerUnitTestsBtn">CanvasBridgeManager 유닛 테스트</button>
+        <button id="runMeasureManagerUnitTestsBtn">MeasureManager 유닛 테스트</button>
+        <button id="runMapManagerUnitTestsBtn">MapManager 유닛 테스트</button>
+        <button id="runUIEngineUnitTestsBtn">UIEngine 유닛 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -136,7 +144,16 @@
             runTurnOrderManagerUnitTests,
             runBasicAIManagerUnitTests,
             runClassAIManagerUnitTests,
-            runBattleSimulationManagerUnitTests
+            runBattleSimulationManagerUnitTests,
+            runAnimationManagerUnitTests,
+            runValorEngineUnitTests,
+            runWeightEngineUnitTests,
+            runStatManagerUnitTests,
+            runVFXManagerUnitTests,
+            runCanvasBridgeManagerUnitTests,
+            runMeasureManagerUnitTests,
+            runMapManagerUnitTests,
+            runUIEngineUnitTests
         } from './tests/index.js';
 
         document.addEventListener('DOMContentLoaded', () => {
@@ -208,6 +225,15 @@
                 runBasicAIManagerUnitTests(battleSimulationManager);
                 runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager);
                 runBattleSimulationManagerUnitTests(measureManager, gameEngine.getAssetLoaderManager(), idManager, logicManager);
+                runAnimationManagerUnitTests();
+                runValorEngineUnitTests();
+                runWeightEngineUnitTests();
+                runStatManagerUnitTests();
+                runVFXManagerUnitTests();
+                runCanvasBridgeManagerUnitTests();
+                runMeasureManagerUnitTests();
+                runMapManagerUnitTests();
+                runUIEngineUnitTests();
             });
 
             document.getElementById('runMeasureManagerIntegrationTestBtn').addEventListener('click', () => {
@@ -229,6 +255,30 @@
             });
             document.getElementById('runGuardianManagerUnitTestsBtn').addEventListener('click', () => {
                 runGuardianManagerTests(guardianManager);
+            });
+            document.getElementById('runValorEngineUnitTestsBtn').addEventListener('click', () => {
+                runValorEngineUnitTests();
+            });
+            document.getElementById('runWeightEngineUnitTestsBtn').addEventListener('click', () => {
+                runWeightEngineUnitTests();
+            });
+            document.getElementById('runStatManagerUnitTestsBtn').addEventListener('click', () => {
+                runStatManagerUnitTests();
+            });
+            document.getElementById('runVFXManagerUnitTestsBtn').addEventListener('click', () => {
+                runVFXManagerUnitTests();
+            });
+            document.getElementById('runCanvasBridgeManagerUnitTestsBtn').addEventListener('click', () => {
+                runCanvasBridgeManagerUnitTests();
+            });
+            document.getElementById('runMeasureManagerUnitTestsBtn').addEventListener('click', () => {
+                runMeasureManagerUnitTests();
+            });
+            document.getElementById('runMapManagerUnitTestsBtn').addEventListener('click', () => {
+                runMapManagerUnitTests();
+            });
+            document.getElementById('runUIEngineUnitTestsBtn').addEventListener('click', () => {
+                runUIEngineUnitTests();
             });
 
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
@@ -366,6 +416,15 @@
             runBasicAIManagerUnitTests(battleSimulationManager);
             runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager);
             runBattleSimulationManagerUnitTests(measureManager, gameEngine.getAssetLoaderManager(), idManager, logicManager);
+            runAnimationManagerUnitTests();
+            runValorEngineUnitTests();
+            runWeightEngineUnitTests();
+            runStatManagerUnitTests();
+            runVFXManagerUnitTests();
+            runCanvasBridgeManagerUnitTests();
+            runMeasureManagerUnitTests();
+            runMapManagerUnitTests();
+            runUIEngineUnitTests();
         });
     </script>
 </body>

--- a/tests/index.js
+++ b/tests/index.js
@@ -23,6 +23,16 @@ export { runClassAIManagerUnitTests } from './unit/classAIManagerUnitTests.js';
 export { runBattleSimulationManagerUnitTests } from './unit/battleSimulationManagerUnitTests.js';
 export { runAnimationManagerUnitTests } from './unit/animationManagerUnitTests.js';
 
+// ✨ 새로 추가되거나 업데이트된 단위 테스트
+export { runValorEngineUnitTests } from './unit/valorEngineUnitTests.js';
+export { runWeightEngineUnitTests } from './unit/weightEngineUnitTests.js';
+export { runStatManagerUnitTests } from './unit/statManagerUnitTests.js';
+export { runVFXManagerUnitTests } from './unit/vfxManagerUnitTests.js';
+export { runCanvasBridgeManagerUnitTests } from './unit/canvasBridgeManagerUnitTests.js';
+export { runMeasureManagerUnitTests as runUpdatedMeasureManagerUnitTests } from './unit/measureManagerUnitTests.js';
+export { runMapManagerUnitTests as runUpdatedMapManagerUnitTests } from './unit/mapManagerUnitTests.js';
+export { runUIEngineUnitTests as runUpdatedUIEngineUnitTests } from './unit/uiEngineUnitTests.js';
+
 export { runMeasureManagerIntegrationTest } from './integration/measureManagerIntegrationTests.js';
 
 export { injectRendererFault } from './fault_injection/rendererFaults.js';

--- a/tests/unit/canvasBridgeManagerUnitTests.js
+++ b/tests/unit/canvasBridgeManagerUnitTests.js
@@ -1,0 +1,93 @@
+// tests/unit/canvasBridgeManagerUnitTests.js
+
+import { CanvasBridgeManager } from '../../js/managers/CanvasBridgeManager.js';
+import { EventManager } from '../../js/managers/EventManager.js';
+import { MeasureManager } from '../../js/managers/MeasureManager.js';
+
+export function runCanvasBridgeManagerUnitTests() {
+    console.log("--- CanvasBridgeManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockGameCanvas = document.createElement('canvas');
+    mockGameCanvas.id = 'gameCanvas';
+    const mockMercenaryPanelCanvas = document.createElement('canvas');
+    mockMercenaryPanelCanvas.id = 'mercenaryPanelCanvas';
+    const mockCombatLogCanvas = document.createElement('canvas');
+    mockCombatLogCanvas.id = 'combatLogCanvas';
+
+    const mockEventManager = new EventManager();
+    const mockMeasureManager = new MeasureManager();
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const cbm = new CanvasBridgeManager(
+            mockGameCanvas,
+            mockMercenaryPanelCanvas,
+            mockCombatLogCanvas,
+            mockEventManager,
+            mockMeasureManager
+        );
+        if (cbm.gameCanvas === mockGameCanvas && cbm.isDragging === false) {
+            console.log("CanvasBridgeManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("CanvasBridgeManager: Initialization failed. [FAIL]", cbm);
+        }
+    } catch (e) {
+        console.error("CanvasBridgeManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: _setupEventListeners가 이벤트 리스너를 추가하는지 간접 확인
+    testCount++;
+    try {
+        const cbm = new CanvasBridgeManager(
+            mockGameCanvas,
+            mockMercenaryPanelCanvas,
+            mockCombatLogCanvas,
+            mockEventManager,
+            mockMeasureManager
+        );
+        console.log("CanvasBridgeManager: Event listeners setup is assumed to be correct if no errors were thrown. [PASS/INFO]");
+        passCount++;
+    } catch (e) {
+        console.error("CanvasBridgeManager: Error during event listener setup test. [FAIL]", e);
+    }
+
+    // 테스트 3: mousedown -> mousemove -> mouseup 흐름 테스트
+    testCount++;
+    try {
+        const cbm = new CanvasBridgeManager(
+            mockGameCanvas,
+            mockMercenaryPanelCanvas,
+            mockCombatLogCanvas,
+            mockEventManager,
+            mockMeasureManager
+        );
+
+        let dragStartEmitted = false;
+        let dragMoveEmitted = false;
+        let dropEmitted = false;
+
+        mockEventManager.subscribe('dragStart', () => { dragStartEmitted = true; });
+        mockEventManager.subscribe('dragMove', () => { dragMoveEmitted = true; });
+        mockEventManager.subscribe('drop', () => { dropEmitted = true; });
+
+        cbm._onMouseDown({ clientX: 10, clientY: 10, target: mockMercenaryPanelCanvas });
+        cbm._onMouseMove({ clientX: 20, clientY: 20, target: mockGameCanvas });
+        cbm._onMouseUp({ clientX: 20, clientY: 20, target: mockGameCanvas });
+
+        if (cbm.isDragging === false && dragStartEmitted && dragMoveEmitted && dropEmitted) {
+            console.log("CanvasBridgeManager: Drag-drop event flow (mousedown-mousemove-mouseup) worked. [PASS]");
+            passCount++;
+        } else {
+            console.error("CanvasBridgeManager: Drag-drop event flow failed. [FAIL]", { isDragging: cbm.isDragging, dragStartEmitted, dragMoveEmitted, dropEmitted });
+        }
+    } catch (e) {
+        console.error("CanvasBridgeManager: Error during drag-drop flow test. [FAIL]", e);
+    }
+
+    console.log(`--- CanvasBridgeManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/mapManagerUnitTests.js
+++ b/tests/unit/mapManagerUnitTests.js
@@ -1,3 +1,119 @@
+// tests/unit/mapManagerUnitTests.js
+
+import { MapManager } from '../../js/managers/MapManager.js';
+import { MeasureManager } from '../../js/managers/MeasureManager.js';
+
 export function runMapManagerUnitTests() {
-    console.warn('MapManager unit tests are not implemented yet.');
+    console.log("--- MapManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockMeasureManager = new MeasureManager();
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const mapManager = new MapManager(mockMeasureManager);
+        if (mapManager.mapData instanceof Array && mapManager.gridRows > 0 && mapManager.gridCols > 0) {
+            console.log("MapManager: Initialized correctly and mapData generated. [PASS]");
+            passCount++;
+        } else {
+            console.error("MapManager: Initialization failed. [FAIL]", mapManager);
+        }
+    } catch (e) {
+        console.error("MapManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: recalculateMapDimensions
+    testCount++;
+    try {
+        const mapManager = new MapManager(mockMeasureManager);
+        const originalTileSize = mapManager.tileSize;
+        const originalGridCols = mapManager.gridCols;
+
+        mockMeasureManager.set('tileSize', 128);
+        mockMeasureManager.set('mapGrid.cols', 20);
+
+        mapManager.recalculateMapDimensions();
+
+        if (mapManager.tileSize === 128 && mapManager.gridCols === 20) {
+            console.log("MapManager: recalculateMapDimensions updated correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("MapManager: recalculateMapDimensions failed. [FAIL]", { tileSize: mapManager.tileSize, gridCols: mapManager.gridCols });
+        }
+        mockMeasureManager.set('tileSize', originalTileSize);
+        mockMeasureManager.set('mapGrid.cols', originalGridCols);
+    } catch (e) {
+        console.error("MapManager: Error during recalculateMapDimensions test. [FAIL]", e);
+    }
+
+    // 테스트 3: getTileType - 유효한 타일
+    testCount++;
+    try {
+        const mapManager = new MapManager(mockMeasureManager);
+        const tileType = mapManager.getTileType(0, 0);
+        if (tileType !== null && (tileType === 'obstacle' || tileType === 'grass')) {
+            console.log("MapManager: getTileType returned valid tile type. [PASS]");
+            passCount++;
+        } else {
+            console.error("MapManager: getTileType failed to return valid tile type. [FAIL]", tileType);
+        }
+    } catch (e) {
+        console.error("MapManager: Error during getTileType (valid) test. [FAIL]", e);
+    }
+
+    // 테스트 4: getTileType - 유효하지 않은 타일
+    testCount++;
+    try {
+        const mapManager = new MapManager(mockMeasureManager);
+        const invalidTileType = mapManager.getTileType(-1, -1);
+        if (invalidTileType === null) {
+            console.log("MapManager: getTileType returned null for invalid tile. [PASS]");
+            passCount++;
+        } else {
+            console.error("MapManager: getTileType failed to return null for invalid tile. [FAIL]", invalidTileType);
+        }
+    } catch (e) {
+        console.error("MapManager: Error during getTileType (invalid) test. [FAIL]", e);
+    }
+
+    // 테스트 5: getMapRenderData
+    testCount++;
+    try {
+        const mapManager = new MapManager(mockMeasureManager);
+        const renderData = mapManager.getMapRenderData();
+        if (renderData.mapData === mapManager.mapData &&
+            renderData.gridCols === mapManager.gridCols &&
+            renderData.gridRows === mapManager.gridRows &&
+            renderData.tileSize === mapManager.tileSize) {
+            console.log("MapManager: getMapRenderData returned correct data. [PASS]");
+            passCount++;
+        } else {
+            console.error("MapManager: getMapRenderData failed. [FAIL]", renderData);
+        }
+    } catch (e) {
+        console.error("MapManager: Error during getMapRenderData test. [FAIL]", e);
+    }
+
+    // 테스트 6: _createPathfindingEngine의 findPath (간접 테스트)
+    testCount++;
+    try {
+        const mapManager = new MapManager(mockMeasureManager);
+        const pathfindingEngine = mapManager.pathfindingEngine;
+        const simplePathFound = pathfindingEngine.findPath(0, 0, 5, 0);
+        const complexPathNotFound = pathfindingEngine.findPath(0, 0, 1, 1);
+
+        if (simplePathFound === true && complexPathNotFound === false) {
+            console.log("MapManager: PathfindingEngine findPath logic works as expected (simple). [PASS]");
+            passCount++;
+        } else {
+            console.error("MapManager: PathfindingEngine findPath logic failed. [FAIL]", { simplePathFound, complexPathNotFound });
+        }
+    } catch (e) {
+        console.error("MapManager: Error during pathfinding test. [FAIL]", e);
+    }
+
+    console.log(`--- MapManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
 }

--- a/tests/unit/measureManagerUnitTests.js
+++ b/tests/unit/measureManagerUnitTests.js
@@ -1,3 +1,143 @@
+// tests/unit/measureManagerUnitTests.js
+
+import { MeasureManager } from '../../js/managers/MeasureManager.js';
+
 export function runMeasureManagerUnitTests() {
-    console.warn('MeasureManager unit tests are not implemented yet.');
+    console.log("--- MeasureManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const measureManager = new MeasureManager();
+        if (measureManager._measurements) {
+            console.log("MeasureManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("MeasureManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("MeasureManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: get 메서드 - 유효한 경로
+    testCount++;
+    try {
+        const measureManager = new MeasureManager();
+        const tileSize = measureManager.get('tileSize');
+        if (typeof tileSize === 'number' && tileSize > 0) {
+            console.log("MeasureManager: get('tileSize') returned expected value. [PASS]");
+            passCount++;
+        } else {
+            console.error("MeasureManager: get('tileSize') failed. [FAIL]", tileSize);
+        }
+    } catch (e) {
+        console.error("MeasureManager: Error during get (valid path) test. [FAIL]", e);
+    }
+
+    // 테스트 3: get 메서드 - 중첩 경로
+    testCount++;
+    try {
+        const measureManager = new MeasureManager();
+        const width = measureManager.get('gameResolution.width');
+        if (typeof width === 'number' && width > 0) {
+            console.log("MeasureManager: get('gameResolution.width') returned expected value. [PASS]");
+            passCount++;
+        } else {
+            console.error("MeasureManager: get('gameResolution.width') failed. [FAIL]", width);
+        }
+    } catch (e) {
+        console.error("MeasureManager: Error during get (nested path) test. [FAIL]", e);
+    }
+
+    // 테스트 4: get 메서드 - 존재하지 않는 경로
+    testCount++;
+    const originalWarn = console.warn;
+    let warnCalled = false;
+    console.warn = (message) => {
+        if (message.includes("Measurement key 'nonExistent.key' not found.")) {
+            warnCalled = true;
+        }
+        originalWarn(message);
+    };
+    try {
+        const measureManager = new MeasureManager();
+        const nonExistent = measureManager.get('nonExistent.key');
+        if (nonExistent === undefined && warnCalled) {
+            console.log("MeasureManager: get (non-existent path) returned undefined with warning. [PASS]");
+            passCount++;
+        } else {
+            console.error("MeasureManager: get (non-existent path) failed. [FAIL]", nonExistent);
+        }
+    } catch (e) {
+        console.error("MeasureManager: Error during get (non-existent path) test. [FAIL]", e);
+    } finally {
+        console.warn = originalWarn;
+    }
+
+    // 테스트 5: set 메서드 - 값 설정
+    testCount++;
+    try {
+        const measureManager = new MeasureManager();
+        const newValue = 1024;
+        const setResult = measureManager.set('gameResolution.width', newValue);
+        const retrievedValue = measureManager.get('gameResolution.width');
+
+        if (setResult === true && retrievedValue === newValue) {
+            console.log("MeasureManager: set('gameResolution.width') updated value correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("MeasureManager: set('gameResolution.width') failed. [FAIL]", retrievedValue);
+        }
+    } catch (e) {
+        console.error("MeasureManager: Error during set (valid path) test. [FAIL]", e);
+    }
+
+    // 테스트 6: set 메서드 - 존재하지 않는 경로에 설정 시도
+    testCount++;
+    const originalWarn2 = console.warn;
+    let warnCalled2 = false;
+    console.warn = (message) => {
+        if (message.includes("Cannot set measurement. Path 'newCategory.value' does not exist.")) {
+            warnCalled2 = true;
+        }
+        originalWarn2(message);
+    };
+    try {
+        const measureManager = new MeasureManager();
+        const setResult = measureManager.set('newCategory.value', 100);
+        if (setResult === false && warnCalled2) {
+            console.log("MeasureManager: set (non-existent parent path) failed with warning. [PASS]");
+            passCount++;
+        } else {
+            console.error("MeasureManager: set (non-existent parent path) succeeded unexpectedly. [FAIL]");
+        }
+    } catch (e) {
+        console.error("MeasureManager: Error during set (non-existent parent path) test. [FAIL]", e);
+    } finally {
+        console.warn = originalWarn2;
+    }
+
+    // 테스트 7: updateGameResolution 메서드
+    testCount++;
+    try {
+        const measureManager = new MeasureManager();
+        const newWidth = 1920;
+        const newHeight = 1080;
+        measureManager.updateGameResolution(newWidth, newHeight);
+        const currentResolution = measureManager.get('gameResolution');
+
+        if (currentResolution.width === newWidth && currentResolution.height === newHeight) {
+            console.log("MeasureManager: updateGameResolution updated correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("MeasureManager: updateGameResolution failed. [FAIL]", currentResolution);
+        }
+    } catch (e) {
+        console.error("MeasureManager: Error during updateGameResolution test. [FAIL]", e);
+    }
+
+    console.log(`--- MeasureManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
 }

--- a/tests/unit/statManagerUnitTests.js
+++ b/tests/unit/statManagerUnitTests.js
@@ -1,0 +1,129 @@
+// tests/unit/statManagerUnitTests.js
+
+import { StatManager } from '../../js/managers/StatManager.js';
+
+export function runStatManagerUnitTests() {
+    console.log("--- StatManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // 모의 ValorEngine
+    const mockValorEngine = {
+        calculateInitialBarrier: (valorStat) => valorStat * 2,
+        calculateDamageAmplification: (currentBarrier, maxBarrier) => 1.0 + (0.5 * (currentBarrier / maxBarrier))
+    };
+
+    // 모의 WeightEngine
+    const mockWeightEngine = {
+        calculateTotalWeight: (unitStats, equippedItems) => {
+            let total = (unitStats.baseStats.weight || 0) + Math.floor((unitStats.baseStats.strength || 0) / 10);
+            for (const item of equippedItems) {
+                total += item.weight || 0;
+            }
+            return total;
+        },
+        getTurnWeightPenalty: (totalWeight) => totalWeight * 0.5
+    };
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const statManager = new StatManager(mockValorEngine, mockWeightEngine);
+        if (statManager.valorEngine === mockValorEngine && statManager.weightEngine === mockWeightEngine) {
+            console.log("StatManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("StatManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: getCalculatedStats - 모든 스탯 포함
+    testCount++;
+    try {
+        const statManager = new StatManager(mockValorEngine, mockWeightEngine);
+        const unitData = {
+            id: 'testUnit1',
+            name: 'Test Warrior',
+            baseStats: {
+                hp: 100, valor: 50, strength: 25, endurance: 20,
+                agility: 10, intelligence: 15, wisdom: 10, luck: 5,
+                weight: 30
+            }
+        };
+        const equippedItems = [{ weight: 5 }];
+
+        const stats = statManager.getCalculatedStats(unitData, equippedItems);
+
+        const expectedBarrier = 50 * 2;
+        const expectedTotalWeight = 30 + Math.floor(25 / 10) + 5;
+        const expectedTurnPenalty = expectedTotalWeight * 0.5;
+
+        if (
+            stats.hp === 100 &&
+            stats.valor === 50 &&
+            stats.strength === 25 &&
+            stats.barrier === expectedBarrier &&
+            stats.totalWeight === expectedTotalWeight &&
+            stats.turnWeightPenalty === expectedTurnPenalty &&
+            stats.physicalAttack === 25 * 1.5 &&
+            stats.physicalDefense === 20 * 1.2 &&
+            stats.magicAttack === 15 * 1.5 &&
+            stats.magicDefense === 10 * 1.2 &&
+            stats.physicalEvadeChance === 10 * 0.2 &&
+            stats.accuracy === 10 * 0.15 &&
+            stats.magicEvadeChance === 5 * 0.1 &&
+            stats.criticalChance === 5 * 0.05 &&
+            stats.criticalDamageMultiplier === 1.5 &&
+            stats.statusEffectResistance === 20 * 0.1 &&
+            stats.statusEffectApplication === 15 * 0.1
+        ) {
+            console.log("StatManager: getCalculatedStats calculated all stats correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatManager: getCalculatedStats failed to calculate all stats correctly. [FAIL]", stats);
+        }
+    } catch (e) {
+        console.error("StatManager: Error during getCalculatedStats (all stats) test. [FAIL]", e);
+    }
+
+    // 테스트 3: getCalculatedStats - baseStats 없을 때
+    testCount++;
+    try {
+        const statManager = new StatManager(mockValorEngine, mockWeightEngine);
+        const unitData = { id: 'testUnit2', name: 'No Stats Unit' };
+        const stats = statManager.getCalculatedStats(unitData);
+
+        if (Object.keys(stats).length > 0 && stats.hp === 0 && stats.valor === 0) {
+            console.log("StatManager: getCalculatedStats handles missing baseStats gracefully. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatManager: getCalculatedStats failed to handle missing baseStats. [FAIL]", stats);
+        }
+    } catch (e) {
+        console.error("StatManager: Error during getCalculatedStats (no baseStats) test. [FAIL]", e);
+    }
+
+    // 테스트 4: updateDamageAmplification
+    testCount++;
+    try {
+        const statManager = new StatManager(mockValorEngine, mockWeightEngine);
+        const currentBarrier = 75;
+        const maxBarrier = 100;
+        const expectedAmplification = mockValorEngine.calculateDamageAmplification(currentBarrier, maxBarrier);
+        const calculatedAmplification = statManager.updateDamageAmplification(currentBarrier, maxBarrier);
+
+        if (calculatedAmplification === expectedAmplification) {
+            console.log("StatManager: updateDamageAmplification delegates correctly to ValorEngine. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatManager: updateDamageAmplification delegation failed. [FAIL]", calculatedAmplification);
+        }
+    } catch (e) {
+        console.error("StatManager: Error during updateDamageAmplification test. [FAIL]", e);
+    }
+
+    console.log(`--- StatManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/uiEngineUnitTests.js
+++ b/tests/unit/uiEngineUnitTests.js
@@ -1,3 +1,172 @@
+// tests/unit/uiEngineUnitTests.js
+
+import { UIEngine } from '../../js/managers/UIEngine.js';
+import { MeasureManager } from '../../js/managers/MeasureManager.js';
+import { EventManager } from '../../js/managers/EventManager.js';
+
 export function runUIEngineUnitTests() {
-    console.warn('UIEngine unit tests are not implemented yet.');
+    console.log("--- UIEngine Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockRenderer = {
+        canvas: { width: 1280, height: 720, getBoundingClientRect: () => ({ left: 0, top: 0 }) },
+        ctx: {
+            fillRect: function() { this.fillRectCalled = true; },
+            fillText: function() { this.fillTextCalled = true; },
+            clearRect: () => {}, save: () => {}, restore: () => {},
+            font: '', textAlign: '', textBaseline: '', fillStyle: '',
+            fillRectCalled: false, fillTextCalled: false
+        }
+    };
+    const mockMeasureManager = new MeasureManager();
+    const mockEventManager = new EventManager();
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        if (uiEngine.renderer === mockRenderer && uiEngine.getUIState() === 'mapScreen') {
+            console.log("UIEngine: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("UIEngine: Initialization failed. [FAIL]", uiEngine);
+        }
+    } catch (e) {
+        console.error("UIEngine: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: recalculateUIDimensions 호출 후 버튼 위치 확인
+    testCount++;
+    try {
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        uiEngine.recalculateUIDimensions();
+
+        const expectedButtonX = (mockRenderer.canvas.width - uiEngine.buttonWidth) / 2;
+        const expectedButtonY = mockRenderer.canvas.height - uiEngine.buttonHeight - uiEngine.buttonMargin;
+
+        if (uiEngine.battleStartButton.x === expectedButtonX && uiEngine.battleStartButton.y === expectedButtonY) {
+            console.log("UIEngine: Recalculated UI dimensions and button position correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("UIEngine: Button position recalculation failed. [FAIL]", uiEngine.battleStartButton);
+        }
+    } catch (e) {
+        console.error("UIEngine: Error during recalculation. [FAIL]", e);
+    }
+
+    // 테스트 3: setUIState 및 getUIState
+    testCount++;
+    try {
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        uiEngine.setUIState('combatScreen');
+        if (uiEngine.getUIState() === 'combatScreen') {
+            console.log("UIEngine: UI state set and retrieved correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("UIEngine: Failed to set UI state. [FAIL]");
+        }
+    } catch (e) {
+        console.error("UIEngine: Error setting/getting UI state. [FAIL]", e);
+    }
+
+    // 테스트 4: isClickOnButton - 버튼 클릭 성공
+    testCount++;
+    try {
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        uiEngine.setUIState('mapScreen');
+        const button = uiEngine.battleStartButton;
+        const clickX = button.x + button.width / 2;
+        const clickY = button.y + button.height / 2;
+
+        if (uiEngine.isClickOnButton(clickX, clickY)) {
+            console.log("UIEngine: isClickOnButton returned true for valid click. [PASS]");
+            passCount++;
+        } else {
+            console.error("UIEngine: isClickOnButton failed for valid click. [FAIL]");
+        }
+    } catch (e) {
+        console.error("UIEngine: Error during isClickOnButton success test. [FAIL]", e);
+    }
+
+    // 테스트 5: isClickOnButton - 버튼 클릭 실패 (다른 UI 상태)
+    testCount++;
+    try {
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        uiEngine.setUIState('combatScreen');
+        const button = uiEngine.battleStartButton;
+        const clickX = button.x + button.width / 2;
+        const clickY = button.y + button.height / 2;
+
+        if (!uiEngine.isClickOnButton(clickX, clickY)) {
+            console.log("UIEngine: isClickOnButton returned false for incorrect UI state. [PASS]");
+            passCount++;
+        } else {
+            console.error("UIEngine: isClickOnButton failed for incorrect UI state. [FAIL]");
+        }
+    } catch (e) {
+        console.error("UIEngine: Error during isClickOnButton (wrong state) test. [FAIL]", e);
+    }
+
+    // 테스트 6: handleBattleStartClick - 이벤트 발생 확인 (간접)
+    testCount++;
+    try {
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        let eventEmitted = false;
+        mockEventManager.subscribe('battleStart', () => { eventEmitted = true; });
+
+        uiEngine.handleBattleStartClick();
+
+        if (eventEmitted) {
+            console.log("UIEngine: handleBattleStartClick emitted 'battleStart' event. [PASS]");
+            passCount++;
+        } else {
+            console.error("UIEngine: handleBattleStartClick failed to emit 'battleStart' event. [FAIL]");
+        }
+    } catch (e) {
+        console.error("UIEngine: Error during handleBattleStartClick test. [FAIL]", e);
+    }
+
+    // 테스트 7: draw 메서드 (mapScreen)
+    testCount++;
+    try {
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        uiEngine.setUIState('mapScreen');
+        mockRenderer.ctx.fillRectCalled = false;
+        mockRenderer.ctx.fillTextCalled = false;
+
+        uiEngine.draw(mockRenderer.ctx);
+
+        if (mockRenderer.ctx.fillRectCalled && mockRenderer.ctx.fillTextCalled) {
+            console.log("UIEngine: draw (mapScreen) called fillRect and fillText. [PASS]");
+            passCount++;
+        } else {
+            console.error("UIEngine: draw (mapScreen) failed to call expected drawing ops. [FAIL]", { fillRect: mockRenderer.ctx.fillRectCalled, fillText: mockRenderer.ctx.fillTextCalled });
+        }
+    } catch (e) {
+        console.error("UIEngine: Error during draw (mapScreen) test. [FAIL]", e);
+    }
+
+    // 테스트 8: draw 메서드 (combatScreen)
+    testCount++;
+    try {
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        uiEngine.setUIState('combatScreen');
+        mockRenderer.ctx.fillRectCalled = false;
+        mockRenderer.ctx.fillTextCalled = false;
+
+        uiEngine.draw(mockRenderer.ctx);
+
+        if (!mockRenderer.ctx.fillRectCalled && mockRenderer.ctx.fillTextCalled) {
+            console.log("UIEngine: draw (combatScreen) called fillText. [PASS]");
+            passCount++;
+        } else {
+            console.error("UIEngine: draw (combatScreen) failed to call expected drawing ops. [FAIL]", { fillRect: mockRenderer.ctx.fillRectCalled, fillText: mockRenderer.ctx.fillTextCalled });
+        }
+    } catch (e) {
+        console.error("UIEngine: Error during draw (combatScreen) test. [FAIL]", e);
+    }
+
+    console.log(`--- UIEngine Unit Test End: ${passCount}/${testCount} tests passed ---`);
 }

--- a/tests/unit/valorEngineUnitTests.js
+++ b/tests/unit/valorEngineUnitTests.js
@@ -1,0 +1,138 @@
+// tests/unit/valorEngineUnitTests.js
+
+import { ValorEngine } from '../../js/managers/ValorEngine.js';
+
+export function runValorEngineUnitTests() {
+    console.log("--- ValorEngine Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const valorEngine = new ValorEngine();
+        if (valorEngine) {
+            console.log("ValorEngine: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("ValorEngine: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("ValorEngine: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: calculateInitialBarrier - 기본 계산
+    testCount++;
+    try {
+        const valorEngine = new ValorEngine();
+        const valorStat = 50;
+        const expectedBarrier = valorStat * 2;
+        const calculatedBarrier = valorEngine.calculateInitialBarrier(valorStat);
+
+        if (calculatedBarrier === expectedBarrier) {
+            console.log(`ValorEngine: calculateInitialBarrier (${valorStat}) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`ValorEngine: calculateInitialBarrier (${valorStat}) failed. Expected ${expectedBarrier}, got ${calculatedBarrier}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("ValorEngine: Error during calculateInitialBarrier test. [FAIL]", e);
+    }
+
+    // 테스트 3: calculateInitialBarrier - 용맹 0일 때
+    testCount++;
+    try {
+        const valorEngine = new ValorEngine();
+        const valorStat = 0;
+        const expectedBarrier = 0;
+        const calculatedBarrier = valorEngine.calculateInitialBarrier(valorStat);
+
+        if (calculatedBarrier === expectedBarrier) {
+            console.log(`ValorEngine: calculateInitialBarrier (${valorStat}) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`ValorEngine: calculateInitialBarrier (${valorStat}) failed. Expected ${expectedBarrier}, got ${calculatedBarrier}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("ValorEngine: Error during calculateInitialBarrier (zero valor) test. [FAIL]", e);
+    }
+
+    // 테스트 4: calculateDamageAmplification - 배리어 가득 찼을 때 (최대 증폭)
+    testCount++;
+    try {
+        const valorEngine = new ValorEngine();
+        const currentBarrier = 100;
+        const maxBarrier = 100;
+        const expectedAmplification = 1.0 + (0.5 * (100 / 100));
+        const calculatedAmplification = valorEngine.calculateDamageAmplification(currentBarrier, maxBarrier);
+
+        if (calculatedAmplification === expectedAmplification) {
+            console.log(`ValorEngine: calculateDamageAmplification (full barrier) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`ValorEngine: calculateDamageAmplification (full barrier) failed. Expected ${expectedAmplification}, got ${calculatedAmplification}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("ValorEngine: Error during calculateDamageAmplification (full barrier) test. [FAIL]", e);
+    }
+
+    // 테스트 5: calculateDamageAmplification - 배리어 절반일 때
+    testCount++;
+    try {
+        const valorEngine = new ValorEngine();
+        const currentBarrier = 50;
+        const maxBarrier = 100;
+        const expectedAmplification = 1.0 + (0.5 * (50 / 100));
+        const calculatedAmplification = valorEngine.calculateDamageAmplification(currentBarrier, maxBarrier);
+
+        if (calculatedAmplification === expectedAmplification) {
+            console.log(`ValorEngine: calculateDamageAmplification (half barrier) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`ValorEngine: calculateDamageAmplification (half barrier) failed. Expected ${expectedAmplification}, got ${calculatedAmplification}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("ValorEngine: Error during calculateDamageAmplification (half barrier) test. [FAIL]", e);
+    }
+
+    // 테스트 6: calculateDamageAmplification - 배리어 0일 때 (증폭 없음)
+    testCount++;
+    try {
+        const valorEngine = new ValorEngine();
+        const currentBarrier = 0;
+        const maxBarrier = 100;
+        const expectedAmplification = 1.0;
+        const calculatedAmplification = valorEngine.calculateDamageAmplification(currentBarrier, maxBarrier);
+
+        if (calculatedAmplification === expectedAmplification) {
+            console.log(`ValorEngine: calculateDamageAmplification (zero barrier) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`ValorEngine: calculateDamageAmplification (zero barrier) failed. Expected ${expectedAmplification}, got ${calculatedAmplification}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("ValorEngine: Error during calculateDamageAmplification (zero barrier) test. [FAIL]", e);
+    }
+
+    // 테스트 7: calculateDamageAmplification - maxBarrier가 0일 때
+    testCount++;
+    try {
+        const valorEngine = new ValorEngine();
+        const currentBarrier = 10;
+        const maxBarrier = 0;
+        const expectedAmplification = 1.0;
+        const calculatedAmplification = valorEngine.calculateDamageAmplification(currentBarrier, maxBarrier);
+
+        if (calculatedAmplification === expectedAmplification) {
+            console.log(`ValorEngine: calculateDamageAmplification (zero max barrier) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`ValorEngine: calculateDamageAmplification (zero max barrier) failed. Expected ${expectedAmplification}, got ${calculatedAmplification}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("ValorEngine: Error during calculateDamageAmplification (zero max barrier) test. [FAIL]", e);
+    }
+
+    console.log(`--- ValorEngine Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/vfxManagerUnitTests.js
+++ b/tests/unit/vfxManagerUnitTests.js
@@ -1,0 +1,179 @@
+// tests/unit/vfxManagerUnitTests.js
+
+import { VFXManager } from '../../js/managers/VFXManager.js';
+import { BattleSimulationManager } from '../../js/managers/BattleSimulationManager.js';
+import { AnimationManager } from '../../js/managers/AnimationManager.js';
+import { MeasureManager } from '../../js/managers/MeasureManager.js';
+import { LogicManager } from '../../js/managers/LogicManager.js';
+import { EventManager } from '../../js/managers/EventManager.js';
+
+export function runVFXManagerUnitTests() {
+    console.log("--- VFXManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // 모의 객체들
+    const mockRenderer = { canvas: { width: 800, height: 600 }, ctx: {} };
+    const mockMeasureManager = new MeasureManager();
+    const mockCameraEngine = {};
+    const mockLogicManager = new LogicManager(mockMeasureManager, { getCurrentSceneName: () => 'battleScene' });
+    const mockEventManager = new EventManager();
+
+    const mockAnimationManager = new AnimationManager(mockMeasureManager);
+    const mockBattleSimulationManager = new BattleSimulationManager(
+        mockMeasureManager,
+        {},
+        {},
+        mockLogicManager,
+        mockAnimationManager,
+        {}
+    );
+    mockAnimationManager.battleSimulationManager = mockBattleSimulationManager;
+
+    const mockCtx = {
+        fillRectCalled: false,
+        fillTextCalled: false,
+        strokeRectCalled: false,
+        clearRect: () => {},
+        fillRect: function() { this.fillRectCalled = true; },
+        fillText: function() { this.fillTextCalled = true; },
+        strokeRect: function() { this.strokeRectCalled = true; },
+        save: () => {},
+        restore: () => {},
+        globalAlpha: 1,
+        fillStyle: '',
+        font: '',
+        textAlign: '',
+        textBaseline: ''
+    };
+    mockRenderer.ctx = mockCtx;
+
+    const mockUnit = {
+        id: 'u1',
+        name: 'Test Unit',
+        gridX: 5, gridY: 5,
+        currentHp: 70, baseStats: { hp: 100, valor: 30 },
+        currentBarrier: 45, maxBarrier: 60
+    };
+    mockBattleSimulationManager.addUnit(mockUnit, new Image(), mockUnit.gridX, mockUnit.gridY);
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
+        if (vfxManager.activeDamageNumbers instanceof Array && vfxManager.eventManager === mockEventManager) {
+            console.log("VFXManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("VFXManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("VFXManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: addDamageNumber 메서드
+    testCount++;
+    try {
+        const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
+        vfxManager.addDamageNumber(mockUnit.id, 25);
+        if (vfxManager.activeDamageNumbers.length === 1 && vfxManager.activeDamageNumbers[0].damage === 25) {
+            console.log("VFXManager: addDamageNumber added number correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("VFXManager: addDamageNumber failed. [FAIL]", vfxManager.activeDamageNumbers);
+        }
+    } catch (e) {
+        console.error("VFXManager: Error during addDamageNumber test. [FAIL]", e);
+    }
+
+    // 테스트 3: update 메서드 - 데미지 숫자 제거 확인
+    testCount++;
+    try {
+        const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
+        vfxManager.addDamageNumber(mockUnit.id, 10);
+        const dmgNum = vfxManager.activeDamageNumbers[0];
+        dmgNum.startTime = performance.now() - dmgNum.duration - 100;
+        vfxManager.update(16);
+        if (vfxManager.activeDamageNumbers.length === 0) {
+            console.log("VFXManager: update removed expired damage number. [PASS]");
+            passCount++;
+        } else {
+            console.error("VFXManager: update failed to remove expired damage number. [FAIL]", vfxManager.activeDamageNumbers);
+        }
+    } catch (e) {
+        console.error("VFXManager: Error during update (remove expired) test. [FAIL]", e);
+    }
+
+    // 테스트 4: drawBarrierBar 메서드
+    testCount++;
+    try {
+        const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
+        mockCtx.fillRectCalled = false;
+        mockCtx.strokeRectCalled = false;
+
+        const effectiveTileSize = 100;
+        const actualDrawX = 100;
+        const actualDrawY = 100;
+
+        vfxManager.drawBarrierBar(mockCtx, mockUnit, effectiveTileSize, actualDrawX, actualDrawY);
+
+        if (mockCtx.fillRectCalled && mockCtx.strokeRectCalled) {
+            console.log("VFXManager: drawBarrierBar called drawing operations. [PASS]");
+            passCount++;
+        } else {
+            console.error("VFXManager: drawBarrierBar did not call drawing operations. [FAIL]");
+        }
+    } catch (e) {
+        console.error("VFXManager: Error during drawBarrierBar test. [FAIL]", e);
+    }
+
+    // 테스트 5: draw 메서드 - HP 바와 배리어 바, 데미지 숫자 그리기 호출 확인
+    testCount++;
+    try {
+        const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
+        vfxManager.addDamageNumber(mockUnit.id, 50);
+
+        mockCtx.fillRectCalled = false;
+        mockCtx.strokeRectCalled = false;
+        mockCtx.fillTextCalled = false;
+
+        vfxManager.draw(mockCtx);
+
+        if (mockCtx.fillRectCalled && mockCtx.strokeRectCalled && mockCtx.fillTextCalled) {
+            console.log("VFXManager: draw called drawing operations for HP, Barrier, and Damage Numbers. [PASS]");
+            passCount++;
+        } else {
+            console.error("VFXManager: draw failed to call all expected drawing operations. [FAIL]", {
+                fillRect: mockCtx.fillRectCalled,
+                strokeRect: mockCtx.strokeRectCalled,
+                fillText: mockCtx.fillTextCalled
+            });
+        }
+    } catch (e) {
+        console.error("VFXManager: Error during draw method test. [FAIL]", e);
+    }
+
+    // 테스트 6: 이벤트 매니저를 통한 damageNumberDisplay 연동 확인 (간접적)
+    testCount++;
+    try {
+        const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
+        vfxManager.activeDamageNumbers = [];
+        mockEventManager.emit('displayDamage', { unitId: mockUnit.id, damage: 123 });
+
+        setTimeout(() => {
+            if (vfxManager.activeDamageNumbers.length > 0 && vfxManager.activeDamageNumbers[0].damage === 123) {
+                console.log("VFXManager: Successfully received and added damage number via EventManager. [PASS]");
+                passCount++;
+            } else {
+                console.error("VFXManager: Failed to receive or add damage number via EventManager. [FAIL]", vfxManager.activeDamageNumbers);
+            }
+        }, 50);
+    } catch (e) {
+        console.error("VFXManager: Error during EventManager integration test. [FAIL]", e);
+    }
+
+    setTimeout(() => {
+        console.log(`--- VFXManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+    }, 100);
+}

--- a/tests/unit/weightEngineUnitTests.js
+++ b/tests/unit/weightEngineUnitTests.js
@@ -1,0 +1,117 @@
+// tests/unit/weightEngineUnitTests.js
+
+import { WeightEngine } from '../../js/managers/WeightEngine.js';
+
+export function runWeightEngineUnitTests() {
+    console.log("--- WeightEngine Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const weightEngine = new WeightEngine();
+        if (weightEngine) {
+            console.log("WeightEngine: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("WeightEngine: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("WeightEngine: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: calculateTotalWeight - 기본 유닛 스탯만 있을 때
+    testCount++;
+    try {
+        const weightEngine = new WeightEngine();
+        const unitStats = { baseStats: { weight: 20, strength: 0 } };
+        const expectedWeight = 20;
+        const calculatedWeight = weightEngine.calculateTotalWeight(unitStats);
+
+        if (calculatedWeight === expectedWeight) {
+            console.log(`WeightEngine: calculateTotalWeight (base only) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`WeightEngine: calculateTotalWeight (base only) failed. Expected ${expectedWeight}, got ${calculatedWeight}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("WeightEngine: Error during calculateTotalWeight (base only) test. [FAIL]", e);
+    }
+
+    // 테스트 3: calculateTotalWeight - 힘 스탯이 있을 때
+    testCount++;
+    try {
+        const weightEngine = new WeightEngine();
+        const unitStats = { baseStats: { weight: 20, strength: 30 } };
+        const expectedWeight = 20 + 3;
+        const calculatedWeight = weightEngine.calculateTotalWeight(unitStats);
+
+        if (calculatedWeight === expectedWeight) {
+            console.log(`WeightEngine: calculateTotalWeight (with strength) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`WeightEngine: calculateTotalWeight (with strength) failed. Expected ${expectedWeight}, got ${calculatedWeight}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("WeightEngine: Error during calculateTotalWeight (with strength) test. [FAIL]", e);
+    }
+
+    // 테스트 4: calculateTotalWeight - 아이템이 있을 때
+    testCount++;
+    try {
+        const weightEngine = new WeightEngine();
+        const unitStats = { baseStats: { weight: 20, strength: 10 } };
+        const equippedItems = [{ weight: 5 }, { weight: 10 }];
+        const expectedWeight = 20 + 1 + 5 + 10;
+        const calculatedWeight = weightEngine.calculateTotalWeight(unitStats, equippedItems);
+
+        if (calculatedWeight === expectedWeight) {
+            console.log(`WeightEngine: calculateTotalWeight (with items) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`WeightEngine: calculateTotalWeight (with items) failed. Expected ${expectedWeight}, got ${calculatedWeight}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("WeightEngine: Error during calculateTotalWeight (with items) test. [FAIL]", e);
+    }
+
+    // 테스트 5: getTurnWeightPenalty - 기본 계산
+    testCount++;
+    try {
+        const weightEngine = new WeightEngine();
+        const totalWeight = 50;
+        const expectedPenalty = totalWeight * 0.5;
+        const calculatedPenalty = weightEngine.getTurnWeightPenalty(totalWeight);
+
+        if (calculatedPenalty === expectedPenalty) {
+            console.log(`WeightEngine: getTurnWeightPenalty (${totalWeight}) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`WeightEngine: getTurnWeightPenalty (${totalWeight}) failed. Expected ${expectedPenalty}, got ${calculatedPenalty}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("WeightEngine: Error during getTurnWeightPenalty test. [FAIL]", e);
+    }
+
+    // 테스트 6: getTurnWeightPenalty - 무게 0일 때
+    testCount++;
+    try {
+        const weightEngine = new WeightEngine();
+        const totalWeight = 0;
+        const expectedPenalty = 0;
+        const calculatedPenalty = weightEngine.getTurnWeightPenalty(totalWeight);
+
+        if (calculatedPenalty === expectedPenalty) {
+            console.log(`WeightEngine: getTurnWeightPenalty (${totalWeight}) correct. [PASS]`);
+            passCount++;
+        } else {
+            console.error(`WeightEngine: getTurnWeightPenalty (${totalWeight}) failed. Expected ${expectedPenalty}, got ${calculatedPenalty}. [FAIL]`);
+        }
+    } catch (e) {
+        console.error("WeightEngine: Error during getTurnWeightPenalty (zero weight) test. [FAIL]", e);
+    }
+
+    console.log(`--- WeightEngine Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}


### PR DESCRIPTION
## Summary
- implement ValorEngine, WeightEngine, StatManager, VFXManager and CanvasBridgeManager unit tests
- flesh out MeasureManager, MapManager and UIEngine unit tests
- export new tests in `tests/index.js`
- extend `debug.html` to offer buttons and auto-run for new tests

## Testing
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687344da17f0832785f2e8bf31701efd