### PR TITLE
Add toggle to disable CompatibilityManager

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -121,6 +121,7 @@
 
         <h4>시스템 제어</h4>
         <button id="toggleDisarmSystemBtn">무장해제 시스템 활성화/비활성화</button>
+        <button id="toggleCompatibilityManagerBtn">호환성 매니저 활성화/비활성화</button>
 
         <h4>상태 이상 테스트</h4>
         <button id="applyPoisonToSkeletonBtn">해골에 독 적용 (3턴)</button>
@@ -427,6 +428,15 @@
                 measureManager.set('gameConfig.enableDisarmSystem', !currentState);
                 toggleDisarmSystemBtn.textContent = `무장해제 시스템: ${!currentState ? '활성화됨' : '비활성화됨'}`;
                 console.log(`[Debug Main] 무장해제 시스템이 ${!currentState ? '활성화' : '비활성화'}되었습니다.`);
+            });
+
+            const toggleCompatibilityManagerBtn = document.getElementById('toggleCompatibilityManagerBtn');
+            toggleCompatibilityManagerBtn.textContent = `호환성 매니저: ${measureManager.get('gameConfig.enableCompatibilityManager') ? '활성화됨' : '비활성화됨'}`;
+            toggleCompatibilityManagerBtn.addEventListener('click', () => {
+                const currentState = measureManager.get('gameConfig.enableCompatibilityManager');
+                gameEngine.setCompatibilityManagerEnabled(!currentState);
+                toggleCompatibilityManagerBtn.textContent = `호환성 매니저: ${!currentState ? '활성화됨' : '비활성화됨'}`;
+                console.log(`[Debug Main] 호환성 매니저가 ${!currentState ? '활성화' : '비활성화'}되었습니다.`);
             });
 
             document.getElementById('applyPoisonToSkeletonBtn').addEventListener('click', () => {

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -137,6 +137,9 @@ export class GameEngine {
             this.mercenaryPanelManager,
             this.battleLogManager
         );
+        if (!this.measureManager.get('gameConfig.enableCompatibilityManager')) {
+            this.compatibilityManager.disable();
+        }
 
         this.cameraEngine = new CameraEngine(this.renderer, this.logicManager, this.sceneEngine);
         this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine);
@@ -436,4 +439,13 @@ export class GameEngine {
     getDiceEngine() { return this.diceEngine; }
     getDiceRollManager() { return this.diceRollManager; }
     getDiceBotManager() { return this.diceBotManager; }
+
+    setCompatibilityManagerEnabled(flag) {
+        this.measureManager.set('gameConfig.enableCompatibilityManager', flag);
+        if (flag) {
+            this.compatibilityManager.enable();
+        } else {
+            this.compatibilityManager.disable();
+        }
+    }
 }

--- a/js/managers/CompatibilityManager.js
+++ b/js/managers/CompatibilityManager.js
@@ -11,6 +11,9 @@ export class CompatibilityManager {
         this.mercenaryPanelManager = mercenaryPanelManager;
         this.battleLogManager = battleLogManager;
 
+        this.enabled = true;
+        this._boundAdjustResolution = this.adjustResolution.bind(this);
+
         // 캔버스 참조 보관
         this.mercenaryPanelCanvas = mercenaryPanelManager ? mercenaryPanelManager.canvas : null;
         this.combatLogCanvas = battleLogManager ? battleLogManager.canvas : null;
@@ -24,8 +27,27 @@ export class CompatibilityManager {
     }
 
     _setupEventListeners() {
-        window.addEventListener('resize', this.adjustResolution.bind(this));
-        console.log("[CompatibilityManager] Listening for window resize events.");
+        if (this.enabled) {
+            window.addEventListener('resize', this._boundAdjustResolution);
+            console.log("[CompatibilityManager] Listening for window resize events.");
+        }
+    }
+
+    enable() {
+        if (!this.enabled) {
+            this.enabled = true;
+            window.addEventListener('resize', this._boundAdjustResolution);
+            this.adjustResolution();
+            console.log('[CompatibilityManager] Enabled.');
+        }
+    }
+
+    disable() {
+        if (this.enabled) {
+            this.enabled = false;
+            window.removeEventListener('resize', this._boundAdjustResolution);
+            console.log('[CompatibilityManager] Disabled.');
+        }
     }
 
     /**
@@ -34,6 +56,7 @@ export class CompatibilityManager {
      * GuardianManager의 최소 해상도 요구 사항을 충족하도록 보장합니다.
      */
     adjustResolution() {
+        if (!this.enabled) return;
         const viewportWidth = window.innerWidth;
         const viewportHeight = window.innerHeight;
 

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -42,7 +42,8 @@ export class MeasureManager {
             },
             // ✨ 새로운 게임 설정 섹션
             gameConfig: {
-                enableDisarmSystem: true // 무장해제 시스템 활성화 여부
+                enableDisarmSystem: true, // 무장해제 시스템 활성화 여부
+                enableCompatibilityManager: false // 호환성 매니저 활성화 여부
             }
         };
     }


### PR DESCRIPTION
## Summary
- allow enabling/disabling CompatibilityManager
- default CompatibilityManager to disabled in configuration
- expose toggle API in GameEngine
- add button in debug.html to control CompatibilityManager

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6873cb7c12c88327a2f687b740a4af8e