### PR TITLE
Fix canvas layout and scaling

### DIFF
--- a/js/managers/BattleStageManager.js
+++ b/js/managers/BattleStageManager.js
@@ -11,15 +11,19 @@ export class BattleStageManager {
      * @param {CanvasRenderingContext2D} ctx - \uce90\ub098\uc2a4 2D \ub80c\ub354\ub9c1 \ucee8\ud14d\uc2a4\ud2b8
      */
     draw(ctx) {
-        // 논리 2 적용: 배틀 스테이지는 맵 화면 박스(캔버스)와 똑같게 한다.
+        // 디바이스 픽셀 비율을 고려하여 논리적인 캔버스 크기를 계산합니다.
+        const pixelRatio = window.devicePixelRatio || 1;
+        const logicalWidth = ctx.canvas.width / pixelRatio;
+        const logicalHeight = ctx.canvas.height / pixelRatio;
+
         ctx.fillStyle = '#6A5ACD'; // 전투 스테이지 배경색 (보라색)
-        ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height); // 캔버스 전체를 채움
+        ctx.fillRect(0, 0, logicalWidth, logicalHeight); // 논리 크기로 채움
 
         ctx.fillStyle = 'white';
         ctx.font = '40px Arial';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         // 텍스트를 캔버스 중앙에 배치
-        ctx.fillText('전투가 시작됩니다!', ctx.canvas.width / 2, ctx.canvas.height / 2);
+        ctx.fillText('전투가 시작됩니다!', logicalWidth / 2, logicalHeight / 2);
     }
 }

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@ body {
     width: 100vw;
     height: 100vh;
     box-sizing: border-box;
-    padding: 10px;
+    padding: 0px;
     justify-content: center; /* 세로 중앙 정렬 */
 }
 
@@ -32,7 +32,7 @@ canvas {
 
 /* 용병 패널 캔버스 전용 스타일 (JS가 크기 제어) */
 #mercenaryPanelCanvas {
-    margin-bottom: 10px; /* 패널과 메인 게임 캔버스 사이의 간격 */
+    margin-bottom: 0px; /* 패널과 메인 게임 캔버스 사이의 간격을 제거 */
     border: 2px solid #00f; /* 구분을 위한 다른 테두리 색상 */
     flex-shrink: 0;
     aspect-ratio: 16 / 2.25; /* 메인 캔버스 높이의 약 25% 비율 */
@@ -40,7 +40,7 @@ canvas {
 
 /* ✨ 전투 로그 캔버스 전용 스타일 (JS가 크기 제어) */
 #combatLogCanvas {
-    margin-top: 10px; /* 메인 게임 캔버스 위쪽 간격 */
+    margin-top: 0px; /* 메인 게임 캔버스 위쪽 간격을 제거 */
     border: 2px solid #f00; /* 구분을 위한 다른 테두리 색상 (빨간색) */
     flex-shrink: 0;
     aspect-ratio: 16 / 1.35; /* 메인 캔버스 높이의 약 15% 비율 */


### PR DESCRIPTION
## Summary
- remove spacing around the canvases so click coordinates match
- adjust `BattleStageManager` drawing to consider device pixel ratio

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68740506ebc48327834ee734cc0381ca