### PR TITLE
Remove battle start text

### DIFF
--- a/js/managers/BattleStageManager.js
+++ b/js/managers/BattleStageManager.js
@@ -31,11 +31,5 @@ export class BattleStageManager {
         // 배경 이미지를 논리적 캔버스 크기에 맞춰 그립니다.
         ctx.drawImage(this.backgroundImage, 0, 0, logicalWidth, logicalHeight);
 
-        ctx.fillStyle = 'white';
-        ctx.font = '40px Arial';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        // 텍스트를 캔버스 중앙에 배치 (논리적 크기 사용)
-        ctx.fillText('전투가 시작됩니다!', logicalWidth / 2, logicalHeight / 2);
     }
 }

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -96,11 +96,7 @@ export class UIEngine {
                 this.battleStartButton.y + this.battleStartButton.height / 2 + 8
             );
         } else if (this._currentUIState === 'combatScreen') {
-            ctx.fillStyle = 'white';
-            ctx.font = '48px Arial';
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
-            ctx.fillText('전투 진행 중!', this.canvas.width / 2, 50);
+            // 전투 화면에서는 현재 별도의 상단 텍스트를 표시하지 않습니다.
         }
     }
 


### PR DESCRIPTION
## Summary
- clean up `BattleStageManager` text overlay
- remove battle progress message from `UIEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6874a251ddc0832796bc71f13970a7cf