### PR TITLE
Add HTML battle start button

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -131,6 +131,8 @@
         <canvas id="gameCanvas"></canvas>
         <canvas id="combatLogCanvas"></canvas>
     </div>
+    <!-- ✨ 전투 시작을 위한 별도의 HTML 버튼 -->
+    <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>
     <script type="module">
     import { GameEngine } from './js/GameEngine.js'; // <-- GameEngine 불러오기
     import {
@@ -464,6 +466,14 @@
             document.getElementById(BUTTON_IDS.TOGGLE_HERO_PANEL).addEventListener('click', () => { // ✨ 상수 사용
                 gameEngine.getUIEngine().toggleHeroPanel();
             });
+
+            // ✨ 전투 시작 HTML 버튼
+            const battleStartHtmlBtn = document.getElementById(BUTTON_IDS.BATTLE_START_HTML);
+            if (battleStartHtmlBtn) {
+                battleStartHtmlBtn.addEventListener('click', () => {
+                    gameEngine.getUIEngine().handleBattleStartClick();
+                });
+            }
 
 
             // 게임 업데이트 함수 정의 (DEBUG ONLY - GameEngine의 _update가 대신함)

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
         <canvas id="combatLogCanvas"></canvas>
     </div>
     <button id="toggleHeroPanelBtn" style="position: absolute; top: 10px; right: 10px; z-index: 100;">영웅 패널</button>
+    <!-- ✨ 캔버스 버튼 외에 별도의 HTML 전투 시작 버튼 -->
+    <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/constants.js
+++ b/js/constants.js
@@ -29,7 +29,9 @@ export const UI_STATES = {
 
 export const BUTTON_IDS = {
     BATTLE_START: 'battleStartButton',
-    TOGGLE_HERO_PANEL: 'toggleHeroPanelBtn'
+    TOGGLE_HERO_PANEL: 'toggleHeroPanelBtn',
+    // HTML 요소로 제공되는 전투 시작 버튼
+    BATTLE_START_HTML: 'battleStartHtmlBtn'
 };
 
 export const ATTACK_TYPES = {

--- a/js/main.js
+++ b/js/main.js
@@ -18,6 +18,14 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             console.warn("Hero Panel toggle button not found in main.js.");
         }
+
+        // ✨ 별도의 HTML 전투 시작 버튼 리스너
+        const battleStartHtmlBtn = document.getElementById(BUTTON_IDS.BATTLE_START_HTML);
+        if (battleStartHtmlBtn) {
+            battleStartHtmlBtn.addEventListener('click', () => {
+                gameEngine.getUIEngine().handleBattleStartClick();
+            });
+        }
     } catch (error) {
         console.error("Fatal Error: Game Engine failed to start.", error);
         alert("\uAC8C\uC784 \uC2DC\uC791 \uC911 \uCE58\uBA85\uC801\uC778 \uC624\uB958\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4. \uCF58\uC194\uC744 \uD655\uC778\uD574\uC8FC\uC138\uC694.");

--- a/style.css
+++ b/style.css
@@ -45,3 +45,23 @@ canvas {
     flex-grow: 1;
     aspect-ratio: 16 / 9;
 }
+
+/* ✨ HTML 전투 시작 버튼 스타일 */
+.game-button {
+    background-color: darkgreen;
+    color: white;
+    padding: 15px 30px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 24px;
+    position: absolute;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 99;
+}
+
+.game-button:hover {
+    background-color: #004d00;
+}


### PR DESCRIPTION
## Summary
- allow starting battles via a normal HTML button
- wire up the button in the main and debug pages
- add CSS styling for the new button
- expose button ID in constants for reuse

## Testing
- `npm test`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687512c3ae3c8327a53276d7a086e556