### PR TITLE
Add battle simulation integration test

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -79,6 +79,7 @@
         <h4>엔진 기본 테스트</h4>
         <button id="runAllEngineTestsBtn">모든 엔진 테스트 실행</button>
         <button id="runMeasureManagerIntegrationTestBtn">측량 매니저 통합 테스트</button>
+        <button id="runBattleSimulationIntegrationTestBtn">전투 시뮬레이션 통합 테스트</button>
 
         <h4>개별 유닛 테스트</h4>
         <button id="runSceneEngineUnitTestsBtn">SceneEngine 유닛 테스트</button>
@@ -131,6 +132,7 @@
             runGuardianManagerTests,
             injectGuardianManagerFaults,
             runMeasureManagerIntegrationTest,
+            runBattleSimulationIntegrationTest,
             runSceneEngineUnitTests,
             injectSceneEngineFaults,
             runLogicManagerUnitTests,
@@ -220,6 +222,7 @@
                 runEventManagerTests(eventManager);
                 runGuardianManagerTests(guardianManager);
                 runMeasureManagerIntegrationTest(gameEngine);
+                runBattleSimulationIntegrationTest(gameEngine);
                 // 모든 유닛 테스트에 새 매니저 추가
                 runSceneEngineUnitTests(sceneEngine);
                 runLogicManagerUnitTests(logicManager);
@@ -251,6 +254,10 @@
 
             document.getElementById('runMeasureManagerIntegrationTestBtn').addEventListener('click', () => {
                 runMeasureManagerIntegrationTest(gameEngine);
+            });
+
+            document.getElementById('runBattleSimulationIntegrationTestBtn').addEventListener('click', () => {
+                runBattleSimulationIntegrationTest(gameEngine);
             });
 
             // 개별 유닛 테스트 버튼 리스너 추가
@@ -431,6 +438,7 @@
             runEventManagerTests(eventManager); // EventManager 테스트도 자동 실행
             runGuardianManagerTests(guardianManager); // GuardianManager 테스트도 자동 실행
             runMeasureManagerIntegrationTest(gameEngine); // MeasureManager 통합 테스트도 자동 실행
+            runBattleSimulationIntegrationTest(gameEngine);
             runSceneEngineUnitTests(sceneEngine);
             runLogicManagerUnitTests(logicManager);
             runCompatibilityManagerUnitTests(compatibilityManager);

--- a/tests/index.js
+++ b/tests/index.js
@@ -38,6 +38,7 @@ export { runDiceRollManagerUnitTests } from './unit/diceRollManagerUnitTests.js'
 export { runDiceBotManagerUnitTests } from './unit/diceBotManagerUnitTests.js';
 
 export { runMeasureManagerIntegrationTest } from './integration/measureManagerIntegrationTests.js';
+export { runBattleSimulationIntegrationTest } from './integration/battleSimulationIntegrationTest.js';
 
 export { injectRendererFault } from './fault_injection/rendererFaults.js';
 export { injectGameLoopFault, getFaultFlags, setFaultFlag } from './fault_injection/gameLoopFaults.js';

--- a/tests/integration/battleSimulationIntegrationTest.js
+++ b/tests/integration/battleSimulationIntegrationTest.js
@@ -1,0 +1,121 @@
+export function runBattleSimulationIntegrationTest(gameEngine) {
+    console.log("--- Battle Simulation Integration Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const eventManager = gameEngine.getEventManager();
+    const battleSimulationManager = gameEngine.getBattleSimulationManager();
+    const battleLogManager = gameEngine.getBattleLogManager();
+    const vfxManager = gameEngine.getVFXManager();
+    const uiEngine = gameEngine.getUIEngine();
+    const sceneEngine = gameEngine.getSceneEngine();
+    const cameraEngine = gameEngine.getCameraEngine();
+
+    let initialWarriorHp;
+    let initialWarriorBarrier;
+    let initialSkeletonHp;
+    let initialSkeletonBarrier;
+
+    function setupTestState() {
+        const warrior = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_warrior_001');
+        const skeleton = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_skeleton_001');
+
+        if (warrior) {
+            warrior.currentHp = warrior.baseStats.hp;
+            warrior.currentBarrier = warrior.maxBarrier;
+            initialWarriorHp = warrior.baseStats.hp;
+            initialWarriorBarrier = warrior.maxBarrier;
+        }
+        if (skeleton) {
+            skeleton.currentHp = skeleton.baseStats.hp;
+            skeleton.currentBarrier = skeleton.maxBarrier;
+            initialSkeletonHp = skeleton.baseStats.hp;
+            initialSkeletonBarrier = skeleton.maxBarrier;
+        }
+
+        battleLogManager.logMessages = [];
+        vfxManager.activeDamageNumbers = [];
+
+        uiEngine.setUIState('mapScreen');
+        sceneEngine.setCurrentScene('territoryScene');
+        cameraEngine.reset();
+
+        eventManager.setGameRunningState(true);
+    }
+
+    testCount++;
+    console.log("Integration Test: Setting up initial battle state...");
+    setupTestState();
+
+    eventManager.emit('battleStart', { mapId: 'testMap', difficulty: 'easy' });
+    console.log("Integration Test: 'battleStart' event emitted. Observing battle flow...");
+
+    const observationDuration = 5000;
+
+    setTimeout(() => {
+        let allTestsPassed = true;
+
+        const warrior = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_warrior_001');
+        const skeleton = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_skeleton_001');
+
+        testCount++;
+        const warriorTookDamage = warrior && (warrior.currentHp < initialWarriorHp || warrior.currentBarrier < initialWarriorBarrier);
+        const skeletonTookDamage = skeleton && (skeleton.currentHp < initialSkeletonHp || skeleton.currentBarrier < initialSkeletonBarrier);
+        if (warriorTookDamage && skeletonTookDamage) {
+            console.log("Integration Test (HP/Barrier Reduction): Both units' HP or Barrier decreased. [PASS]");
+            passCount++;
+        } else {
+            console.error("Integration Test (HP/Barrier Reduction): HP or Barrier did not decrease as expected. [FAIL]", { warrior: {hp: warrior.currentHp, barrier: warrior.currentBarrier}, skeleton: {hp: skeleton.currentHp, barrier: skeleton.currentBarrier} });
+            allTestsPassed = false;
+        }
+
+        testCount++;
+        const battleLogUpdated = battleLogManager.logMessages.some(msg => msg.includes('공격 시도!') || msg.includes('피해를 입고 HP') || msg.includes('쓰러졌습니다!'));
+        if (battleLogUpdated) {
+            console.log("Integration Test (Battle Log): Battle log contains relevant messages. [PASS]");
+            passCount++;
+        } else {
+            console.error("Integration Test (Battle Log): Battle log was not updated. [FAIL]", battleLogManager.logMessages);
+            allTestsPassed = false;
+        }
+
+        testCount++;
+        const hasDamageNumbers = vfxManager.activeDamageNumbers.length > 0;
+        const hasYellowDamage = vfxManager.activeDamageNumbers.some(dmg => dmg.color === 'yellow');
+        if (hasDamageNumbers && hasYellowDamage) {
+            console.log("Integration Test (Damage Numbers & Color): Damage numbers (including yellow for barrier) were added to VFXManager. [PASS]");
+            passCount++;
+        } else {
+            console.error("Integration Test (Damage Numbers & Color): Damage numbers were not registered or yellow damage missing. [FAIL]", vfxManager.activeDamageNumbers);
+            allTestsPassed = false;
+        }
+
+        testCount++;
+        const isGameStillRunning = eventManager.getGameRunningState();
+        if (!isGameStillRunning) {
+            if ((warrior && warrior.currentHp <= 0) || (skeleton && skeleton.currentHp <= 0)) {
+                console.log("Integration Test (Battle End): Battle ended due to unit defeat. [PASS]");
+                passCount++;
+            } else {
+                console.error("Integration Test (Battle End): Battle ended, but no unit defeated. [FAIL]");
+                allTestsPassed = false;
+            }
+        } else {
+            console.log("Integration Test (Battle End): Battle still ongoing (increase observationDuration if a quick end is expected). [INFO]");
+            passCount++;
+        }
+
+        if (allTestsPassed && passCount === testCount) {
+            console.log(`--- Battle Simulation Integration Test End: ALL ${passCount}/${testCount} tests passed ---`);
+        } else {
+            console.error(`--- Battle Simulation Integration Test End: ${passCount}/${testCount} tests passed. FAILURES detected. ---`);
+        }
+
+        uiEngine.setUIState('mapScreen');
+        sceneEngine.setCurrentScene('territoryScene');
+        cameraEngine.reset();
+        eventManager.setGameRunningState(false);
+        console.log("Integration Test: Game state reset to map screen and game loop stopped.");
+    }, observationDuration);
+}


### PR DESCRIPTION
## Summary
- add battle simulation integration test covering barrier damage
- export the new integration test in tests/index.js
- hook up the integration test in debug tools

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68739acafe8c83279391d76172f055e2