### PR TITLE
Add background image to battle stage

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -153,7 +153,7 @@ export class GameEngine {
         this.layerEngine = new LayerEngine(this.renderer, this.cameraEngine);
 
         this.territoryManager = new TerritoryManager();
-        this.battleStageManager = new BattleStageManager();
+        this.battleStageManager = new BattleStageManager(this.assetLoaderManager); // ✨ assetLoaderManager 전달
         this.battleGridManager = new BattleGridManager(this.measureManager, this.logicManager);
         // VFXManager에 AnimationManager를 전달하여 HP 바 위치를 애니메이션과 동기화합니다.
         this.vfxManager = new VFXManager(
@@ -326,6 +326,8 @@ export class GameEngine {
             UNITS.WARRIOR.spriteId,
             'assets/images/warrior.png'
         );
+        // ✨ 전투 배경 이미지 로드
+        await this.assetLoaderManager.loadImage('sprite_battle_stage_forest', 'assets/images/battle-stage-forest.png');
 
         console.log(`[GameEngine] Registered unit ID: ${UNITS.WARRIOR.id}`);
         console.log(`[GameEngine] Loaded warrior sprite: ${UNITS.WARRIOR.spriteId}`);

--- a/js/managers/BattleStageManager.js
+++ b/js/managers/BattleStageManager.js
@@ -1,8 +1,10 @@
 // js/managers/BattleStageManager.js
 
 export class BattleStageManager {
-    constructor() {
+    constructor(assetLoaderManager) {
         console.log("🏟️ BattleStageManager initialized. Preparing the arena. 🏟️");
+        this.assetLoaderManager = assetLoaderManager; // AssetLoaderManager 저장
+        this.backgroundImage = null; // 배경 이미지 객체
     }
 
     /**
@@ -15,8 +17,19 @@ export class BattleStageManager {
         const logicalWidth = ctx.canvas.width / (window.devicePixelRatio || 1);
         const logicalHeight = ctx.canvas.height / (window.devicePixelRatio || 1);
 
-        ctx.fillStyle = '#6A5ACD'; // 전투 스테이지 배경색 (보라색)
-        ctx.fillRect(0, 0, logicalWidth, logicalHeight); // 논리적 크기를 사용하여 배경 채움
+        if (!this.backgroundImage) {
+            // 이미지가 로드되지 않았다면 로드 시도
+            this.backgroundImage = this.assetLoaderManager.getImage('sprite_battle_stage_forest');
+            if (!this.backgroundImage) {
+                console.warn("[BattleStageManager] Battle stage background image not loaded. Using fallback color.");
+                ctx.fillStyle = '#6A5ACD'; // 대체 색상 (보라색)
+                ctx.fillRect(0, 0, logicalWidth, logicalHeight);
+                return;
+            }
+        }
+
+        // 배경 이미지를 논리적 캔버스 크기에 맞춰 그립니다.
+        ctx.drawImage(this.backgroundImage, 0, 0, logicalWidth, logicalHeight);
 
         ctx.fillStyle = 'white';
         ctx.font = '40px Arial';


### PR DESCRIPTION
## Summary
- load battle stage background image via AssetLoaderManager
- pass AssetLoaderManager to `BattleStageManager`
- draw the background image if available with fallback color

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68749ffa21408327b66439f8b83c9341