### PR TITLE
Integrate battle calculation into TurnEngine

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -227,7 +227,7 @@
                 runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
                 runPanelEngineUnitTests();
                 runBattleLogManagerUnitTests(eventManager, measureManager);
-                runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
+                runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);
                 runDelayEngineUnitTests();
                 runTimingEngineUnitTests();
                 runRuleManagerUnitTests();
@@ -437,7 +437,7 @@
             runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
             runPanelEngineUnitTests();
             runBattleLogManagerUnitTests(eventManager, measureManager);
-            runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
+            runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);
             runDelayEngineUnitTests();
             runTimingEngineUnitTests();
             runRuleManagerUnitTests();

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -166,11 +166,6 @@ export class GameEngine {
             this.eventManager // ✨ eventManager 추가
         );
         this.bindingManager = new BindingManager();
-        this.battleCalculationManager = new BattleCalculationManager(
-            this.eventManager,
-            this.battleSimulationManager,
-            this.diceRollManager
-        );
 
         // ✨ 새로운 엔진들 초기화
         this.delayEngine = new DelayEngine();
@@ -182,6 +177,13 @@ export class GameEngine {
         this.diceEngine = new DiceEngine();
         this.diceRollManager = new DiceRollManager(this.diceEngine);
         this.diceBotManager = new DiceBotManager(this.diceEngine);
+
+        // BattleCalculationManager는 DiceRollManager가 준비된 이후에 초기화합니다.
+        this.battleCalculationManager = new BattleCalculationManager(
+            this.eventManager,
+            this.battleSimulationManager,
+            this.diceRollManager
+        );
 
         // ✨ BasicAIManager 초기화
         this.basicAIManager = new BasicAIManager(this.battleSimulationManager);
@@ -202,7 +204,8 @@ export class GameEngine {
             this.classAIManager,
             this.delayEngine,
             this.timingEngine,
-            this.animationManager
+            this.animationManager,
+            this.battleCalculationManager
         );
 
         this.sceneEngine.registerScene('territoryScene', [this.territoryManager]);

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -1,7 +1,7 @@
 // js/managers/TurnEngine.js
 
 export class TurnEngine {
-    constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager) {
+    constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager) {
         console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
@@ -10,6 +10,7 @@ export class TurnEngine {
         this.delayEngine = delayEngine;
         this.timingEngine = timingEngine;
         this.animationManager = animationManager;
+        this.battleCalculationManager = battleCalculationManager;
 
         this.currentTurn = 0;
         this.activeUnitIndex = -1;
@@ -113,6 +114,8 @@ export class TurnEngine {
                                     targetId: targetUnit.id,
                                     attackType: 'melee'
                                 });
+                                const defaultAttackSkillData = { type: 'physical', dice: { num: 1, sides: 6 } };
+                                this.battleCalculationManager.requestDamageCalculation(unit.id, targetUnit.id, defaultAttackSkillData);
                                 await this.delayEngine.waitFor(500);
                             } else {
                                 console.log(`[TurnEngine] Target ${action.targetId} is no longer valid for attack.`);

--- a/tests/unit/turnEngineUnitTests.js
+++ b/tests/unit/turnEngineUnitTests.js
@@ -2,7 +2,7 @@
 
 import { TurnEngine } from '../../js/managers/TurnEngine.js';
 
-export function runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager) {
+export function runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager) {
     console.log("--- TurnEngine Unit Test Start ---");
 
     let testCount = 0;
@@ -17,7 +17,7 @@ export function runTurnEngineUnitTests(eventManager, battleSimulationManager, tu
     // 테스트 1: 초기화 확인
     testCount++;
     try {
-        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);
         if (turnEngine.currentTurn === 0 && turnEngine.turnPhaseCallbacks.startOfTurn instanceof Array) {
             console.log("TurnEngine: Initialized correctly. [PASS]");
             passCount++;
@@ -31,7 +31,7 @@ export function runTurnEngineUnitTests(eventManager, battleSimulationManager, tu
     // 테스트 2: initializeTurnOrder 호출
     testCount++;
     try {
-        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);
         turnEngine.initializeTurnOrder();
         if (turnEngine.turnOrder.length > 0 && turnEngine.turnOrder[0].id === 'u1') {
             console.log("TurnEngine: initializeTurnOrder called TurnOrderManager. [PASS]");
@@ -46,7 +46,7 @@ export function runTurnEngineUnitTests(eventManager, battleSimulationManager, tu
     // 테스트 3: 턴 단계 콜백 등록
     testCount++;
     try {
-        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);
         let callbackCalled = false;
         const testCallback = async () => { callbackCalled = true; };
         turnEngine.addTurnPhaseCallback('startOfTurn', testCallback);
@@ -66,7 +66,7 @@ export function runTurnEngineUnitTests(eventManager, battleSimulationManager, tu
     window.setTimeout = (fn, delay) => fn();
 
     try {
-        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager);
+        const turnEngine = new TurnEngine(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);
         classAIManager.getBasicClassAction = async (unit, allUnits) => {
             if (unit.id === 'u1') return { actionType: 'attack', targetId: 'u2' };
             if (unit.id === 'u2') return { actionType: 'attack', targetId: 'u1' };


### PR DESCRIPTION
## Summary
- accept `BattleCalculationManager` in `TurnEngine`
- invoke damage calculation when units attack
- pass `battleCalculationManager` from `GameEngine`
- update unit tests and debug page for new parameter
- initialize `BattleCalculationManager` after dice managers are ready

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6873865557588327b6f458a27f44872d