### PR TITLE
Fix battle button click on high-DPI displays

### DIFF
--- a/js/managers/InputManager.js
+++ b/js/managers/InputManager.js
@@ -27,8 +27,9 @@ export class InputManager {
 
     _onMouseDown(event) {
         const rect = this.canvas.getBoundingClientRect();
-        const mouseX = event.clientX - rect.left;
-        const mouseY = event.clientY - rect.top;
+        const pixelRatio = this.renderer.pixelRatio || 1;
+        const mouseX = (event.clientX - rect.left) / pixelRatio;
+        const mouseY = (event.clientY - rect.top) / pixelRatio;
 
         if (this.uiEngine.getUIState() === 'mapScreen' && this.uiEngine.isClickOnButton(mouseX, mouseY)) {
             this.isDragging = false;
@@ -45,8 +46,9 @@ export class InputManager {
 
     _onMouseMove(event) {
         if (this.isDragging) {
-            const dx = event.clientX - this.lastMouseX;
-            const dy = event.clientY - this.lastMouseY;
+            const pixelRatio = this.renderer.pixelRatio || 1;
+            const dx = (event.clientX - this.lastMouseX) / pixelRatio;
+            const dy = (event.clientY - this.lastMouseY) / pixelRatio;
             this.cameraEngine.pan(dx, dy);
             this.lastMouseX = event.clientX;
             this.lastMouseY = event.clientY;
@@ -63,16 +65,18 @@ export class InputManager {
 
         const zoomAmount = event.deltaY > 0 ? -0.1 : 0.1;
         const rect = this.canvas.getBoundingClientRect();
-        const mouseX = event.clientX - rect.left;
-        const mouseY = event.clientY - rect.top;
+        const pixelRatio = this.renderer.pixelRatio || 1;
+        const mouseX = (event.clientX - rect.left) / pixelRatio;
+        const mouseY = (event.clientY - rect.top) / pixelRatio;
 
         this.cameraEngine.zoomAt(zoomAmount, mouseX, mouseY);
     }
 
     _onClick(event) {
         const rect = this.canvas.getBoundingClientRect();
-        const mouseX = event.clientX - rect.left; // 캔버스 내부 논리적 X 좌표 (이 부분이 올바르게 계산됨)
-        const mouseY = event.clientY - rect.top;   // 캔버스 내부 논리적 Y 좌표 (이 부분이 올바르게 계산됨)
+        const pixelRatio = this.renderer.pixelRatio || 1;
+        const mouseX = (event.clientX - rect.left) / pixelRatio; // 캔버스 내부 논리적 X 좌표
+        const mouseY = (event.clientY - rect.top) / pixelRatio;   // 캔버스 내부 논리적 Y 좌표
 
         console.log(`[InputManager Debug] Click event received: ClientX=${event.clientX}, ClientY=${event.clientY}`);
         console.log(`[InputManager Debug] Canvas Local Mouse: X=${mouseX}, Y=${mouseY}`);


### PR DESCRIPTION
## Summary
- correct canvas coordinate calculations in InputManager
- account for device pixel ratio when interpreting mouse actions

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687400bd52508327bd8321ba7926bc30