### PR TITLE
Add detailed render coordinate logs

### DIFF
--- a/js/managers/BattleGridManager.js
+++ b/js/managers/BattleGridManager.js
@@ -36,26 +36,34 @@ export class BattleGridManager {
         const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
         const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
+        console.log(`[BattleGridManager Debug] Drawing Grid Parameters (in draw()): \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\n            Scene Content (Logical): ${sceneContentDimensions.width}x${sceneContentDimensions.height}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}\n            Total Grid Render Size (Logical): ${totalGridWidth.toFixed(2)}x${totalGridHeight.toFixed(2)}`
+        );
+
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
         ctx.lineWidth = 1;
 
         // 세로선 그리기
         for (let i = 0; i <= this.gridCols; i++) {
+            const lineX = gridOffsetX + i * effectiveTileSize;
+            console.log(`[BattleGridManager Debug] Vertical Line ${i}: X=${lineX.toFixed(2)} from Y=${gridOffsetY.toFixed(2)} to Y=${(gridOffsetY + totalGridHeight).toFixed(2)}`);
             ctx.beginPath();
-            ctx.moveTo(gridOffsetX + i * effectiveTileSize, gridOffsetY);
-            ctx.lineTo(gridOffsetX + i * effectiveTileSize, gridOffsetY + totalGridHeight);
+            ctx.moveTo(lineX, gridOffsetY);
+            ctx.lineTo(lineX, gridOffsetY + totalGridHeight);
             ctx.stroke();
         }
 
         // 가로선 그리기
         for (let i = 0; i <= this.gridRows; i++) {
+            const lineY = gridOffsetY + i * effectiveTileSize;
+            console.log(`[BattleGridManager Debug] Horizontal Line ${i}: Y=${lineY.toFixed(2)} from X=${gridOffsetX.toFixed(2)} to X=${(gridOffsetX + totalGridWidth).toFixed(2)}`);
             ctx.beginPath();
-            ctx.moveTo(gridOffsetX, gridOffsetY + i * effectiveTileSize);
-            ctx.lineTo(gridOffsetX + totalGridWidth, gridOffsetY + i * effectiveTileSize);
+            ctx.moveTo(gridOffsetX, lineY);
+            ctx.lineTo(gridOffsetX + totalGridWidth, lineY);
             ctx.stroke();
         }
 
         // 그리드 영역 테두리 (확인용)
+        console.log(`[BattleGridManager Debug] Border Rect: X=${gridOffsetX.toFixed(2)}, Y=${gridOffsetY.toFixed(2)}, W=${totalGridWidth.toFixed(2)}, H=${totalGridHeight.toFixed(2)}`);
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
         ctx.lineWidth = 2;
         ctx.strokeRect(gridOffsetX, gridOffsetY, totalGridWidth, totalGridHeight);

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -247,6 +247,10 @@ export class VFXManager {
         const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
         const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
+        // ✨ DEBUG LOG START FOR VFXManager Drawing Parameters
+        console.log(`[VFXManager Debug] Drawing VFX Parameters: \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}`);
+        // ✨ DEBUG LOG END FOR VFXManager Drawing Parameters
+
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
             // ✨ AnimationManager를 통해 현재 애니메이션이 적용된 위치를 조회합니다.
             const { drawX, drawY } = this.animationManager.getRenderPosition(
@@ -257,6 +261,8 @@ export class VFXManager {
                 gridOffsetX,
                 gridOffsetY
             );
+            // ✨ 추가: 각 유닛의 HP/배리어 바가 그려지는 최종 위치 로그
+            console.log(`[VFXManager Debug] Unit ${unit.id} (HP/Barrier Bar): drawX=${drawX.toFixed(2)}, drawY=${drawY.toFixed(2)}`);
             this.drawHpBar(ctx, unit, effectiveTileSize, drawX, drawY);
             this.drawBarrierBar(ctx, unit, effectiveTileSize, drawX, drawY); // ✨ 배리어 바 그리기 호출
         }


### PR DESCRIPTION
## Summary
- log grid drawing coordinates and border info in BattleGridManager
- log canvas and unit bar positions in VFXManager

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68740dc858548327b476f4b7413fb5fb