### PR TITLE
Remove mercenary panel canvas, add hero panel overlay

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -61,10 +61,7 @@
             flex-direction: column;
             align-items: center;
         }
-        #mercenaryPanelCanvas {
-            margin-bottom: 10px;
-            border: 2px solid #00f;
-        }
+        /* #mercenaryPanelCanvas 스타일은 이제 필요 없습니다. */
         #combatLogCanvas {
             margin-top: 10px;
             border: 2px solid #f00;
@@ -115,6 +112,7 @@
         <button id="injectCompatibilityManagerFaultsBtn" class="fault-btn">CompatibilityManager 결함 주입</button>
         <h4>이벤트 발생 시뮬레이션</h4>
         <button id="simulateEventsBtn">이벤트 시뮬레이션 시작/정지</button>
+        <button id="toggleHeroPanelBtn">영웅 패널</button>
 
         <h4>전투 계산 테스트</h4>
         <button id="testDamageCalculationBtn">대미지 계산 테스트 (전사 -> 해골)</button>
@@ -129,7 +127,6 @@
         <button id="clearAllEffectsBtn">모든 효과 제거 (전체)</button>
     </div>
     <div id="gameContainer">
-        <canvas id="mercenaryPanelCanvas"></canvas>
         <canvas id="gameCanvas"></canvas>
         <canvas id="combatLogCanvas"></canvas>
     </div>
@@ -262,7 +259,7 @@
                 runSceneEngineUnitTests(sceneEngine);
                 runLogicManagerUnitTests(logicManager);
                 runCompatibilityManagerUnitTests(compatibilityManager);
-                runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
+                runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager);
                 runPanelEngineUnitTests();
                 runBattleLogManagerUnitTests(eventManager, measureManager);
                 runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);
@@ -455,6 +452,11 @@
                 }
             });
 
+            // ✨ 영웅 패널 토글 버튼
+            document.getElementById('toggleHeroPanelBtn').addEventListener('click', () => {
+                gameEngine.getUIEngine().toggleHeroPanel();
+            });
+
 
             // 게임 업데이트 함수 정의 (DEBUG ONLY - GameEngine의 _update가 대신함)
             // 이 함수는 더 이상 GameLoop에 직접 전달되지 않습니다.
@@ -466,14 +468,9 @@
             gameEngine._draw = function() { // GameEngine의 _draw를 오버라이드하여 FPS 로직 추가
                 originalDraw.apply(this, arguments); // 원래 _draw 함수 호출
 
-                // ✨ 용병 패널 그리기 호출
-                if (gameEngine.mercenaryPanelManager) {
-                    gameEngine.mercenaryPanelManager.draw(gameEngine.mercenaryPanelManager.ctx);
-                }
-
                 // ✨ 전투 로그 패널 그리기 호출 추가
-                if (gameEngine.battleLogManager) {
-                    gameEngine.battleLogManager.draw(gameEngine.battleLogManager.ctx);
+                if (gameEngine.getPanelEngine()) {
+                    gameEngine.getPanelEngine().drawPanel('combatLog', gameEngine.getBattleLogManager().ctx);
                 }
 
                 // FPS 카운터 업데이트
@@ -517,7 +514,7 @@
             runSceneEngineUnitTests(sceneEngine);
             runLogicManagerUnitTests(logicManager);
             runCompatibilityManagerUnitTests(compatibilityManager);
-            runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager);
+            runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager);
             runPanelEngineUnitTests();
             runBattleLogManagerUnitTests(eventManager, measureManager);
             runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
 </head>
 <body>
     <div id="gameContainer">
-        <canvas id="mercenaryPanelCanvas"></canvas>
         <canvas id="gameCanvas"></canvas>
         <canvas id="combatLogCanvas"></canvas>
     </div>
+    <button id="toggleHeroPanelBtn" style="position: absolute; top: 10px; right: 10px; z-index: 100;">영웅 패널</button>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/managers/CanvasBridgeManager.js
+++ b/js/managers/CanvasBridgeManager.js
@@ -2,7 +2,8 @@ export class CanvasBridgeManager {
     constructor(gameCanvas, mercenaryPanelCanvas, combatLogCanvas, eventManager, measureManager) {
         console.log("\ud83c\udf0e CanvasBridgeManager initialized. Ready to bridge canvas interactions. \ud83c\udf0e");
         this.gameCanvas = gameCanvas;
-        this.mercenaryPanelCanvas = mercenaryPanelCanvas;
+        // mercenaryPanelCanvas는 이제 독립적인 캔버스가 아니므로 참조하지 않습니다.
+        // this.mercenaryPanelCanvas = mercenaryPanelCanvas; 
         this.combatLogCanvas = combatLogCanvas;
         this.eventManager = eventManager;
         this.measureManager = measureManager;
@@ -18,7 +19,8 @@ export class CanvasBridgeManager {
     }
 
     _setupEventListeners() {
-        [this.gameCanvas, this.mercenaryPanelCanvas, this.combatLogCanvas].forEach(canvas => {
+        // gameCanvas와 combatLogCanvas에만 이벤트 리스너를 추가합니다.
+        [this.gameCanvas, this.combatLogCanvas].forEach(canvas => {
             if (canvas) {
                 canvas.addEventListener('mousedown', this._onMouseDown.bind(this));
                 canvas.addEventListener('mousemove', this._onMouseMove.bind(this));
@@ -30,13 +32,15 @@ export class CanvasBridgeManager {
     }
 
     _onMouseDown(event) {
-        if (event.target === this.mercenaryPanelCanvas) {
-            this.isDragging = true;
-            this.dragStartX = event.clientX;
-            this.dragStartY = event.clientY;
-            console.log("[CanvasBridgeManager] Dragging started from Mercenary Panel.");
-            this.eventManager.emit('dragStart', { clientX: event.clientX, clientY: event.clientY, sourceCanvas: event.target.id });
-        }
+        // MercenaryPanelCanvas에서의 드래그 시작 로직은 이제 UIEngine이 처리합니다.
+        // 이곳에서는 메인 게임 캔버스나 전투 로그 캔버스에서만 드래그를 시작합니다.
+        // 예를 들어, 맵 드래그 등.
+        // 여기서는 `event.target === this.mercenaryPanelCanvas` 조건문을 제거합니다.
+        this.isDragging = true;
+        this.dragStartX = event.clientX;
+        this.dragStartY = event.clientY;
+        console.log(`[CanvasBridgeManager] Dragging started from ${event.target.id}.`);
+        this.eventManager.emit('dragStart', { clientX: event.clientX, clientY: event.clientY, sourceCanvas: event.target.id });
     }
 
     _onMouseMove(event) {

--- a/js/managers/CompatibilityManager.js
+++ b/js/managers/CompatibilityManager.js
@@ -8,11 +8,12 @@ export class CompatibilityManager {
         this.uiEngine = uiEngine;
         this.mapManager = mapManager;
         this.logicManager = logicManager;
-        this.mercenaryPanelManager = mercenaryPanelManager;
+        // mercenaryPanelManager는 이제 독립적인 캔버스를 가지지 않으므로 직접 참조하지 않습니다.
+        // this.mercenaryPanelManager = mercenaryPanelManager;
         this.battleLogManager = battleLogManager;
 
         // 캔버스 참조 보관
-        this.mercenaryPanelCanvas = mercenaryPanelManager ? mercenaryPanelManager.canvas : null;
+        // this.mercenaryPanelCanvas = mercenaryPanelManager ? mercenaryPanelManager.canvas : null; // 이제 필요 없음
         this.combatLogCanvas = battleLogManager ? battleLogManager.canvas : null;
 
         this.baseGameWidth = this.measureManager.get('gameResolution.width');
@@ -47,11 +48,6 @@ export class CompatibilityManager {
             this.renderer.canvas.style.height = `${minRes.minHeight}px`;
             this.renderer.resizeCanvas(minRes.minWidth, minRes.minHeight);
 
-            if (this.mercenaryPanelCanvas) {
-                const mHeight = Math.floor(minRes.minWidth * (this.measureManager.get('mercenaryPanel.heightRatio') / (this.baseGameWidth / this.baseGameHeight)));
-                this.mercenaryPanelCanvas.style.width = `${minRes.minWidth}px`;
-                this.mercenaryPanelCanvas.style.height = `${mHeight}px`;
-            }
             if (this.combatLogCanvas) {
                 const cHeight = Math.floor(minRes.minWidth * (this.measureManager.get('combatLog.heightRatio') / (this.baseGameWidth / this.baseGameHeight)));
                 this.combatLogCanvas.style.width = `${minRes.minWidth}px`;
@@ -67,7 +63,7 @@ export class CompatibilityManager {
         const mainGameAspectRatio = this.baseGameWidth / this.baseGameHeight;
         const maxMainGameCanvasWidth = viewportWidth - totalPadding;
 
-        const mercenaryPanelExpectedHeightRatio = this.measureManager.get('mercenaryPanel.heightRatio');
+        // mercenaryPanelCanvas가 사라졌으므로 해당 비율은 사용하지 않습니다.
         const combatLogExpectedHeightRatio = this.measureManager.get('combatLog.heightRatio');
 
         let mainGameCanvasWidth;
@@ -75,17 +71,16 @@ export class CompatibilityManager {
 
         const currentViewportAspectRatio = viewportWidth / viewportHeight;
         const totalGameAspectRatio = this.baseAspectRatio +
-                                     (this.baseAspectRatio * mercenaryPanelExpectedHeightRatio) +
                                      (this.baseAspectRatio * combatLogExpectedHeightRatio);
 
         if (currentViewportAspectRatio > totalGameAspectRatio) {
-            mainGameCanvasHeight = availableHeight / (1 + mercenaryPanelExpectedHeightRatio + combatLogExpectedHeightRatio);
+            mainGameCanvasHeight = availableHeight / (1 + combatLogExpectedHeightRatio);
             mainGameCanvasWidth = mainGameCanvasHeight * mainGameAspectRatio;
         } else {
             mainGameCanvasWidth = maxMainGameCanvasWidth;
             mainGameCanvasHeight = mainGameCanvasWidth / mainGameAspectRatio;
-            if ((mainGameCanvasHeight + (mainGameCanvasHeight * mercenaryPanelExpectedHeightRatio) + (mainGameCanvasHeight * combatLogExpectedHeightRatio)) > availableHeight) {
-                mainGameCanvasHeight = availableHeight / (1 + mercenaryPanelExpectedHeightRatio + combatLogExpectedHeightRatio);
+            if ((mainGameCanvasHeight + (mainGameCanvasHeight * combatLogExpectedHeightRatio)) > availableHeight) {
+                mainGameCanvasHeight = availableHeight / (1 + combatLogExpectedHeightRatio);
                 mainGameCanvasWidth = mainGameCanvasHeight * mainGameAspectRatio;
             }
         }
@@ -120,18 +115,7 @@ export class CompatibilityManager {
         this.renderer.resizeCanvas(mainGameCanvasWidth, mainGameCanvasHeight);
         console.log(`[CompatibilityManager] Main Canvas adjusted to: ${mainGameCanvasWidth}x${mainGameCanvasHeight}`);
 
-        // 2. 용병 패널 캔버스 해상도 업데이트
-        if (this.mercenaryPanelCanvas) {
-            const mercenaryPanelHeight = Math.floor(mainGameCanvasHeight * mercenaryPanelExpectedHeightRatio);
-            this.mercenaryPanelCanvas.style.width = `${mainGameCanvasWidth}px`;
-            this.mercenaryPanelCanvas.style.height = `${mercenaryPanelHeight}px`;
-            if (this.mercenaryPanelManager && this.mercenaryPanelManager.resizeCanvas) {
-                this.mercenaryPanelManager.resizeCanvas();
-            }
-            console.log(`[CompatibilityManager] Mercenary Panel Canvas adjusted to: ${mainGameCanvasWidth}x${mercenaryPanelHeight}`);
-        }
-
-        // 3. 전투 로그 캔버스 해상도 업데이트
+        // 2. 전투 로그 캔버스 해상도 업데이트
         if (this.combatLogCanvas) {
             const combatLogHeight = Math.floor(mainGameCanvasHeight * combatLogExpectedHeightRatio);
             this.combatLogCanvas.style.width = `${mainGameCanvasWidth}px`;
@@ -153,9 +137,6 @@ export class CompatibilityManager {
         }
         if (this.mapManager && this.mapManager.recalculateMapDimensions) {
             this.mapManager.recalculateMapDimensions();
-        }
-        if (this.mercenaryPanelManager && this.mercenaryPanelManager.recalculatePanelDimensions) {
-            this.mercenaryPanelManager.recalculatePanelDimensions();
         }
         if (this.battleLogManager && this.battleLogManager.recalculateLogDimensions) {
             this.battleLogManager.recalculateLogDimensions();

--- a/js/managers/MercenaryPanelManager.js
+++ b/js/managers/MercenaryPanelManager.js
@@ -1,83 +1,56 @@
 // js/managers/MercenaryPanelManager.js
 
-// Renderer는 이제 PanelEngine 또는 상위 GameEngine에서 관리되므로 여기서는 필요 없습니다.
-
 export class MercenaryPanelManager {
-    // 생성자에서 캔버스 ID 대신 캔버스 요소를 직접 받도록 변경합니다.
-    constructor(mercenaryCanvasElement, measureManager, battleSimulationManager, logicManager) {
+    // 생성자에서 캔버스 요소 대신 필요한 매니저들을 직접 받도록 변경합니다.
+    constructor(measureManager, battleSimulationManager, logicManager, eventManager) {
         console.log("\uD83D\uDC65 MercenaryPanelManager initialized. Ready to display mercenary details. \uD83D\uDC65");
-        this.canvas = mercenaryCanvasElement; // ✨ 캔버스 요소를 직접 받습니다.
-        this.ctx = this.canvas.getContext('2d'); // ✨ 컨텍스트를 직접 얻습니다.
+        // this.canvas, this.ctx는 이제 더 이상 자체적으로 관리하지 않습니다.
         this.measureManager = measureManager;
         this.battleSimulationManager = battleSimulationManager; // 유닛 데이터를 가져오기 위함
-        this.logicManager = logicManager; // ✨ LogicManager 추가
+        this.logicManager = logicManager;
+        this.eventManager = eventManager;
 
-        // ✨ MeasureManager에서 그리드 행/열 정보를 가져옴
+        // MeasureManager에서 그리드 행/열 정보를 가져옴
         this.gridRows = this.measureManager.get('mercenaryPanel.gridRows');
         this.gridCols = this.measureManager.get('mercenaryPanel.gridCols');
         this.numSlots = this.gridRows * this.gridCols;
 
-        this.pixelRatio = window.devicePixelRatio || 1;
-
-        // 초기 내부 해상도 설정 후 패널 치수 계산
-        this.resizeCanvas();
-        this.recalculatePanelDimensions();
-
-        // ✨ window.resize 이벤트 리스너 제거 (CompatibilityManager가 크기 제어)
-    }
-
-    /**
-     * 패널의 내부 치수(슬롯 크기 등)를 재계산합니다.
-     * 이 메서드는 CompatibilityManager가 캔버스 크기를 조정한 후 호출해야 합니다.
-     */
-    recalculatePanelDimensions() {
-        // ✨ 캔버스 요소의 현재 크기를 기반으로 내부 슬롯 크기 계산
-        this.slotWidth = (this.canvas.width / this.pixelRatio) / this.gridCols;
-        this.slotHeight = (this.canvas.height / this.pixelRatio) / this.gridRows;
-        console.log(`[MercenaryPanelManager] Panel dimensions recalculated. Canvas size: ${this.canvas.width}x${this.canvas.height}, Slot size: ${this.slotWidth}x${this.slotHeight}`);
-        this.resizeCanvas();
-    }
-
-    /**
-     * 캔버스 내부 해상도를 CSS 크기와 pixelRatio에 맞춰 조정합니다.
-     */
-    resizeCanvas() {
-        const displayWidth = this.canvas.clientWidth;
-        const displayHeight = this.canvas.clientHeight;
-
-        if (this.canvas.width !== displayWidth * this.pixelRatio ||
-            this.canvas.height !== displayHeight * this.pixelRatio) {
-            this.canvas.width = displayWidth * this.pixelRatio;
-            this.canvas.height = displayHeight * this.pixelRatio;
-            this.ctx = this.canvas.getContext('2d');
-            this.ctx.scale(this.pixelRatio, this.pixelRatio);
-            console.log(`[MercenaryPanelManager] Canvas internal resolution set to: ${this.canvas.width}x${this.canvas.height} (Display: ${displayWidth}x${displayHeight}, Ratio: ${this.pixelRatio})`);
-        }
+        console.log("[MercenaryPanelManager] Initialized as a drawing component.");
     }
 
     /**
      * 용병 패널과 그리드를 그립니다.
-     * 이 메서드는 PanelEngine에 의해 호출되며, 해당 패널 캔버스의 컨텍스트를 받습니다.
-     * @param {CanvasRenderingContext2D} ctx - 패널 캔버스의 2D 렌더링 컨텍스트
+     * 이 메서드는 UIEngine에 의해 호출되며, 메인 게임 캔버스의 컨텍스트를 받습니다.
+     * @param {CanvasRenderingContext2D} ctx - 메인 게임 캔버스의 2D 렌더링 컨텍스트
+     * @param {number} panelX - 패널을 그릴 X 좌표
+     * @param {number} panelY - 패널을 그릴 Y 좌표
+     * @param {number} panelWidth - 패널의 너비
+     * @param {number} panelHeight - 패널의 높이
      */
-    draw(ctx) {
-        ctx.clearRect(0, 0, this.canvas.width / this.pixelRatio, this.canvas.height / this.pixelRatio);
-        ctx.fillStyle = '#1A1A1A';
-        ctx.fillRect(0, 0, this.canvas.width / this.pixelRatio, this.canvas.height / this.pixelRatio);
+    draw(ctx, panelX, panelY, panelWidth, panelHeight) {
+        // 패널 배경 그리기 (반투명 검은색)
+        ctx.clearRect(panelX, panelY, panelWidth, panelHeight); // 기존 내용 지우기
+        ctx.fillStyle = 'rgba(26, 26, 26, 0.9)'; // 반투명 배경
+        ctx.fillRect(panelX, panelY, panelWidth, panelHeight);
+
+        // 슬롯 크기 재계산 (주어진 패널 크기에 맞게)
+        const slotWidth = panelWidth / this.gridCols;
+        const slotHeight = panelHeight / this.gridRows;
 
         ctx.strokeStyle = '#555';
         ctx.lineWidth = 1;
 
+        // 그리드 선 그리기
         for (let i = 0; i <= this.gridCols; i++) {
             ctx.beginPath();
-            ctx.moveTo(i * this.slotWidth, 0);
-            ctx.lineTo(i * this.slotWidth, this.canvas.height / this.pixelRatio);
+            ctx.moveTo(panelX + i * slotWidth, panelY);
+            ctx.lineTo(panelX + i * slotWidth, panelY + panelHeight);
             ctx.stroke();
         }
         for (let i = 0; i <= this.gridRows; i++) {
             ctx.beginPath();
-            ctx.moveTo(0, i * this.slotHeight);
-            ctx.lineTo(this.canvas.width / this.pixelRatio, i * this.slotHeight);
+            ctx.moveTo(panelX, panelY + i * slotHeight);
+            ctx.lineTo(panelX + panelWidth, panelY + i * slotHeight);
             ctx.stroke();
         }
 
@@ -87,20 +60,21 @@ export class MercenaryPanelManager {
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
 
+        // 각 슬롯에 유닛 정보 그리기
         for (let i = 0; i < this.numSlots; i++) {
             const row = Math.floor(i / this.gridCols);
             const col = i % this.gridCols;
-            const x = col * this.slotWidth + this.slotWidth / 2;
-            const y = row * this.slotHeight + this.slotHeight / 2;
+            const x = panelX + col * slotWidth + slotWidth / 2;
+            const y = panelY + row * slotHeight + slotHeight / 2;
 
             if (units[i]) {
                 const unit = units[i];
                 ctx.fillText(`${unit.name}`, x, y - 10);
                 ctx.fillText(`HP: ${unit.currentHp}/${unit.baseStats.hp}`, x, y + 10);
                 if (unit.image) {
-                    const imgSize = Math.min(this.slotWidth, this.slotHeight) * 0.7;
-                    const imgX = col * this.slotWidth + (this.slotWidth - imgSize) / 2;
-                    const imgY = row * this.slotHeight + (this.slotHeight - imgSize) / 2 - 25;
+                    const imgSize = Math.min(slotWidth, slotHeight) * 0.7;
+                    const imgX = panelX + col * slotWidth + (slotWidth - imgSize) / 2;
+                    const imgY = panelY + row * slotHeight + (slotHeight - imgSize) / 2 - 25;
                     ctx.drawImage(unit.image, imgX, imgY, imgSize, imgSize);
                 }
             } else {

--- a/js/managers/PanelEngine.js
+++ b/js/managers/PanelEngine.js
@@ -29,6 +29,8 @@ export class PanelEngine {
     drawPanel(panelName, ctx) {
         const panel = this.panels.get(panelName);
         if (panel) {
+            // PanelEngine은 이제 패널 컨텍스트를 직접 전달하고, MercenaryPanelManager는 PanelEngine을 통해 그려지지 않습니다.
+            // 따라서 이곳에서는 BattleLogManager만 예상됩니다.
             panel.draw(ctx);
         } else {
             console.warn(`[PanelEngine] Panel '${panelName}' not found.`);

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -1,16 +1,18 @@
 // js/managers/UIEngine.js
 
 export class UIEngine {
-    constructor(renderer, measureManager, eventManager) {
+    constructor(renderer, measureManager, eventManager, mercenaryPanelManager) {
         console.log("\ud83c\udf9b UIEngine initialized. Ready to draw interfaces. \ud83c\udf9b");
         this.renderer = renderer;
         this.measureManager = measureManager;
         this.eventManager = eventManager;
+        this.mercenaryPanelManager = mercenaryPanelManager; // MercenaryPanelManager 인스턴스 저장
 
         this.canvas = renderer.canvas;
         this.ctx = renderer.ctx;
 
         this._currentUIState = 'mapScreen';
+        this.heroPanelVisible = false; // 영웅 패널 가시성 상태
 
         this.recalculateUIDimensions();
 
@@ -58,6 +60,13 @@ export class UIEngine {
         console.log(`[UIEngine] Internal UI state updated to: ${newState}`);
     }
 
+    // 영웅 패널 가시성 토글
+    toggleHeroPanel() {
+        this.heroPanelVisible = !this.heroPanelVisible;
+        console.log(`[UIEngine] Hero Panel Visibility: ${this.heroPanelVisible ? 'Visible' : 'Hidden'}`);
+        // 필요에 따라 UI 상태를 변경할 수 있지만, 오버레이는 현재 UI 상태와 별개로 표시될 수 있습니다.
+    }
+
     // canvas 내부 좌표(mouseX, mouseY)를 직접 받아 버튼 영역과 비교합니다.
     isClickOnButton(mouseX, mouseY) {
         if (this._currentUIState !== 'mapScreen') {
@@ -78,6 +87,7 @@ export class UIEngine {
     }
 
     draw(ctx) {
+        // 현재 UI 상태에 따라 기본 UI 그리기
         if (this._currentUIState === 'mapScreen') {
             ctx.fillStyle = 'darkgreen';
             ctx.fillRect(
@@ -97,6 +107,22 @@ export class UIEngine {
             );
         } else if (this._currentUIState === 'combatScreen') {
             // 전투 화면에서는 현재 별도의 상단 텍스트를 표시하지 않습니다.
+        }
+
+        // 영웅 패널이 활성화되어 있으면 오버레이로 그립니다.
+        if (this.heroPanelVisible && this.mercenaryPanelManager) {
+            // 오버레이 배경 (반투명)
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+            ctx.fillRect(0, 0, this.canvas.width / (window.devicePixelRatio || 1), this.canvas.height / (window.devicePixelRatio || 1));
+
+            // 영웅 패널이 그려질 중앙 영역 계산
+            const panelWidth = this.measureManager.get('gameResolution.width') * 0.8; // 캔버스 너비의 80%
+            const panelHeight = this.measureManager.get('gameResolution.height') * 0.7; // 캔버스 높이의 70%
+            const panelX = (this.measureManager.get('gameResolution.width') - panelWidth) / 2;
+            const panelY = (this.measureManager.get('gameResolution.height') - panelHeight) / 2;
+
+            // MercenaryPanelManager의 draw 메서드를 호출하여 메인 캔버스에 그립니다.
+            this.mercenaryPanelManager.draw(ctx, panelX, panelY, panelWidth, panelHeight);
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -30,13 +30,7 @@ canvas {
     box-sizing: border-box; /* 테두리 포함 크기 계산 */
 }
 
-/* 용병 패널 캔버스 전용 스타일 (JS가 크기 제어) */
-#mercenaryPanelCanvas {
-    margin-bottom: 0px; /* 패널과 메인 게임 캔버스 사이의 간격을 제거 */
-    border: 2px solid #00f; /* 구분을 위한 다른 테두리 색상 */
-    flex-shrink: 0;
-    aspect-ratio: 16 / 2.25; /* 메인 캔버스 높이의 약 25% 비율 */
-}
+/* 용병 패널 캔버스 스타일은 이제 필요 없습니다. */
 
 /* ✨ 전투 로그 캔버스 전용 스타일 (JS가 크기 제어) */
 #combatLogCanvas {

--- a/tests/unit/canvasBridgeManagerUnitTests.js
+++ b/tests/unit/canvasBridgeManagerUnitTests.js
@@ -12,8 +12,6 @@ export function runCanvasBridgeManagerUnitTests() {
 
     const mockGameCanvas = document.createElement('canvas');
     mockGameCanvas.id = 'gameCanvas';
-    const mockMercenaryPanelCanvas = document.createElement('canvas');
-    mockMercenaryPanelCanvas.id = 'mercenaryPanelCanvas';
     const mockCombatLogCanvas = document.createElement('canvas');
     mockCombatLogCanvas.id = 'combatLogCanvas';
 
@@ -25,7 +23,7 @@ export function runCanvasBridgeManagerUnitTests() {
     try {
         const cbm = new CanvasBridgeManager(
             mockGameCanvas,
-            mockMercenaryPanelCanvas,
+            null,
             mockCombatLogCanvas,
             mockEventManager,
             mockMeasureManager
@@ -45,7 +43,7 @@ export function runCanvasBridgeManagerUnitTests() {
     try {
         const cbm = new CanvasBridgeManager(
             mockGameCanvas,
-            mockMercenaryPanelCanvas,
+            null,
             mockCombatLogCanvas,
             mockEventManager,
             mockMeasureManager
@@ -61,7 +59,7 @@ export function runCanvasBridgeManagerUnitTests() {
     try {
         const cbm = new CanvasBridgeManager(
             mockGameCanvas,
-            mockMercenaryPanelCanvas,
+            null,
             mockCombatLogCanvas,
             mockEventManager,
             mockMeasureManager
@@ -75,7 +73,7 @@ export function runCanvasBridgeManagerUnitTests() {
         mockEventManager.subscribe('dragMove', () => { dragMoveEmitted = true; });
         mockEventManager.subscribe('drop', () => { dropEmitted = true; });
 
-        cbm._onMouseDown({ clientX: 10, clientY: 10, target: mockMercenaryPanelCanvas });
+        cbm._onMouseDown({ clientX: 10, clientY: 10, target: mockGameCanvas });
         cbm._onMouseMove({ clientX: 20, clientY: 20, target: mockGameCanvas });
         cbm._onMouseUp({ clientX: 20, clientY: 20, target: mockGameCanvas });
 

--- a/tests/unit/mercenaryPanelManagerUnitTests.js
+++ b/tests/unit/mercenaryPanelManagerUnitTests.js
@@ -2,13 +2,13 @@
 
 import { MercenaryPanelManager } from '../../js/managers/MercenaryPanelManager.js';
 
-export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager) {
+export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager) {
     console.log("--- MercenaryPanelManager Unit Test Start ---");
 
     let testCount = 0;
     let passCount = 0;
 
-    // Mock 캔버스 요소 생성
+    // Mock 캔버스와 컨텍스트 생성 (draw 테스트용)
     const mockCanvas = document.createElement('canvas');
     mockCanvas.width = 600;
     mockCanvas.height = 200;
@@ -17,10 +17,9 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
     // 테스트 1: 초기화 및 캔버스 속성 확인
     testCount++;
     try {
-        const panelManager = new MercenaryPanelManager(mockCanvas, measureManager, battleSimulationManager, logicManager);
-        if (panelManager.canvas === mockCanvas && panelManager.ctx === mockCtx &&
-            panelManager.gridRows === 2 && panelManager.gridCols === 6) {
-            console.log("MercenaryPanelManager: Initialized correctly with canvas properties. [PASS]");
+        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager);
+        if (panelManager.gridRows === 2 && panelManager.gridCols === 6) {
+            console.log("MercenaryPanelManager: Initialized correctly. [PASS]");
             passCount++;
         } else {
             console.error("MercenaryPanelManager: Initialization failed. [FAIL]", panelManager);
@@ -32,7 +31,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
     // 테스트 2: recalculatePanelDimensions 호출 후 슬롯 크기 확인
     testCount++;
     try {
-        const panelManager = new MercenaryPanelManager(mockCanvas, measureManager, battleSimulationManager, logicManager);
+        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager);
         panelManager.recalculatePanelDimensions(); // 수동 호출
         const expectedSlotWidth = 600 / 6; // 600px / 6 cols
         const expectedSlotHeight = 200 / 2; // 200px / 2 rows
@@ -50,7 +49,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
     // 테스트 3: draw 메서드가 호출되는지 시각적 확인 (콘솔 로그를 통한 간접 확인)
     testCount++;
     try {
-        const panelManager = new MercenaryPanelManager(mockCanvas, measureManager, battleSimulationManager, logicManager);
+        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager);
         const originalFillRect = mockCtx.fillRect;
         let fillRectCalled = false;
         mockCtx.fillRect = function(...args) {
@@ -58,7 +57,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
             originalFillRect.apply(this, args);
         };
 
-        panelManager.draw(mockCtx);
+        panelManager.draw(mockCtx, 0, 0, 600, 200);
 
         if (fillRectCalled) {
             console.log("MercenaryPanelManager: Draw method called and performed basic drawing operations. [PASS]");
@@ -84,7 +83,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
         const originalUnitsOnGrid = battleSimulationManager.unitsOnGrid;
         battleSimulationManager.unitsOnGrid = [mockUnit];
 
-        const panelManager = new MercenaryPanelManager(mockCanvas, measureManager, battleSimulationManager, logicManager);
+        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager);
         const originalFillText = mockCtx.fillText;
         let fillTextCalledForUnit = false;
         mockCtx.fillText = function(text, ...args) {
@@ -100,7 +99,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
             originalDrawImage.apply(this, args);
         };
 
-        panelManager.draw(mockCtx);
+        panelManager.draw(mockCtx, 0, 0, 600, 200);
 
         if (fillTextCalledForUnit && drawImageCalledForUnit) {
             console.log("MercenaryPanelManager: Draw method drew unit info and image. [PASS]");

--- a/tests/unit/uiEngineUnitTests.js
+++ b/tests/unit/uiEngineUnitTests.js
@@ -22,11 +22,12 @@ export function runUIEngineUnitTests() {
     };
     const mockMeasureManager = new MeasureManager();
     const mockEventManager = new EventManager();
+    const mockMercenaryPanelManager = { draw: () => {} };
 
     // 테스트 1: 초기화 확인
     testCount++;
     try {
-        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager, mockMercenaryPanelManager);
         if (uiEngine.renderer === mockRenderer && uiEngine.getUIState() === 'mapScreen') {
             console.log("UIEngine: Initialized correctly. [PASS]");
             passCount++;
@@ -40,7 +41,7 @@ export function runUIEngineUnitTests() {
     // 테스트 2: recalculateUIDimensions 호출 후 버튼 위치 확인
     testCount++;
     try {
-        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager, mockMercenaryPanelManager);
         uiEngine.recalculateUIDimensions();
 
         const expectedButtonX = (mockRenderer.canvas.width - uiEngine.buttonWidth) / 2;
@@ -59,7 +60,7 @@ export function runUIEngineUnitTests() {
     // 테스트 3: setUIState 및 getUIState
     testCount++;
     try {
-        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager, mockMercenaryPanelManager);
         uiEngine.setUIState('combatScreen');
         if (uiEngine.getUIState() === 'combatScreen') {
             console.log("UIEngine: UI state set and retrieved correctly. [PASS]");
@@ -74,7 +75,7 @@ export function runUIEngineUnitTests() {
     // 테스트 4: isClickOnButton - 버튼 클릭 성공
     testCount++;
     try {
-        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager, mockMercenaryPanelManager);
         uiEngine.setUIState('mapScreen');
         const button = uiEngine.battleStartButton;
         const clickX = button.x + button.width / 2;
@@ -93,7 +94,7 @@ export function runUIEngineUnitTests() {
     // 테스트 5: isClickOnButton - 버튼 클릭 실패 (다른 UI 상태)
     testCount++;
     try {
-        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager, mockMercenaryPanelManager);
         uiEngine.setUIState('combatScreen');
         const button = uiEngine.battleStartButton;
         const clickX = button.x + button.width / 2;
@@ -112,7 +113,7 @@ export function runUIEngineUnitTests() {
     // 테스트 6: handleBattleStartClick - 이벤트 발생 확인 (간접)
     testCount++;
     try {
-        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager, mockMercenaryPanelManager);
         let eventEmitted = false;
         mockEventManager.subscribe('battleStart', () => { eventEmitted = true; });
 
@@ -131,7 +132,7 @@ export function runUIEngineUnitTests() {
     // 테스트 7: draw 메서드 (mapScreen)
     testCount++;
     try {
-        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager, mockMercenaryPanelManager);
         uiEngine.setUIState('mapScreen');
         mockRenderer.ctx.fillRectCalled = false;
         mockRenderer.ctx.fillTextCalled = false;
@@ -151,7 +152,7 @@ export function runUIEngineUnitTests() {
     // 테스트 8: draw 메서드 (combatScreen)
     testCount++;
     try {
-        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager);
+        const uiEngine = new UIEngine(mockRenderer, mockMeasureManager, mockEventManager, mockMercenaryPanelManager);
         uiEngine.setUIState('combatScreen');
         mockRenderer.ctx.fillRectCalled = false;
         mockRenderer.ctx.fillTextCalled = false;


### PR DESCRIPTION
## Summary
- drop the standalone mercenary panel canvas and make the hero panel an overlay
- provide a button to toggle the hero panel in both index and debug pages
- update compatibility, canvas bridge, panel, and UI engines for new behavior
- update tests for the new interfaces

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68750236123c8327b08a50b789b549a9