### PR TITLE
Implement barrier-based damage and VFX color

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -175,14 +175,15 @@ export class GameEngine {
 
         // ✨ DiceEngine 및 관련 매니저 초기화
         this.diceEngine = new DiceEngine();
-        this.diceRollManager = new DiceRollManager(this.diceEngine);
+        this.diceRollManager = new DiceRollManager(this.diceEngine, this.valorEngine);
         this.diceBotManager = new DiceBotManager(this.diceEngine);
 
         // BattleCalculationManager는 DiceRollManager가 준비된 이후에 초기화합니다.
         this.battleCalculationManager = new BattleCalculationManager(
             this.eventManager,
             this.battleSimulationManager,
-            this.diceRollManager
+            this.diceRollManager,
+            this.delayEngine
         );
 
         // ✨ BasicAIManager 초기화

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -15,16 +15,17 @@ export class VFXManager {
 
         // ✨ subscribe to damage display events
         this.eventManager.subscribe('displayDamage', (data) => {
-            this.addDamageNumber(data.unitId, data.damage);
+            this.addDamageNumber(data.unitId, data.damage, data.color);
         });
     }
 
     /**
      * 특정 유닛 위에 데미지 숫자를 표시하도록 큐에 추가합니다.
-     * @param {string} unitId
-     * @param {number} damageAmount
+     * @param {string} unitId - 데미지를 받은 유닛의 ID
+     * @param {number} damageAmount - 표시할 데미지 양
+     * @param {string} [color='red'] - 데미지 숫자의 색상 (예: 'yellow', 'red')
      */
-    addDamageNumber(unitId, damageAmount) {
+    addDamageNumber(unitId, damageAmount, color = 'red') {
         const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
         if (!unit) {
             console.warn(`[VFXManager] Cannot show damage for unknown unit: ${unitId}`);
@@ -36,9 +37,10 @@ export class VFXManager {
             damage: damageAmount,
             startTime: performance.now(),
             duration: 1000,
-            floatSpeed: 0.05
+            floatSpeed: 0.05,
+            color: color
         });
-        console.log(`[VFXManager] Added damage number: ${damageAmount} for ${unit.name}`);
+        console.log(`[VFXManager] Added damage number: ${damageAmount} (${color}) for ${unit.name}`);
     }
 
     /**
@@ -186,7 +188,7 @@ export class VFXManager {
 
             ctx.save();
             ctx.globalAlpha = alpha;
-            ctx.fillStyle = (dmgNum.damage > 0) ? '#FF4500' : '#ADFF2F';
+            ctx.fillStyle = dmgNum.color || ((dmgNum.damage > 0) ? '#FF4500' : '#ADFF2F');
             ctx.font = `bold ${20 + (1 - progress) * 5}px Arial`;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'bottom';

--- a/js/workers/battleCalculationWorker.js
+++ b/js/workers/battleCalculationWorker.js
@@ -5,22 +5,40 @@ self.onmessage = (event) => {
 
     switch (type) {
         case 'CALCULATE_DAMAGE': {
-            const { attackerStats, targetStats, skillData, currentTargetHp, preCalculatedDamageRoll } = payload;
+            // ✨ payload에서 대상 유닛의 배리어 정보를 가져옵니다.
+            const { attackerStats, targetStats, skillData, currentTargetHp, currentTargetBarrier, maxBarrier, preCalculatedDamageRoll } = payload;
 
-            let damage = preCalculatedDamageRoll - targetStats.defense;
-            if (damage < 0) damage = 0;
+            // 최종 적용될 데미지 (방어력 적용 후)
+            let finalDamageToApply = preCalculatedDamageRoll - targetStats.defense;
+            if (finalDamageToApply < 0) finalDamageToApply = 0; // 데미지는 0 미만이 될 수 없음
 
-            if (skillData && skillData.type === 'magic') {
-                // 이미 preCalculatedDamageRoll에 마법 공격력이 포함되었다면 추가 처리 불필요
+            let barrierDamageDealt = 0; // 배리어로 흡수된 데미지
+            let hpDamageDealt = 0;      // HP로 들어간 데미지
+            let newBarrier = currentTargetBarrier;
+            let newHp = currentTargetHp;
+
+            if (finalDamageToApply > 0) {
+                if (newBarrier >= finalDamageToApply) {
+                    // 배리어가 모든 데미지를 흡수
+                    barrierDamageDealt = finalDamageToApply;
+                    newBarrier -= finalDamageToApply;
+                } else {
+                    // 배리어가 일부를 흡수하고, 남은 데미지는 HP로
+                    barrierDamageDealt = newBarrier; // 배리어가 흡수한 양
+                    hpDamageDealt = finalDamageToApply - newBarrier; // HP로 들어갈 양
+                    newBarrier = 0; // 배리어 소진
+                    newHp -= hpDamageDealt;
+                }
             }
-
-            const newTargetHp = Math.max(0, currentTargetHp - damage);
+            newHp = Math.max(0, newHp); // HP는 0 미만이 될 수 없음
 
             self.postMessage({
                 type: 'DAMAGE_CALCULATED',
                 unitId: payload.targetUnitId,
-                newHp: newTargetHp,
-                damageDealt: damage
+                newHp: newHp,
+                newBarrier: newBarrier,          // ✨ 업데이트된 배리어 값 반환
+                hpDamageDealt: hpDamageDealt,    // ✨ HP로 들어간 데미지 반환
+                barrierDamageDealt: barrierDamageDealt // ✨ 배리어로 흡수된 데미지 반환
             });
             break;
         }

--- a/tests/unit/diceRollManagerUnitTests.js
+++ b/tests/unit/diceRollManagerUnitTests.js
@@ -3,6 +3,7 @@
 import { DiceRollManager } from '../../js/managers/DiceRollManager.js';
 import { DiceEngine } from '../../js/managers/DiceEngine.js';
 
+
 export function runDiceRollManagerUnitTests() {
     console.log("--- DiceRollManager Unit Test Start ---");
 
@@ -21,10 +22,14 @@ export function runDiceRollManagerUnitTests() {
         getRandomInt: (min, max) => Math.floor(Math.random() * (max - min + 1)) + min
     };
 
+    const mockValorEngine = {
+        calculateDamageAmplification: () => 1.0
+    };
+
     // 테스트 1: 초기화 확인
     testCount++;
     try {
-        const drm = new DiceRollManager(mockDiceEngine);
+        const drm = new DiceRollManager(mockDiceEngine, mockValorEngine);
         if (drm.diceEngine === mockDiceEngine) {
             console.log("DiceRollManager: Initialized correctly. [PASS]");
             passCount++;
@@ -40,7 +45,7 @@ export function runDiceRollManagerUnitTests() {
     mockDiceEngine.rollDResults = [3, 4];
     mockDiceEngine.rollDIndex = 0;
     try {
-        const drm = new DiceRollManager(mockDiceEngine);
+        const drm = new DiceRollManager(mockDiceEngine, mockValorEngine);
         const result = drm.rollDice(2, 6);
         if (result === 7) {
             console.log("DiceRollManager: rollDice(2, 6) returned correct sum. [PASS]");
@@ -57,7 +62,7 @@ export function runDiceRollManagerUnitTests() {
     mockDiceEngine.rollDResults = [10, 15];
     mockDiceEngine.rollDIndex = 0;
     try {
-        const drm = new DiceRollManager(mockDiceEngine);
+        const drm = new DiceRollManager(mockDiceEngine, mockValorEngine);
         const result = drm.rollWithAdvantage(20);
         if (result === 15) {
             console.log("DiceRollManager: rollWithAdvantage returned correct higher value. [PASS]");
@@ -74,7 +79,7 @@ export function runDiceRollManagerUnitTests() {
     mockDiceEngine.rollDResults = [12, 5];
     mockDiceEngine.rollDIndex = 0;
     try {
-        const drm = new DiceRollManager(mockDiceEngine);
+        const drm = new DiceRollManager(mockDiceEngine, mockValorEngine);
         const result = drm.rollWithDisadvantage(20);
         if (result === 5) {
             console.log("DiceRollManager: rollWithDisadvantage returned correct lower value. [PASS]");
@@ -91,10 +96,10 @@ export function runDiceRollManagerUnitTests() {
     mockDiceEngine.rollDResults = [6, 6];
     mockDiceEngine.rollDIndex = 0;
     try {
-        const drm = new DiceRollManager(mockDiceEngine);
-        const attackerStats = { attack: 10 };
+        const drm = new DiceRollManager(mockDiceEngine, mockValorEngine);
+        const attackerUnit = { baseStats: { attack: 10 }, currentBarrier: 0, maxBarrier: 0 };
         const skillData = { type: 'physical', dice: { num: 2, sides: 6 } };
-        const result = drm.performDamageRoll(attackerStats, skillData);
+        const result = drm.performDamageRoll(attackerUnit, skillData);
         if (result === 22) {
             console.log("DiceRollManager: performDamageRoll (physical) calculated correctly. [PASS]");
             passCount++;
@@ -110,10 +115,10 @@ export function runDiceRollManagerUnitTests() {
     mockDiceEngine.rollDResults = [4];
     mockDiceEngine.rollDIndex = 0;
     try {
-        const drm = new DiceRollManager(mockDiceEngine);
-        const attackerStats = { magic: 15 };
+        const drm = new DiceRollManager(mockDiceEngine, mockValorEngine);
+        const attackerUnit = { baseStats: { magic: 15 }, currentBarrier: 0, maxBarrier: 0 };
         const skillData = { type: 'magic', dice: { num: 1, sides: 8 } };
-        const result = drm.performDamageRoll(attackerStats, skillData);
+        const result = drm.performDamageRoll(attackerUnit, skillData);
         if (result === 19) {
             console.log("DiceRollManager: performDamageRoll (magic) calculated correctly. [PASS]");
             passCount++;
@@ -129,7 +134,7 @@ export function runDiceRollManagerUnitTests() {
     mockDiceEngine.rollDResults = [18];
     mockDiceEngine.rollDIndex = 0;
     try {
-        const drm = new DiceRollManager(mockDiceEngine);
+        const drm = new DiceRollManager(mockDiceEngine, mockValorEngine);
         const unitStats = { strength: 3 };
         const difficultyClass = 20;
         const result = drm.performSavingThrow(unitStats, difficultyClass, 'strength');
@@ -148,7 +153,7 @@ export function runDiceRollManagerUnitTests() {
     mockDiceEngine.rollDResults = [5];
     mockDiceEngine.rollDIndex = 0;
     try {
-        const drm = new DiceRollManager(mockDiceEngine);
+        const drm = new DiceRollManager(mockDiceEngine, mockValorEngine);
         const unitStats = { agility: 2 };
         const difficultyClass = 10;
         const result = drm.performSavingThrow(unitStats, difficultyClass, 'dexterity');

--- a/tests/unit/vfxManagerUnitTests.js
+++ b/tests/unit/vfxManagerUnitTests.js
@@ -76,8 +76,10 @@ export function runVFXManagerUnitTests() {
     testCount++;
     try {
         const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
-        vfxManager.addDamageNumber(mockUnit.id, 25);
-        if (vfxManager.activeDamageNumbers.length === 1 && vfxManager.activeDamageNumbers[0].damage === 25) {
+        vfxManager.addDamageNumber(mockUnit.id, 25, 'yellow');
+        if (vfxManager.activeDamageNumbers.length === 1 &&
+            vfxManager.activeDamageNumbers[0].damage === 25 &&
+            vfxManager.activeDamageNumbers[0].color === 'yellow') {
             console.log("VFXManager: addDamageNumber added number correctly. [PASS]");
             passCount++;
         } else {
@@ -91,7 +93,7 @@ export function runVFXManagerUnitTests() {
     testCount++;
     try {
         const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
-        vfxManager.addDamageNumber(mockUnit.id, 10);
+        vfxManager.addDamageNumber(mockUnit.id, 10, 'red');
         const dmgNum = vfxManager.activeDamageNumbers[0];
         dmgNum.startTime = performance.now() - dmgNum.duration - 100;
         vfxManager.update(16);
@@ -132,7 +134,7 @@ export function runVFXManagerUnitTests() {
     testCount++;
     try {
         const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
-        vfxManager.addDamageNumber(mockUnit.id, 50);
+        vfxManager.addDamageNumber(mockUnit.id, 50, 'red');
 
         mockCtx.fillRectCalled = false;
         mockCtx.strokeRectCalled = false;
@@ -159,10 +161,12 @@ export function runVFXManagerUnitTests() {
     try {
         const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
         vfxManager.activeDamageNumbers = [];
-        mockEventManager.emit('displayDamage', { unitId: mockUnit.id, damage: 123 });
+        mockEventManager.emit('displayDamage', { unitId: mockUnit.id, damage: 123, color: 'yellow' });
 
         setTimeout(() => {
-            if (vfxManager.activeDamageNumbers.length > 0 && vfxManager.activeDamageNumbers[0].damage === 123) {
+            if (vfxManager.activeDamageNumbers.length > 0 &&
+                vfxManager.activeDamageNumbers[0].damage === 123 &&
+                vfxManager.activeDamageNumbers[0].color === 'yellow') {
                 console.log("VFXManager: Successfully received and added damage number via EventManager. [PASS]");
                 passCount++;
             } else {


### PR DESCRIPTION
## Summary
- extend `DiceRollManager` with `ValorEngine` for barrier amplification
- update `BattleCalculationManager` to handle barrier damage and show colored numbers
- apply barrier logic in worker
- allow VFX damage numbers to specify color
- wire new managers in `GameEngine`
- adjust unit tests for updated APIs

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68739154eb908327bcec5214f79c25cc