### PR TITLE
Implement status effect system

### DIFF
--- a/data/statusEffects.js
+++ b/data/statusEffects.js
@@ -1,0 +1,51 @@
+// data/statusEffects.js
+
+export const STATUS_EFFECT_TYPES = {
+    DEBUFF: 'debuff',
+    BUFF: 'buff',
+    CONTROL: 'control'
+};
+
+export const STATUS_EFFECTS = {
+    POISON: {
+        id: 'status_poison',
+        name: '독',
+        type: STATUS_EFFECT_TYPES.DEBUFF,
+        description: '매 턴 시작 시 일정량의 고정 피해를 입습니다.',
+        duration: 3,
+        effect: {
+            damagePerTurn: 10
+        }
+    },
+    STUN: {
+        id: 'status_stun',
+        name: '기절',
+        type: STATUS_EFFECT_TYPES.CONTROL,
+        description: '다음 턴에 행동할 수 없습니다.',
+        duration: 1,
+        effect: {
+            canAct: false
+        }
+    },
+    BLEED: {
+        id: 'status_bleed',
+        name: '출혈',
+        type: STATUS_EFFECT_TYPES.DEBUFF,
+        description: '이동하거나 공격할 때 추가 피해를 입습니다.',
+        duration: 2,
+        effect: {
+            damageOnAction: 5
+        }
+    },
+    BERSERK: {
+        id: 'status_berserk',
+        name: '광폭화',
+        type: STATUS_EFFECT_TYPES.BUFF,
+        description: '공격력이 증가하지만 방어력이 감소합니다.',
+        duration: 2,
+        effect: {
+            attackModifier: 1.2,
+            defenseModifier: 0.8
+        }
+    }
+};

--- a/debug.html
+++ b/debug.html
@@ -99,6 +99,10 @@
         <button id="runDiceRollManagerUnitTestsBtn">DiceRollManager 유닛 테스트</button>
         <button id="runDiceBotManagerUnitTestsBtn">DiceBotManager 유닛 테스트</button>
 
+        <button id="runTurnCountManagerUnitTestsBtn">TurnCountManager 유닛 테스트</button>
+        <button id="runStatusEffectManagerUnitTestsBtn">StatusEffectManager 유닛 테스트</button>
+        <button id="runWorkflowManagerUnitTestsBtn">WorkflowManager 유닛 테스트</button>
+
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
         <button id="injectUpdateFaultBtn" class="fault-btn">Update 함수 결함 주입</button>
@@ -113,6 +117,12 @@
 
         <h4>전투 계산 테스트</h4>
         <button id="testDamageCalculationBtn">대미지 계산 테스트 (전사 -> 해골)</button>
+
+        <h4>상태 이상 테스트</h4>
+        <button id="applyPoisonToSkeletonBtn">해골에 독 적용 (3턴)</button>
+        <button id="applyStunToSkeletonBtn">해골에 기절 적용 (1턴)</button>
+        <button id="applyBerserkToWarriorBtn">전사에 광폭화 적용 (2턴)</button>
+        <button id="clearAllEffectsBtn">모든 효과 제거 (전체)</button>
     </div>
     <div id="gameContainer">
         <canvas id="mercenaryPanelCanvas"></canvas>
@@ -161,8 +171,12 @@
             runUIEngineUnitTests,
             runDiceEngineUnitTests,
             runDiceRollManagerUnitTests,
-            runDiceBotManagerUnitTests
+            runDiceBotManagerUnitTests,
+            runTurnCountManagerUnitTests,
+            runStatusEffectManagerUnitTests,
+            runWorkflowManagerUnitTests
         } from './tests/index.js';
+        import { STATUS_EFFECTS } from './data/statusEffects.js';
 
         document.addEventListener('DOMContentLoaded', () => {
             let gameEngine; // gameEngine 인스턴스를 스코프 밖으로 뺍니다.
@@ -196,6 +210,9 @@
             const idManager = gameEngine.getIdManager();
             const basicAIManager = gameEngine.getBasicAIManager();
             const animationManager = gameEngine.getAnimationManager();
+            const turnCountManager = gameEngine.getTurnCountManager();
+            const statusEffectManager = gameEngine.getStatusEffectManager();
+            const workflowManager = gameEngine.getWorkflowManager();
             // ✨ 다이스 관련 매니저 가져오기
             const diceEngine = gameEngine.getDiceEngine();
             const diceRollManager = gameEngine.getDiceRollManager();
@@ -208,6 +225,19 @@
             });
             eventManager.subscribe('skillExecuted', (data) => {
                 console.log(`[Debug Main] Skill '${data.skillName}' was executed.`);
+            });
+            eventManager.subscribe('statusEffectApplied', ({ unitId, statusEffectId, effectData }) => {
+                const unit = battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+                const unitName = unit ? unit.name : unitId;
+                console.log(`[Debug Main] 상태 효과 적용: ${effectData.name} (${statusEffectId}) 이(가) ${unitName}에게 적용됨. 지속 시간: ${effectData.duration}턴.`);
+            });
+            eventManager.subscribe('statusEffectRemoved', ({ unitId, statusEffectId }) => {
+                const unit = battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+                const unitName = unit ? unit.name : unitId;
+                console.log(`[Debug Main] 상태 효과 제거: ${statusEffectId} 이(가) ${unitName}에게서 제거됨.`);
+            });
+            eventManager.subscribe('logMessage', ({ message }) => {
+                console.log(`[Debug Main Log] ${message}`);
             });
 
 
@@ -250,6 +280,9 @@
                 runDiceEngineUnitTests();
                 runDiceRollManagerUnitTests();
                 runDiceBotManagerUnitTests();
+                runTurnCountManagerUnitTests();
+                runStatusEffectManagerUnitTests(eventManager, idManager, turnCountManager, battleCalculationManager);
+                runWorkflowManagerUnitTests(eventManager, statusEffectManager, battleSimulationManager);
             });
 
             document.getElementById('runMeasureManagerIntegrationTestBtn').addEventListener('click', () => {
@@ -310,6 +343,15 @@
             document.getElementById('runDiceBotManagerUnitTestsBtn').addEventListener('click', () => {
                 runDiceBotManagerUnitTests();
             });
+            document.getElementById('runTurnCountManagerUnitTestsBtn').addEventListener('click', () => {
+                runTurnCountManagerUnitTests();
+            });
+            document.getElementById('runStatusEffectManagerUnitTestsBtn').addEventListener('click', () => {
+                runStatusEffectManagerUnitTests(eventManager, idManager, turnCountManager, battleCalculationManager);
+            });
+            document.getElementById('runWorkflowManagerUnitTestsBtn').addEventListener('click', () => {
+                runWorkflowManagerUnitTests(eventManager, statusEffectManager, battleSimulationManager);
+            });
 
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
                 injectRendererFault(renderer);
@@ -366,6 +408,20 @@
                         dice: { num: 2, sides: 8 }
                     });
                 }, 4000);
+            });
+
+            document.getElementById('applyPoisonToSkeletonBtn').addEventListener('click', () => {
+                workflowManager.triggerStatusEffectApplication('unit_skeleton_001', STATUS_EFFECTS.POISON.id);
+            });
+            document.getElementById('applyStunToSkeletonBtn').addEventListener('click', () => {
+                workflowManager.triggerStatusEffectApplication('unit_skeleton_001', STATUS_EFFECTS.STUN.id);
+            });
+            document.getElementById('applyBerserkToWarriorBtn').addEventListener('click', () => {
+                workflowManager.triggerStatusEffectApplication('unit_warrior_001', STATUS_EFFECTS.BERSERK.id);
+            });
+            document.getElementById('clearAllEffectsBtn').addEventListener('click', () => {
+                turnCountManager.clearAllEffects();
+                console.log("[Debug Main] 모든 유닛의 모든 효과를 제거했습니다.");
             });
 
             let isSimulatingEvents = false;
@@ -465,6 +521,9 @@
             runDiceEngineUnitTests();
             runDiceRollManagerUnitTests();
             runDiceBotManagerUnitTests();
+            runTurnCountManagerUnitTests();
+            runStatusEffectManagerUnitTests(eventManager, idManager, turnCountManager, battleCalculationManager);
+            runWorkflowManagerUnitTests(eventManager, statusEffectManager, battleSimulationManager);
         });
     </script>
 </body>

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -37,6 +37,10 @@ import { StatManager } from './managers/StatManager.js'; // ✨ StatManager 추�
 import { DiceEngine } from './managers/DiceEngine.js';
 import { DiceRollManager } from './managers/DiceRollManager.js';
 import { DiceBotManager } from './managers/DiceBotManager.js';
+import { TurnCountManager } from './managers/TurnCountManager.js';
+import { StatusEffectManager } from './managers/StatusEffectManager.js';
+import { WorkflowManager } from './managers/WorkflowManager.js';
+import { STATUS_EFFECTS } from '../data/statusEffects.js';
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
@@ -186,6 +190,20 @@ export class GameEngine {
             this.delayEngine
         );
 
+        // Status effect 관련 매니저 초기화
+        this.turnCountManager = new TurnCountManager();
+        this.statusEffectManager = new StatusEffectManager(
+            this.eventManager,
+            this.idManager,
+            this.turnCountManager,
+            this.battleCalculationManager
+        );
+        this.workflowManager = new WorkflowManager(
+            this.eventManager,
+            this.statusEffectManager,
+            this.battleSimulationManager
+        );
+
         // ✨ BasicAIManager 초기화
         this.basicAIManager = new BasicAIManager(this.battleSimulationManager);
 
@@ -206,7 +224,8 @@ export class GameEngine {
             this.delayEngine,
             this.timingEngine,
             this.animationManager,
-            this.battleCalculationManager
+            this.battleCalculationManager,
+            this.statusEffectManager
         );
 
         this.sceneEngine.registerScene('territoryScene', [this.territoryManager]);
@@ -397,6 +416,9 @@ export class GameEngine {
     getClassAIManager() { return this.classAIManager; }
     getAnimationManager() { return this.animationManager; }
     getCanvasBridgeManager() { return this.canvasBridgeManager; }
+    getTurnCountManager() { return this.turnCountManager; }
+    getStatusEffectManager() { return this.statusEffectManager; }
+    getWorkflowManager() { return this.workflowManager; }
 
     // Dice 관련 엔진/매니저에 대한 getter
     getDiceEngine() { return this.diceEngine; }

--- a/js/managers/StatusEffectManager.js
+++ b/js/managers/StatusEffectManager.js
@@ -1,0 +1,63 @@
+// js/managers/StatusEffectManager.js
+import { STATUS_EFFECTS } from '../../data/statusEffects.js';
+
+export class StatusEffectManager {
+    constructor(eventManager, idManager, turnCountManager, battleCalculationManager) {
+        console.log("\u2728 StatusEffectManager initialized. Managing unit status effects. \u2728");
+        this.eventManager = eventManager;
+        this.idManager = idManager;
+        this.turnCountManager = turnCountManager;
+        this.battleCalculationManager = battleCalculationManager;
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        this.eventManager.subscribe('unitTurnEnd', ({ unitId }) => {
+            const expired = this.turnCountManager.updateTurns(unitId);
+            if (expired.length > 0) {
+                console.log(`[StatusEffectManager] Unit ${unitId} had expired effects: ${expired.join(', ')}`);
+            }
+        });
+
+        this.eventManager.subscribe('unitTurnStart', ({ unitId }) => {
+            const active = this.turnCountManager.getEffectsOfUnit(unitId);
+            if (active) {
+                for (const [effectId, effect] of active.entries()) {
+                    if (effect.effectData.effect.damagePerTurn) {
+                        const damage = effect.effectData.effect.damagePerTurn;
+                        console.log(`[StatusEffectManager] Unit ${unitId} takes ${damage} poison damage from ${effect.effectData.name}.`);
+                        this.battleCalculationManager.requestDamageCalculation('statusEffectSource', unitId, {
+                            type: 'statusEffect',
+                            damageAmount: damage,
+                            isFixedDamage: true
+                        });
+                        this.eventManager.emit('displayDamage', { unitId, damage, color: 'purple' });
+                    }
+                }
+            }
+        });
+        console.log("[StatusEffectManager] Subscribed to unit turn events.");
+    }
+
+    applyStatusEffect(unitId, statusEffectId) {
+        const effectData = STATUS_EFFECTS[statusEffectId.toUpperCase()];
+        if (effectData) {
+            this.turnCountManager.addEffect(unitId, effectData);
+            this.eventManager.emit('statusEffectApplied', { unitId, statusEffectId, effectData });
+            console.log(`[StatusEffectManager] Applied status effect '${effectData.name}' to unit '${unitId}'.`);
+        } else {
+            console.warn(`[StatusEffectManager] Status effect with ID '${statusEffectId}' not found.`);
+        }
+    }
+
+    removeStatusEffect(unitId, statusEffectId) {
+        if (this.turnCountManager.removeEffect(unitId, statusEffectId)) {
+            this.eventManager.emit('statusEffectRemoved', { unitId, statusEffectId });
+            console.log(`[StatusEffectManager] Removed status effect '${statusEffectId}' from unit '${unitId}'.`);
+        }
+    }
+
+    getUnitActiveEffects(unitId) {
+        return this.turnCountManager.getEffectsOfUnit(unitId);
+    }
+}

--- a/js/managers/TurnCountManager.js
+++ b/js/managers/TurnCountManager.js
@@ -1,0 +1,92 @@
+// js/managers/TurnCountManager.js
+
+export class TurnCountManager {
+    constructor() {
+        console.log("\u23F3 TurnCountManager initialized. Tracking all timed effects. \u23F3");
+        // key: unitId, value: Map<effectId, { effectData, turnsRemaining }>
+        this.activeEffects = new Map();
+    }
+
+    /**
+     * 유닛에게 새로운 지속 효과(상태 이상, 버프, 디버프)를 추가합니다.
+     * @param {string} unitId
+     * @param {object} effectData
+     */
+    addEffect(unitId, effectData) {
+        if (!effectData || !effectData.id || effectData.duration === undefined) {
+            console.error("[TurnCountManager] Invalid effectData provided:", effectData);
+            return;
+        }
+        if (!this.activeEffects.has(unitId)) {
+            this.activeEffects.set(unitId, new Map());
+        }
+        const unitEffects = this.activeEffects.get(unitId);
+        unitEffects.set(effectData.id, {
+            effectData: effectData,
+            turnsRemaining: effectData.duration
+        });
+        console.log(`[TurnCountManager] Added effect '${effectData.name}' (${effectData.id}) to unit '${unitId}'. Duration: ${effectData.duration} turns.`);
+    }
+
+    /**
+     * 특정 유닛의 모든 지속 효과의 남은 턴을 감소시키고 만료된 효과를 제거합니다.
+     * @param {string} unitId
+     * @returns {string[]} 만료된 효과의 ID 목록
+     */
+    updateTurns(unitId) {
+        const unitEffects = this.activeEffects.get(unitId);
+        if (!unitEffects) return [];
+
+        const expiredEffects = [];
+        for (const [effectId, effect] of unitEffects.entries()) {
+            effect.turnsRemaining--;
+            console.log(`[TurnCountManager] Effect '${effect.effectData.name}' (${effectId}) on unit '${unitId}' has ${effect.turnsRemaining} turns remaining.`);
+            if (effect.turnsRemaining <= 0) {
+                expiredEffects.push(effectId);
+            }
+        }
+        for (const effectId of expiredEffects) {
+            unitEffects.delete(effectId);
+            console.log(`[TurnCountManager] Effect '${effectId}' on unit '${unitId}' has expired and been removed.`);
+        }
+        if (unitEffects.size === 0) {
+            this.activeEffects.delete(unitId);
+        }
+        return expiredEffects;
+    }
+
+    /**
+     * 특정 유닛이 가진 모든 활성 지속 효과를 반환합니다.
+     * @param {string} unitId
+     */
+    getEffectsOfUnit(unitId) {
+        return this.activeEffects.get(unitId);
+    }
+
+    /**
+     * 특정 유닛의 특정 지속 효과를 강제로 제거합니다.
+     * @param {string} unitId
+     * @param {string} effectId
+     */
+    removeEffect(unitId, effectId) {
+        const unitEffects = this.activeEffects.get(unitId);
+        if (unitEffects && unitEffects.has(effectId)) {
+            unitEffects.delete(effectId);
+            if (unitEffects.size === 0) {
+                this.activeEffects.delete(unitId);
+            }
+            console.log(`[TurnCountManager] Effect '${effectId}' removed from unit '${unitId}'.`);
+            return true;
+        }
+        console.warn(`[TurnCountManager] Effect '${effectId}' not found on unit '${unitId}'.`);
+        return false;
+    }
+
+    /**
+     * 모든 유닛의 모든 지속 효과를 초기화합니다.
+     */
+    clearAllEffects() {
+        this.activeEffects.clear();
+        console.log("[TurnCountManager] All active effects cleared.");
+    }
+}

--- a/js/managers/WorkflowManager.js
+++ b/js/managers/WorkflowManager.js
@@ -1,0 +1,34 @@
+// js/managers/WorkflowManager.js
+
+export class WorkflowManager {
+    constructor(eventManager, statusEffectManager, battleSimulationManager) {
+        console.log("\uD83D\uDCCA WorkflowManager initialized. Streamlining complex processes. \uD83D\uDCCA");
+        this.eventManager = eventManager;
+        this.statusEffectManager = statusEffectManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.eventManager.subscribe('requestStatusEffectApplication', this._processStatusEffectApplication.bind(this));
+        console.log("[WorkflowManager] Subscribed to 'requestStatusEffectApplication' event.");
+    }
+
+    _processStatusEffectApplication(data) {
+        const { unitId, statusEffectId } = data;
+        if (!unitId || !statusEffectId) {
+            console.warn("[WorkflowManager] Missing unitId or statusEffectId for application workflow.");
+            return;
+        }
+        const targetUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+        if (!targetUnit) {
+            console.warn(`[WorkflowManager] Target unit '${unitId}' not found for status effect application.`);
+            return;
+        }
+        console.log(`[WorkflowManager] Processing application of status effect '${statusEffectId}' to unit '${unitId}'.`);
+        this.statusEffectManager.applyStatusEffect(unitId, statusEffectId);
+        this.eventManager.emit('logMessage', { message: `${targetUnit.name}에게 '${statusEffectId}' 상태 효과가 적용되었습니다!` });
+        console.log(`[WorkflowManager] Workflow for status effect '${statusEffectId}' on unit '${unitId}' completed.`);
+    }
+
+    triggerStatusEffectApplication(unitId, statusEffectId) {
+        this.eventManager.emit('requestStatusEffectApplication', { unitId, statusEffectId });
+        console.log(`[WorkflowManager] Triggered status effect application for unit '${unitId}' with effect '${statusEffectId}'.`);
+    }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -36,6 +36,9 @@ export { runUIEngineUnitTests as runUpdatedUIEngineUnitTests } from './unit/uiEn
 export { runDiceEngineUnitTests } from './unit/diceEngineUnitTests.js';
 export { runDiceRollManagerUnitTests } from './unit/diceRollManagerUnitTests.js';
 export { runDiceBotManagerUnitTests } from './unit/diceBotManagerUnitTests.js';
+export { runTurnCountManagerUnitTests } from './unit/turnCountManagerUnitTests.js';
+export { runStatusEffectManagerUnitTests } from './unit/statusEffectManagerUnitTests.js';
+export { runWorkflowManagerUnitTests } from './unit/workflowManagerUnitTests.js';
 
 export { runMeasureManagerIntegrationTest } from './integration/measureManagerIntegrationTests.js';
 export { runBattleSimulationIntegrationTest } from './integration/battleSimulationIntegrationTest.js';

--- a/tests/unit/statusEffectManagerUnitTests.js
+++ b/tests/unit/statusEffectManagerUnitTests.js
@@ -1,0 +1,125 @@
+// tests/unit/statusEffectManagerUnitTests.js
+
+import { StatusEffectManager } from '../../js/managers/StatusEffectManager.js';
+import { TurnCountManager } from '../../js/managers/TurnCountManager.js';
+import { EventManager } from '../../js/managers/EventManager.js';
+
+export function runStatusEffectManagerUnitTests(eventManager, idManager, turnCountManager, battleCalculationManager) {
+    console.log("--- StatusEffectManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockBattleCalculationManager = {
+        requestDamageCalculationCalled: false,
+        requestDamageCalculation: function(attackerId, targetId, skillData) {
+            this.requestDamageCalculationCalled = true;
+            console.log(`[MockBattleCalculationManager] Damage calculation requested: ${attackerId} -> ${targetId} with ${JSON.stringify(skillData)}`);
+        }
+    };
+
+    testCount++;
+    try {
+        const seManager = new StatusEffectManager(eventManager, idManager, turnCountManager, mockBattleCalculationManager);
+        if (seManager.eventManager === eventManager && seManager.turnCountManager === turnCountManager) {
+            console.log("StatusEffectManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatusEffectManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("StatusEffectManager: Error during initialization. [FAIL]", e);
+    }
+
+    testCount++;
+    let effectAppliedEventFired = false;
+    eventManager.subscribe('statusEffectApplied', (data) => {
+        if (data.unitId === 'testUnit1' && data.statusEffectId === 'status_poison') {
+            effectAppliedEventFired = true;
+        }
+    });
+    turnCountManager.clearAllEffects();
+
+    try {
+        const seManager = new StatusEffectManager(eventManager, idManager, turnCountManager, mockBattleCalculationManager);
+        seManager.applyStatusEffect('testUnit1', 'status_poison');
+        const activeEffects = turnCountManager.getEffectsOfUnit('testUnit1');
+
+        if (activeEffects && activeEffects.has('status_poison') && effectAppliedEventFired) {
+            console.log("StatusEffectManager: applyStatusEffect applied effect and fired event. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatusEffectManager: applyStatusEffect failed. [FAIL]", activeEffects, effectAppliedEventFired);
+        }
+    } catch (e) {
+        console.error("StatusEffectManager: Error during applyStatusEffect test. [FAIL]", e);
+    }
+
+    testCount++;
+    let effectRemovedEventFired = false;
+    eventManager.subscribe('statusEffectRemoved', (data) => {
+        if (data.unitId === 'testUnit1' && data.statusEffectId === 'status_poison') {
+            effectRemovedEventFired = true;
+        }
+    });
+
+    try {
+        const seManager = new StatusEffectManager(eventManager, idManager, turnCountManager, mockBattleCalculationManager);
+        seManager.applyStatusEffect('testUnit1', 'status_poison');
+        const removed = seManager.removeStatusEffect('testUnit1', 'status_poison');
+        const activeEffects = turnCountManager.getEffectsOfUnit('testUnit1');
+
+        if (removed && (!activeEffects || !activeEffects.has('status_poison')) && effectRemovedEventFired) {
+            console.log("StatusEffectManager: removeStatusEffect removed effect and fired event. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatusEffectManager: removeStatusEffect failed. [FAIL]", removed, activeEffects, effectRemovedEventFired);
+        }
+    } catch (e) {
+        console.error("StatusEffectManager: Error during removeStatusEffect test. [FAIL]", e);
+    }
+
+    testCount++;
+    turnCountManager.clearAllEffects();
+    try {
+        const seManager = new StatusEffectManager(eventManager, idManager, turnCountManager, mockBattleCalculationManager);
+        seManager.applyStatusEffect('testUnit2', 'status_stun');
+        const activeEffects = seManager.getUnitActiveEffects('testUnit2');
+        if (activeEffects && activeEffects.has('status_stun')) {
+            console.log("StatusEffectManager: getUnitActiveEffects returned correct effects. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatusEffectManager: getUnitActiveEffects failed. [FAIL]", activeEffects);
+        }
+    } catch (e) {
+        console.error("StatusEffectManager: Error during getUnitActiveEffects test. [FAIL]", e);
+    }
+
+    testCount++;
+    turnCountManager.clearAllEffects();
+    mockBattleCalculationManager.requestDamageCalculationCalled = false;
+    let displayDamageEventFired = false;
+    eventManager.subscribe('displayDamage', (data) => {
+        if (data.unitId === 'testUnit3' && data.color === 'purple') {
+            displayDamageEventFired = true;
+        }
+    });
+
+    try {
+        const seManager = new StatusEffectManager(eventManager, idManager, turnCountManager, mockBattleCalculationManager);
+        seManager.applyStatusEffect('testUnit3', 'status_poison');
+
+        eventManager.emit('unitTurnStart', { unitId: 'testUnit3' });
+
+        if (mockBattleCalculationManager.requestDamageCalculationCalled && displayDamageEventFired) {
+            console.log("StatusEffectManager: Poison damage applied on unitTurnStart. [PASS]");
+            passCount++;
+        } else {
+            console.error("StatusEffectManager: Poison damage not applied on unitTurnStart. [FAIL]", mockBattleCalculationManager.requestDamageCalculationCalled, displayDamageEventFired);
+        }
+    } catch (e) {
+        console.error("StatusEffectManager: Error during poison damage test. [FAIL]", e);
+    }
+
+    console.log(`--- StatusEffectManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/turnCountManagerUnitTests.js
+++ b/tests/unit/turnCountManagerUnitTests.js
@@ -1,0 +1,134 @@
+// tests/unit/turnCountManagerUnitTests.js
+
+import { TurnCountManager } from '../../js/managers/TurnCountManager.js';
+
+export function runTurnCountManagerUnitTests() {
+    console.log("--- TurnCountManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockEffectData1 = { id: 'effect1', name: 'TestEffect1', duration: 3 };
+    const mockEffectData2 = { id: 'effect2', name: 'TestEffect2', duration: 1 };
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const turnCountManager = new TurnCountManager();
+        if (turnCountManager.activeEffects instanceof Map && turnCountManager.activeEffects.size === 0) {
+            console.log("TurnCountManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnCountManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnCountManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: addEffect 메서드
+    testCount++;
+    try {
+        const turnCountManager = new TurnCountManager();
+        turnCountManager.addEffect('unitA', mockEffectData1);
+        if (turnCountManager.activeEffects.has('unitA') && turnCountManager.activeEffects.get('unitA').has('effect1')) {
+            console.log("TurnCountManager: addEffect added effect correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnCountManager: addEffect failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnCountManager: Error during addEffect. [FAIL]", e);
+    }
+
+    // 테스트 3: updateTurns 메서드 - 턴 감소 및 만료 확인
+    testCount++;
+    try {
+        const turnCountManager = new TurnCountManager();
+        turnCountManager.addEffect('unitB', mockEffectData1); // duration 3
+        turnCountManager.addEffect('unitB', mockEffectData2); // duration 1
+
+        // 1턴 업데이트
+        let expired = turnCountManager.updateTurns('unitB');
+        let unitEffects = turnCountManager.getEffectsOfUnit('unitB');
+        if (unitEffects.get('effect1').turnsRemaining === 2 && expired.length === 0) {
+            console.log("TurnCountManager: updateTurns decremented correctly (1st turn). [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnCountManager: updateTurns failed (1st turn). [FAIL]", unitEffects.get('effect1').turnsRemaining, expired);
+        }
+
+        // 2턴 업데이트 (effect2 만료 예정)
+        expired = turnCountManager.updateTurns('unitB');
+        unitEffects = turnCountManager.getEffectsOfUnit('unitB');
+        if (unitEffects.get('effect1').turnsRemaining === 1 && expired.includes('effect2') && !unitEffects.has('effect2')) {
+            console.log("TurnCountManager: updateTurns expired effect2 correctly (2nd turn). [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnCountManager: updateTurns failed (2nd turn). [FAIL]", unitEffects, expired);
+        }
+
+        // 3턴 업데이트 (effect1 만료 예정)
+        expired = turnCountManager.updateTurns('unitB');
+        unitEffects = turnCountManager.getEffectsOfUnit('unitB');
+        if (expired.includes('effect1') && !unitEffects) {
+            console.log("TurnCountManager: updateTurns expired effect1 and removed unit (3rd turn). [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnCountManager: updateTurns failed (3rd turn). [FAIL]", unitEffects, expired);
+        }
+
+    } catch (e) {
+        console.error("TurnCountManager: Error during updateTurns test. [FAIL]", e);
+    }
+
+    // 테스트 4: getEffectsOfUnit 메서드
+    testCount++;
+    try {
+        const turnCountManager = new TurnCountManager();
+        turnCountManager.addEffect('unitC', mockEffectData1);
+        const effects = turnCountManager.getEffectsOfUnit('unitC');
+        if (effects && effects.get('effect1')) {
+            console.log("TurnCountManager: getEffectsOfUnit returned correct effects. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnCountManager: getEffectsOfUnit failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnCountManager: Error during getEffectsOfUnit. [FAIL]", e);
+    }
+
+    // 테스트 5: removeEffect 메서드
+    testCount++;
+    try {
+        const turnCountManager = new TurnCountManager();
+        turnCountManager.addEffect('unitD', mockEffectData1);
+        const removed = turnCountManager.removeEffect('unitD', 'effect1');
+        if (removed && !turnCountManager.activeEffects.has('unitD')) {
+            console.log("TurnCountManager: removeEffect removed effect and unit correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnCountManager: removeEffect failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnCountManager: Error during removeEffect. [FAIL]", e);
+    }
+
+    // 테스트 6: clearAllEffects 메서드
+    testCount++;
+    try {
+        const turnCountManager = new TurnCountManager();
+        turnCountManager.addEffect('unitE', mockEffectData1);
+        turnCountManager.addEffect('unitF', mockEffectData2);
+        turnCountManager.clearAllEffects();
+        if (turnCountManager.activeEffects.size === 0) {
+            console.log("TurnCountManager: clearAllEffects cleared all effects. [PASS]");
+            passCount++;
+        } else {
+            console.error("TurnCountManager: clearAllEffects failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TurnCountManager: Error during clearAllEffects. [FAIL]", e);
+    }
+
+    console.log(`--- TurnCountManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/workflowManagerUnitTests.js
+++ b/tests/unit/workflowManagerUnitTests.js
@@ -1,0 +1,115 @@
+// tests/unit/workflowManagerUnitTests.js
+
+import { WorkflowManager } from '../../js/managers/WorkflowManager.js';
+import { EventManager } from '../../js/managers/EventManager.js';
+import { StatusEffectManager } from '../../js/managers/StatusEffectManager.js';
+import { TurnCountManager } from '../../js/managers/TurnCountManager.js';
+import { STATUS_EFFECTS } from '../../data/statusEffects.js';
+
+export function runWorkflowManagerUnitTests(eventManager, statusEffectManager, battleSimulationManager) {
+    console.log("--- WorkflowManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockStatusEffectManager = {
+        applyStatusEffectCalled: false,
+        applyStatusEffect: function(unitId, effectId) {
+            this.applyStatusEffectCalled = true;
+            console.log(`[MockStatusEffectManager] applyStatusEffect called for ${unitId}, ${effectId}`);
+        }
+    };
+
+    const mockBattleSimulationManager = {
+        unitsOnGrid: [
+            { id: 'mockUnit1', name: 'Mock Unit 1', type: 'mercenary' },
+            { id: 'mockUnit2', name: 'Mock Unit 2', type: 'enemy' }
+        ]
+    };
+
+    testCount++;
+    try {
+        const wfManager = new WorkflowManager(eventManager, mockStatusEffectManager, mockBattleSimulationManager);
+        if (wfManager.eventManager === eventManager && wfManager.statusEffectManager === mockStatusEffectManager) {
+            console.log("WorkflowManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("WorkflowManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("WorkflowManager: Error during initialization. [FAIL]", e);
+    }
+
+    testCount++;
+    let requestEventFired = false;
+    eventManager.subscribe('requestStatusEffectApplication', (data) => {
+        if (data.unitId === 'mockUnit1' && data.statusEffectId === 'status_poison') {
+            requestEventFired = true;
+        }
+    });
+
+    try {
+        const wfManager = new WorkflowManager(eventManager, mockStatusEffectManager, mockBattleSimulationManager);
+        wfManager.triggerStatusEffectApplication('mockUnit1', 'status_poison');
+        if (requestEventFired) {
+            console.log("WorkflowManager: triggerStatusEffectApplication fired request event. [PASS]");
+            passCount++;
+        } else {
+            console.error("WorkflowManager: triggerStatusEffectApplication failed to fire request event. [FAIL]");
+        }
+    } catch (e) {
+        console.error("WorkflowManager: Error during triggerStatusEffectApplication test. [FAIL]", e);
+    }
+
+    testCount++;
+    mockStatusEffectManager.applyStatusEffectCalled = false;
+    let logMessageEventFired = false;
+    eventManager.subscribe('logMessage', (data) => {
+        if (data.message.includes('독')) {
+            logMessageEventFired = true;
+        }
+    });
+
+    try {
+        const wfManager = new WorkflowManager(eventManager, mockStatusEffectManager, mockBattleSimulationManager);
+        wfManager._processStatusEffectApplication({ unitId: 'mockUnit2', statusEffectId: STATUS_EFFECTS.POISON.id });
+
+        if (mockStatusEffectManager.applyStatusEffectCalled && logMessageEventFired) {
+            console.log("WorkflowManager: _processStatusEffectApplication executed correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("WorkflowManager: _processStatusEffectApplication failed. [FAIL]", mockStatusEffectManager.applyStatusEffectCalled, logMessageEventFired);
+        }
+    } catch (e) {
+        console.error("WorkflowManager: Error during _processStatusEffectApplication test. [FAIL]", e);
+    }
+
+    testCount++;
+    const originalWarn = console.warn;
+    let warnCalled = false;
+    console.warn = (message) => {
+        if (message.includes("Target unit 'nonExistentUnit' not found")) {
+            warnCalled = true;
+        }
+        originalWarn(message);
+    };
+
+    try {
+        const wfManager = new WorkflowManager(eventManager, mockStatusEffectManager, mockBattleSimulationManager);
+        mockStatusEffectManager.applyStatusEffectCalled = false;
+        wfManager._processStatusEffectApplication({ unitId: 'nonExistentUnit', statusEffectId: STATUS_EFFECTS.POISON.id });
+
+        if (warnCalled && !mockStatusEffectManager.applyStatusEffectCalled) {
+            console.log("WorkflowManager: Handled non-existent unit gracefully. [PASS]");
+            passCount++;
+        } else {
+            console.error("WorkflowManager: Failed to handle non-existent unit. [FAIL]");
+        }
+    } catch (e) {
+        console.error("WorkflowManager: Error during non-existent unit test. [FAIL]", e);
+    } finally {
+        console.warn = originalWarn;
+    }
+
+    console.log(`--- WorkflowManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}


### PR DESCRIPTION
## Summary
- add TurnCountManager to track timed effects
- define status effects data
- manage application of effects with StatusEffectManager and WorkflowManager
- integrate new managers into GameEngine and TurnEngine
- extend debug tools and unit tests for status effects

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6873a7121340832791fb089a29c75c46