### PR TITLE
Update grid ratio and UI scaling

### DIFF
--- a/js/managers/BattleGridManager.js
+++ b/js/managers/BattleGridManager.js
@@ -5,8 +5,8 @@ export class BattleGridManager {
         console.log("\uD83D\uDCDC BattleGridManager initialized. Ready to draw the battlefield grid. \uD83D\uDCDC");
         this.measureManager = measureManager;
         this.logicManager = logicManager;
-        this.gridRows = 10;
-        this.gridCols = 15;
+        this.gridRows = 9;  // 16:9 비율에 맞춘 행 수
+        this.gridCols = 16; // 16:9 비율에 맞춘 열 수
     }
 
     /**
@@ -17,8 +17,6 @@ export class BattleGridManager {
         const sceneContentDimensions = this.logicManager.getCurrentSceneContentDimensions(); // 순수 그리드 컨텐츠 크기 (gameResolution)
         const canvasWidth = this.measureManager.get('gameResolution.width'); // 캔버스 실제 CSS 너비
         const canvasHeight = this.measureManager.get('gameResolution.height'); // 캔버스 실제 CSS 높이
-
-        const stagePadding = this.measureManager.get('battleStage.padding');
 
         // LogicManager에서 계산된 순수 그리드 컨텐츠 크기 (패딩 제외)
         const gridContentWidth = sceneContentDimensions.width;

--- a/js/managers/BattleLogManager.js
+++ b/js/managers/BattleLogManager.js
@@ -25,12 +25,9 @@ export class BattleLogManager {
      * 이 메서드는 CompatibilityManager가 캔버스 크기를 조정한 후 호출해야 합니다.
      */
     recalculateLogDimensions() {
-        const measuredLineHeight = this.measureManager.get('combatLog.lineHeight');
-        const measuredPadding = this.measureManager.get('combatLog.padding');
-
-        // 캔버스 높이에 따라 표시할 최대 줄 수와 줄 간격 재조정
-        this.padding = measuredPadding;
-        this.lineHeight = measuredLineHeight;
+        const logicalCanvasHeight = this.measureManager.get('gameResolution.height');
+        this.padding = this.measureManager.get('combatLog.padding');
+        this.lineHeight = Math.floor(logicalCanvasHeight * this.measureManager.get('combatLog.lineHeightRatio'));
         this.maxLogLines = Math.floor(((this.canvas.height / this.pixelRatio) - 2 * this.padding) / this.lineHeight);
         
         // 최대 줄 수를 초과하는 오래된 메시지 제거

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -10,8 +10,8 @@ export class BattleSimulationManager {
         this.animationManager = animationManager;
         this.valorEngine = valorEngine;
         this.unitsOnGrid = [];
-        this.gridRows = 10; // BattleGridManager와 동일한 그리드 차원
-        this.gridCols = 15;
+        this.gridRows = 9;  // 16:9 비율에 맞춘 행 수
+        this.gridCols = 16; // 16:9 비율에 맞춘 열 수
     }
 
     /**
@@ -103,21 +103,20 @@ export class BattleSimulationManager {
         const canvasWidth = this.measureManager.get('gameResolution.width'); // 캔버스 실제 CSS 너비
         const canvasHeight = this.measureManager.get('gameResolution.height'); // 캔버스 실제 CSS 높이
 
-        const stagePadding = this.measureManager.get('battleStage.padding');
-
         // LogicManager에서 계산된 순수 그리드 컨텐츠 크기 (패딩 제외)
         const gridContentWidth = sceneContentDimensions.width;
         const gridContentHeight = sceneContentDimensions.height;
 
-        // 이 gridContentWidth/Height를 사용하여 effectiveTileSize를 역으로 계산
-        const effectiveTileSize = gridContentWidth / this.gridCols;
+        // BattleGridManager와 동일한 로직으로 타일 크기를 계산
+        const tileSizeBasedOnWidth = gridContentWidth / this.gridCols;
+        const tileSizeBasedOnHeight = gridContentHeight / this.gridRows;
+        const effectiveTileSize = Math.min(tileSizeBasedOnWidth, tileSizeBasedOnHeight);
 
-        // 전체 그리드 크기 (여기서는 gridContentWidth/Height와 동일)
-        const totalGridWidth = gridContentWidth;
-        const totalGridHeight = gridContentHeight;
+        // 실제 그려질 그리드의 총 크기
+        const totalGridWidth = effectiveTileSize * this.gridCols;
+        const totalGridHeight = effectiveTileSize * this.gridRows;
 
-        // ✨ 그리드를 캔버스 중앙에 배치하기 위한 오프셋 계산 (패딩 포함)
-        // (캔버스 전체 크기 - 그리드 컨텐츠 크기) / 2 + 패딩
+        // 그리드를 캔버스 중앙에 배치하기 위한 오프셋 계산
         const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
         const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -7,7 +7,7 @@ export class MeasureManager {
         // 게임의 모든 사이즈 관련 설정을 이곳에 정의
         this._measurements = {
             tileSize: 512, // 맵 타일의 기본 사이즈 (이 값은 이제 BattleGridManager에서 직접 사용되지 않고, 기본 타일 사이즈의 개념으로 유지)
-            mapGrid: { rows: 10, cols: 15 }, // 맵 그리드의 행/열
+            mapGrid: { rows: 9, cols: 16 }, // ✨ 그리드 비율을 16:9로 변경
             gameResolution: {
                 width: 1280,
                 height: 720
@@ -15,9 +15,14 @@ export class MeasureManager {
             ui: {
                 mapPanelWidthRatio: 0.7,
                 mapPanelHeightRatio: 0.9,
-                buttonHeight: 50,
+                buttonHeight: 50, // 이전 절대값, 하위 비율 설정과 함께 유지
                 buttonWidth: 200,
-                buttonMargin: 10
+                buttonMargin: 10,
+                // ✨ 비율 기반 UI 크기 정의
+                buttonHeightRatio: 0.07,  // 게임 높이의 7%
+                buttonWidthRatio: 0.20,   // 게임 너비의 20%
+                buttonMarginRatio: 0.015, // 게임 높이의 1.5%
+                fontSizeRatio: 0.03       // 폰트 크기 비율 (게임 높이의 3%)
             },
             // 새로운 설정: 배틀 스테이지 관련
             battleStage: {
@@ -29,16 +34,20 @@ export class MeasureManager {
             },
             // ✨ 용병 패널 관련 설정 업데이트
             mercenaryPanel: {
-                baseSlotSize: 100, // 각 슬롯의 기본 크기 (UI 계산용)
+                baseSlotSize: 100,
                 gridRows: 2,
                 gridCols: 6,
-                heightRatio: 0.25 // 메인 캔버스 높이의 25% (예시)
+                heightRatio: 0.25,
+                // ✨ 패널 내부 텍스트 크기 비율
+                unitTextFontSizeRatio: 0.04
             },
             // ✨ 전투 로그 관련 설정 추가
             combatLog: {
-                heightRatio: 0.15, // 메인 캔버스 높이의 15% (예시)
-                lineHeight: 20, // 한 줄 높이 (px)
-                padding: 10 // 내부 여백 (px)
+                heightRatio: 0.15,
+                lineHeight: 20, // 절대값 (호환용)
+                padding: 10,
+                // ✨ 줄 높이를 게임 높이 비율로 표현
+                lineHeightRatio: 0.025
             },
             // ✨ 새로운 게임 설정 섹션
             gameConfig: {

--- a/js/managers/MercenaryPanelManager.js
+++ b/js/managers/MercenaryPanelManager.js
@@ -49,14 +49,15 @@ export class MercenaryPanelManager {
         }
         for (let i = 0; i <= this.gridRows; i++) {
             ctx.beginPath();
-            ctx.moveTo(panelX, panelY + i * slotHeight);
+            ctx.moveTo(0, panelY + i * slotHeight); // 패널 영역 전체에 선을 그림
             ctx.lineTo(panelX + panelWidth, panelY + i * slotHeight);
             ctx.stroke();
         }
 
         const units = this.battleSimulationManager ? this.battleSimulationManager.unitsOnGrid : [];
         ctx.fillStyle = 'white';
-        ctx.font = '14px Arial';
+        const unitNameFontSize = Math.floor(panelHeight * this.measureManager.get('mercenaryPanel.unitTextFontSizeRatio'));
+        const unitHpFontSize = Math.floor(unitNameFontSize * 0.8);
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
 
@@ -69,15 +70,19 @@ export class MercenaryPanelManager {
 
             if (units[i]) {
                 const unit = units[i];
-                ctx.fillText(`${unit.name}`, x, y - 10);
-                ctx.fillText(`HP: ${unit.currentHp}/${unit.baseStats.hp}`, x, y + 10);
+                ctx.font = `${unitNameFontSize}px Arial`;
+                ctx.fillText(`${unit.name}`, x, y - unitNameFontSize * 0.8);
+
+                ctx.font = `${unitHpFontSize}px Arial`;
+                ctx.fillText(`HP: ${unit.currentHp}/${unit.baseStats.hp}`, x, y + unitHpFontSize * 0.8);
                 if (unit.image) {
                     const imgSize = Math.min(slotWidth, slotHeight) * 0.7;
                     const imgX = panelX + col * slotWidth + (slotWidth - imgSize) / 2;
-                    const imgY = panelY + row * slotHeight + (slotHeight - imgSize) / 2 - 25;
+                    const imgY = panelY + row * slotHeight + (slotHeight - imgSize) / 2 - unitNameFontSize * 1.5;
                     ctx.drawImage(unit.image, imgX, imgY, imgSize, imgSize);
                 }
             } else {
+                ctx.font = `${unitNameFontSize}px Arial`;
                 ctx.fillText(`Slot ${i + 1}`, x, y);
             }
         }

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -17,10 +17,11 @@ export class UIEngine {
 
         this.recalculateUIDimensions();
 
-        const pixelRatio = window.devicePixelRatio || 1;
+        const logicalCanvasWidth = this.measureManager.get('gameResolution.width');
+        const logicalCanvasHeight = this.measureManager.get('gameResolution.height');
         this.battleStartButton = {
-            x: (this.canvas.width / pixelRatio - this.buttonWidth) / 2,
-            y: (this.canvas.height / pixelRatio) - this.buttonHeight - this.buttonMargin,
+            x: (logicalCanvasWidth - this.buttonWidth) / 2,
+            y: logicalCanvasHeight - this.buttonHeight - this.buttonMargin,
             width: this.buttonWidth,
             height: this.buttonHeight,
             text: '전투 시작'
@@ -43,17 +44,21 @@ export class UIEngine {
 
     recalculateUIDimensions() {
         console.log("[UIEngine] Recalculating UI dimensions based on MeasureManager...");
-        // measureManager에서 가져오는 값들이 올바른지 확인합니다.
-        this.mapPanelWidth = this.canvas.width * this.measureManager.get('ui.mapPanelWidthRatio');
-        this.mapPanelHeight = this.canvas.height * this.measureManager.get('ui.mapPanelHeightRatio');
-        this.buttonHeight = this.measureManager.get('ui.buttonHeight');
-        this.buttonWidth = this.measureManager.get('ui.buttonWidth');
-        this.buttonMargin = this.measureManager.get('ui.buttonMargin');
 
-        const pixelRatio = window.devicePixelRatio || 1;
+        const logicalCanvasWidth = this.measureManager.get('gameResolution.width');
+        const logicalCanvasHeight = this.measureManager.get('gameResolution.height');
+
+        this.mapPanelWidth = logicalCanvasWidth * this.measureManager.get('ui.mapPanelWidthRatio');
+        this.mapPanelHeight = logicalCanvasHeight * this.measureManager.get('ui.mapPanelHeightRatio');
+
+        this.buttonHeight = Math.floor(logicalCanvasHeight * this.measureManager.get('ui.buttonHeightRatio'));
+        this.buttonWidth = Math.floor(logicalCanvasWidth * this.measureManager.get('ui.buttonWidthRatio'));
+        this.buttonMargin = Math.floor(logicalCanvasHeight * this.measureManager.get('ui.buttonMarginRatio'));
+        this.uiFontSize = Math.floor(logicalCanvasHeight * this.measureManager.get('ui.fontSizeRatio'));
+
         this.battleStartButton = {
-            x: (this.canvas.width / pixelRatio - this.buttonWidth) / 2, // 논리적 캔버스 너비 사용
-            y: (this.canvas.height / pixelRatio) - this.buttonHeight - this.buttonMargin, // 논리적 캔버스 높이 사용
+            x: (logicalCanvasWidth - this.buttonWidth) / 2,
+            y: logicalCanvasHeight - this.buttonHeight - this.buttonMargin,
             width: this.buttonWidth,
             height: this.buttonHeight,
             text: '전투 시작'
@@ -72,7 +77,7 @@ export class UIEngine {
 
         // ✨ 추가: 버튼 계산 후 최종 위치 및 크기 로그
         console.log(`[UIEngine Debug] Battle Start Button: X=${this.battleStartButton.x}, Y=${this.battleStartButton.y}, Width=${this.battleStartButton.width}, Height=${this.battleStartButton.height}`);
-        console.log(`[UIEngine Debug] Canvas Logical Dimensions: ${this.canvas.width / pixelRatio}x${this.canvas.height / pixelRatio}`);
+        console.log(`[UIEngine Debug] Canvas Logical Dimensions: ${logicalCanvasWidth}x${logicalCanvasHeight}`);
     }
 
     getUIState() {
@@ -110,13 +115,13 @@ export class UIEngine {
                 battleStartButtonRect.height
             );
             ctx.fillStyle = 'white';
-            ctx.font = '24px Arial';
+            ctx.font = `${this.uiFontSize}px Arial`;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
             ctx.fillText(
                 this.battleStartButton.text,
                 battleStartButtonRect.x + battleStartButtonRect.width / 2,
-                battleStartButtonRect.y + battleStartButtonRect.height / 2 + 8
+                battleStartButtonRect.y + battleStartButtonRect.height / 2 + (this.uiFontSize * 0.25)
             );
         } else if (this._currentUIState === 'combatScreen') {
             // 전투 화면에서는 현재 별도의 상단 텍스트를 표시하지 않습니다.


### PR DESCRIPTION
## Summary
- change map grid to 16x9
- calculate UI sizes using ratios from `MeasureManager`
- draw grid and units with new ratio settings
- scale fonts dynamically for mercenary panel and logs

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68750d17a6208327a993612e27df6579