### PR TITLE
Adjust camera zoom to fit upgraded resolution

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -281,6 +281,9 @@ export class GameEngine {
                 }
             }
 
+            // 초기 카메라 위치와 줌을 설정하여 모든 콘텐츠가 화면에 들어오도록 합니다.
+            this.cameraEngine.reset();
+
             this.eventManager.subscribe('unitDeath', (data) => {
                 console.log(`[GameEngine] Notification: Unit ${data.unitId} (${data.unitName}) has died.`);
             });

--- a/js/managers/CameraEngine.js
+++ b/js/managers/CameraEngine.js
@@ -47,7 +47,9 @@ export class CameraEngine {
     reset() {
         this.x = 0;
         this.y = 0;
-        this.zoom = 1;
+        // 화면에 콘텐츠 전체가 보이도록 최소 줌 값을 가져와 적용합니다.
+        const { minZoom } = this.logicManager.getZoomLimits();
+        this.zoom = minZoom;
         const clampedPos = this.logicManager.applyPanConstraints(this.x, this.y, this.zoom);
         this.x = clampedPos.x;
         this.y = clampedPos.y;


### PR DESCRIPTION
## Summary
- ensure the CameraEngine uses the minimum zoom so that all content fits on screen
- reset the camera after async setup so initial view isn't clipped

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6873bf34341c8327b32985f58666cefc