### PR TITLE
Update LogicManager and battle rendering

### DIFF
--- a/js/managers/AnimationManager.js
+++ b/js/managers/AnimationManager.js
@@ -21,19 +21,18 @@ export class AnimationManager {
     queueMoveAnimation(unitId, startGridX, startGridY, endGridX, endGridY) {
         return new Promise(resolve => {
             const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions();
-            const contentWidth = sceneContentDimensions.width;
-            const contentHeight = sceneContentDimensions.height;
+            const canvasWidth = this.measureManager.get('gameResolution.width') || sceneContentDimensions.width;
+            const canvasHeight = this.measureManager.get('gameResolution.height') || sceneContentDimensions.height;
             const stagePadding = this.measureManager.get('battleStage.padding');
-            const gridDrawableWidth = contentWidth - 2 * stagePadding;
-            const gridDrawableHeight = contentHeight - 2 * stagePadding;
-            const effectiveTileSize = Math.min(
-                gridDrawableWidth / this.battleSimulationManager.gridCols,
-                gridDrawableHeight / this.battleSimulationManager.gridRows
-            );
-            const totalGridWidth = this.battleSimulationManager.gridCols * effectiveTileSize;
-            const totalGridHeight = this.battleSimulationManager.gridRows * effectiveTileSize;
-            const gridOffsetX = stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
-            const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+
+            const gridContentWidth = sceneContentDimensions.width;
+            const gridContentHeight = sceneContentDimensions.height;
+
+            const effectiveTileSize = gridContentWidth / this.battleSimulationManager.gridCols;
+            const totalGridWidth = gridContentWidth;
+            const totalGridHeight = gridContentHeight;
+            const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
+            const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
             const startPixelX = gridOffsetX + startGridX * effectiveTileSize;
             const startPixelY = gridOffsetY + startGridY * effectiveTileSize;
             const endPixelX = gridOffsetX + endGridX * effectiveTileSize;

--- a/js/managers/BattleGridManager.js
+++ b/js/managers/BattleGridManager.js
@@ -14,28 +14,27 @@ export class BattleGridManager {
      * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
      */
     draw(ctx) {
-        const sceneContentDimensions = this.logicManager.getCurrentSceneContentDimensions();
-        const contentWidth = sceneContentDimensions.width;
-        const contentHeight = sceneContentDimensions.height;
+        const sceneContentDimensions = this.logicManager.getCurrentSceneContentDimensions(); // 이제 순수 그리드 크기를 반환
+        const canvasWidth = this.measureManager.get('gameResolution.width'); // 캔버스 실제 CSS 너비
+        const canvasHeight = this.measureManager.get('gameResolution.height'); // 캔버스 실제 CSS 높이
 
         const stagePadding = this.measureManager.get('battleStage.padding');
 
-        const gridDrawableWidth = contentWidth - 2 * stagePadding;
-        const gridDrawableHeight = contentHeight - 2 * stagePadding;
+        // LogicManager에서 계산된 순수 그리드 컨텐츠 크기 (패딩 제외)
+        const gridContentWidth = sceneContentDimensions.width;
+        const gridContentHeight = sceneContentDimensions.height;
 
-        // 3. 15x10 그리드가 이 유효 영역에 딱 맞도록 유효 타일 크기 계산
-        const effectiveTileSize = Math.min(
-            gridDrawableWidth / this.gridCols,
-            gridDrawableHeight / this.gridRows
-        );
+        // 이 gridContentWidth/Height를 사용하여 effectiveTileSize를 역으로 계산
+        const effectiveTileSize = gridContentWidth / this.gridCols; // 또는 gridContentHeight / this.gridRows; (둘은 같을 것임)
 
-        const totalGridWidth = this.gridCols * effectiveTileSize;
-        const totalGridHeight = this.gridRows * effectiveTileSize;
+        // 전체 그리드 크기 (여기서는 gridContentWidth/Height와 동일)
+        const totalGridWidth = gridContentWidth;
+        const totalGridHeight = gridContentHeight;
 
-        // 4. 그리드를 캔버스의 유효 영역 내 중앙에 배치
-        // (캔버스 시작점 0,0 + 패딩 + 남은 공간 중앙 정렬)
-        const gridOffsetX = stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
-        const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+        // ✨ 그리드를 캔버스 중앙에 배치하기 위한 오프셋 계산 (패딩 포함)
+        // (캔버스 전체 크기 - 그리드 컨텐츠 크기) / 2 + 패딩
+        const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
+        const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
         ctx.lineWidth = 1;

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -99,25 +99,27 @@ export class BattleSimulationManager {
      * @param {CanvasRenderingContext2D} ctx
      */
     draw(ctx) {
-        const sceneContentDimensions = this.logicManager.getCurrentSceneContentDimensions();
-        const contentWidth = sceneContentDimensions.width;
-        const contentHeight = sceneContentDimensions.height;
+        const sceneContentDimensions = this.logicManager.getCurrentSceneContentDimensions(); // 이제 순수 그리드 크기를 반환
+        const canvasWidth = this.measureManager.get('gameResolution.width'); // 캔버스 실제 CSS 너비
+        const canvasHeight = this.measureManager.get('gameResolution.height'); // 캔버스 실제 CSS 높이
 
         const stagePadding = this.measureManager.get('battleStage.padding');
 
-        const gridDrawableWidth = contentWidth - 2 * stagePadding;
-        const gridDrawableHeight = contentHeight - 2 * stagePadding;
+        // LogicManager에서 계산된 순수 그리드 컨텐츠 크기 (패딩 제외)
+        const gridContentWidth = sceneContentDimensions.width;
+        const gridContentHeight = sceneContentDimensions.height;
 
-        const effectiveTileSize = Math.min(
-            gridDrawableWidth / this.gridCols,
-            gridDrawableHeight / this.gridRows
-        );
+        // 이 gridContentWidth/Height를 사용하여 effectiveTileSize를 역으로 계산
+        const effectiveTileSize = gridContentWidth / this.gridCols;
 
-        const totalGridWidth = this.gridCols * effectiveTileSize;
-        const totalGridHeight = this.gridRows * effectiveTileSize;
+        // 전체 그리드 크기 (여기서는 gridContentWidth/Height와 동일)
+        const totalGridWidth = gridContentWidth;
+        const totalGridHeight = gridContentHeight;
 
-        const gridOffsetX = stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
-        const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+        // ✨ 그리드를 캔버스 중앙에 배치하기 위한 오프셋 계산 (패딩 포함)
+        // (캔버스 전체 크기 - 그리드 컨텐츠 크기) / 2 + 패딩
+        const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
+        const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
         for (const unit of this.unitsOnGrid) {
             const image = unit.image;

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -65,20 +65,27 @@ export class VFXManager {
             return;
         }
 
-        const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions();
-        const contentWidth = sceneContentDimensions.width;
-        const contentHeight = sceneContentDimensions.height;
+        const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions(); // 이제 순수 그리드 크기를 반환
+        const canvasWidth = this.measureManager.get('gameResolution.width'); // 캔버스 실제 CSS 너비
+        const canvasHeight = this.measureManager.get('gameResolution.height'); // 캔버스 실제 CSS 높이
+
         const stagePadding = this.measureManager.get('battleStage.padding');
-        const gridDrawableWidth = contentWidth - 2 * stagePadding;
-        const gridDrawableHeight = contentHeight - 2 * stagePadding;
-        const effectiveTileSize = Math.min(
-            gridDrawableWidth / this.battleSimulationManager.gridCols,
-            gridDrawableHeight / this.battleSimulationManager.gridRows
-        );
-        const totalGridWidth = this.battleSimulationManager.gridCols * effectiveTileSize;
-        const totalGridHeight = this.battleSimulationManager.gridRows * effectiveTileSize;
-        const gridOffsetX = stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
-        const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+
+        // LogicManager에서 계산된 순수 그리드 컨텐츠 크기 (패딩 제외)
+        const gridContentWidth = sceneContentDimensions.width;
+        const gridContentHeight = sceneContentDimensions.height;
+
+        // 이 gridContentWidth/Height를 사용하여 effectiveTileSize를 역으로 계산
+        const effectiveTileSize = gridContentWidth / this.battleSimulationManager.gridCols;
+
+        // 전체 그리드 크기 (여기서는 gridContentWidth/Height와 동일)
+        const totalGridWidth = gridContentWidth;
+        const totalGridHeight = gridContentHeight;
+
+        // ✨ 그리드를 캔버스 중앙에 배치하기 위한 오프셋 계산 (패딩 포함)
+        // (캔버스 전체 크기 - 그리드 컨텐츠 크기) / 2 + 패딩
+        const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
+        const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
         const { drawX, drawY } = this.animationManager.getRenderPosition(
             unit.id,
@@ -218,25 +225,27 @@ export class VFXManager {
      * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
      */
     draw(ctx) {
-        const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions();
-        const contentWidth = sceneContentDimensions.width;
-        const contentHeight = sceneContentDimensions.height;
+        const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions(); // 이제 순수 그리드 크기를 반환
+        const canvasWidth = this.measureManager.get('gameResolution.width'); // 캔버스 실제 CSS 너비
+        const canvasHeight = this.measureManager.get('gameResolution.height'); // 캔버스 실제 CSS 높이
 
         const stagePadding = this.measureManager.get('battleStage.padding');
 
-        const gridDrawableWidth = contentWidth - 2 * stagePadding;
-        const gridDrawableHeight = contentHeight - 2 * stagePadding;
+        // LogicManager에서 계산된 순수 그리드 컨텐츠 크기 (패딩 제외)
+        const gridContentWidth = sceneContentDimensions.width;
+        const gridContentHeight = sceneContentDimensions.height;
 
-        const effectiveTileSize = Math.min(
-            gridDrawableWidth / this.battleSimulationManager.gridCols,
-            gridDrawableHeight / this.battleSimulationManager.gridRows
-        );
+        // 이 gridContentWidth/Height를 사용하여 effectiveTileSize를 역으로 계산
+        const effectiveTileSize = gridContentWidth / this.battleSimulationManager.gridCols;
 
-        const totalGridWidth = this.battleSimulationManager.gridCols * effectiveTileSize;
-        const totalGridHeight = this.battleSimulationManager.gridRows * effectiveTileSize;
+        // 전체 그리드 크기 (여기서는 gridContentWidth/Height와 동일)
+        const totalGridWidth = gridContentWidth;
+        const totalGridHeight = gridContentHeight;
 
-        const gridOffsetX = stagePadding + (gridDrawableWidth - totalGridWidth) / 2;
-        const gridOffsetY = stagePadding + (gridDrawableHeight - totalGridHeight) / 2;
+        // ✨ 그리드를 캔버스 중앙에 배치하기 위한 오프셋 계산 (패딩 포함)
+        // (캔버스 전체 크기 - 그리드 컨텐츠 크기) / 2 + 패딩
+        const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
+        const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
             // ✨ AnimationManager를 통해 현재 애니메이션이 적용된 위치를 조회합니다.
@@ -291,7 +300,7 @@ export class VFXManager {
         for (const [unitId, drop] of this.activeWeaponDrops.entries()) {
             if (!drop.sprite) continue;
 
-            const weaponSize = this.measureManager.get('tileSize') * 0.5;
+            const weaponSize = effectiveTileSize * 0.5; // 무기 이미지 크기
 
             ctx.save();
             ctx.globalAlpha = drop.opacity;

--- a/tests/unit/logicManagerUnitTests.js
+++ b/tests/unit/logicManagerUnitTests.js
@@ -44,7 +44,7 @@ export function runLogicManagerUnitTests(logicManager) {
     testCount++;
     let logicManagerBattle = new logicManager.constructor(mockMeasureManager, mockSceneManagerBattle);
     const battleContent = logicManagerBattle.getCurrentSceneContentDimensions();
-    if (battleContent.width === 1280 && battleContent.height === 720) {
+    if (battleContent.width === 960 && battleContent.height === 640) {
         console.log("LogicManager: Battle scene content dimensions correct. [PASS]");
         passCount++;
     } else {
@@ -54,7 +54,8 @@ export function runLogicManagerUnitTests(logicManager) {
     // \ud14c\uc2a4\ud2b8 3: \uc90c \uc81c\ud55c (\ucee8\ud150\uce20\uac00 \uce74\ubc84\uc2a4 \ud06c\uae30\uc77c \ub54c)
     testCount++;
     const zoomLimits = logicManagerBattle.getZoomLimits();
-    if (zoomLimits.minZoom === 1.0 && zoomLimits.maxZoom === 3.0) {
+    const expectedMinZoom = 1280 / 960; // 1.333...
+    if (Math.abs(zoomLimits.minZoom - expectedMinZoom) < 0.01 && zoomLimits.maxZoom === 6.0) {
         console.log("LogicManager: Zoom limits correct for canvas-sized content. [PASS]");
         passCount++;
     } else {
@@ -64,7 +65,7 @@ export function runLogicManagerUnitTests(logicManager) {
     // \ud14c\uc2a4\ud2b8 4: \ud310 \uc81c\uc57d (\uc90c 1.0\uc77c \ub54c, \ucee8\ud150\uce20\uac00 \uce74\ubc84\uc2a4 \ud06c\uae30\uc774\ub85c \uc911\uc559 \uc815\ub82c)
     testCount++;
     const panPos1 = logicManagerBattle.applyPanConstraints(50, 50, 1.0);
-    if (panPos1.x === 0 && panPos1.y === 0) {
+    if (panPos1.x === 160 && panPos1.y === 40) {
         console.log("LogicManager: Pan constraints correct for zoom 1.0 (centered). [PASS]");
         passCount++;
     } else {
@@ -74,7 +75,7 @@ export function runLogicManagerUnitTests(logicManager) {
     // \ud14c\uc2a4\ud2b8 5: \ud310 \uc81c\uc57d (\uc90c 2.0\uc77c \ub54c, \ucee8\ud150\uce20\uac00 \uce74\ubc84\uc2a4\ubcf4\ub2e4 \ucf00\uc57c \uc774\ub3d9 \uac00\ub2a5)
     testCount++;
     const panPos2 = logicManagerBattle.applyPanConstraints(100, 100, 2.0);
-    if (panPos2.x === 100 && panPos2.y === 100) {
+    if (panPos2.x === 0 && panPos2.y === 0) {
         console.log("LogicManager: Pan constraints correct for zoom 2.0 (within bounds). [PASS]");
         passCount++;
     } else {
@@ -84,7 +85,7 @@ export function runLogicManagerUnitTests(logicManager) {
     // \ud14c\uc2a4\ud2b8 6: \ud310 \uc81c\uc57d (\ubc94\uc704\ub97c \ubc8c\uc5b4\ub098\ub294 \uacbd\uc6b0)
     testCount++;
     const panPos3 = logicManagerBattle.applyPanConstraints(-2000, -1000, 2.0);
-    if (panPos3.x === -1280 && panPos3.y === -720) {
+    if (panPos3.x === -640 && panPos3.y === -560) {
         console.log("LogicManager: Pan constraints correct for out-of-bounds (clamped). [PASS]");
         passCount++;
     } else {


### PR DESCRIPTION
## Summary
- compute battle scene content size based on grid dimensions
- adjust grid, simulation, VFX and animation managers to use new content size
- update unit tests for LogicManager

## Testing
- `npm test`
- `node tests/index.js` *(fails: SyntaxError: Unexpected reserved word)*
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6873b559819083279e31d6439bad7069