### PR TITLE
Implement capture animation feature

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -64,6 +64,10 @@ export class GameEngine {
             throw new Error("Renderer initialization failed.");
         }
         this.eventManager = new EventManager();
+        // GameEngine에서 각 매니저 인스턴스에 대한 getter를 추가하여 순환 참조를 피합니다.
+        this.getVFXManager = () => this.vfxManager;
+        this.getStatusEffectManager = () => this.statusEffectManager;
+        this.getBattleCalculationManager = () => this.battleCalculationManager;
         this.guardianManager = new GuardianManager();
         this.measureManager = new MeasureManager();
         // 게임 규칙을 관리하는 RuleManager 초기화
@@ -187,7 +191,9 @@ export class GameEngine {
             this.eventManager,
             this.battleSimulationManager,
             this.diceRollManager,
-            this.delayEngine
+            this.delayEngine,
+            this.getVFXManager.bind(this),
+            this.getStatusEffectManager.bind(this)
         );
 
         // Status effect 관련 매니저 초기화
@@ -196,7 +202,7 @@ export class GameEngine {
             this.eventManager,
             this.idManager,
             this.turnCountManager,
-            this.battleCalculationManager
+            this.getBattleCalculationManager.bind(this)
         );
         this.workflowManager = new WorkflowManager(
             this.eventManager,
@@ -333,6 +339,11 @@ export class GameEngine {
         await this.assetLoaderManager.loadImage(
             UNITS.WARRIOR.spriteId,
             'assets/images/warrior.png'
+        );
+        // ✨ 포획 애니메이션에 사용될 전사 마무리 이미지 로드
+        await this.assetLoaderManager.loadImage(
+            'sprite_warrior_finish',
+            'assets/images/warrior-finish.png'
         );
         // ✨ 전투 배경 이미지 로드
         await this.assetLoaderManager.loadImage('sprite_battle_stage_forest', 'assets/images/battle-stage-forest.png');

--- a/js/constants.js
+++ b/js/constants.js
@@ -18,7 +18,8 @@ export const GAME_EVENTS = {
     DRAG_START: 'dragStart',
     DRAG_MOVE: 'dragMove',
     DROP: 'drop',
-    DRAG_CANCEL: 'dragCancel'
+    DRAG_CANCEL: 'dragCancel',
+    ATTEMPT_UNIT_CAPTURE: 'attemptUnitCapture'
 };
 
 export const UI_STATES = {

--- a/js/managers/BattleCalculationManager.js
+++ b/js/managers/BattleCalculationManager.js
@@ -1,14 +1,16 @@
 // js/managers/BattleCalculationManager.js
-import { DelayEngine } from './DelayEngine.js'; // ✨ DelayEngine 추가
-import { GAME_EVENTS } from '../constants.js';
+import { DelayEngine } from './DelayEngine.js';
+import { GAME_EVENTS, ATTACK_TYPES } from '../constants.js';
 
 export class BattleCalculationManager {
-    constructor(eventManager, battleSimulationManager, diceRollManager, delayEngine) {
+    constructor(eventManager, battleSimulationManager, diceRollManager, delayEngine, getVFXManager, getStatusEffectManager) {
         console.log("\ud83d\udcca BattleCalculationManager initialized. Delegating heavy calculations to worker. \ud83d\udcca");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
         this.diceRollManager = diceRollManager;
-        this.delayEngine = delayEngine; // ✨ delayEngine 저장
+        this.delayEngine = delayEngine;
+        this.getVFXManager = getVFXManager;
+        this.getStatusEffectManager = getStatusEffectManager;
         this.worker = new Worker('./js/workers/battleCalculationWorker.js');
 
         this.worker.onmessage = this._handleWorkerMessage.bind(this);
@@ -18,15 +20,33 @@ export class BattleCalculationManager {
     }
 
     async _handleWorkerMessage(event) {
-        const { type, unitId, newHp, newBarrier, hpDamageDealt, barrierDamageDealt } = event.data;
+        const { type, unitId, attackerUnitId, newHp, newBarrier, hpDamageDealt, barrierDamageDealt } = event.data;
 
         if (type === GAME_EVENTS.DAMAGE_CALCULATED) {
             console.log(`[BattleCalculationManager] Received damage calculation result for ${unitId}: New HP = ${newHp}, New Barrier = ${newBarrier}, HP Damage = ${hpDamageDealt}, Barrier Damage = ${barrierDamageDealt}`);
 
             const unitToUpdate = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+            const attackerUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === attackerUnitId);
+
             if (unitToUpdate) {
                 unitToUpdate.currentHp = newHp;
                 unitToUpdate.currentBarrier = newBarrier;
+
+                if (newHp <= 0) {
+                    const statusEffectManager = this.getStatusEffectManager();
+                    const activeEffects = statusEffectManager.getUnitActiveEffects(unitId);
+                    const isDisarmed = activeEffects?.has('status_disarmed');
+
+                    if (isDisarmed && attackerUnit && attackerUnit.type === ATTACK_TYPES.MERCENARY) {
+                        console.log(`[BattleCalculationManager] Unit '${unitId}' is disarmed and defeated by a mercenary ('${attackerUnit.name}'). Initiating capture animation.`);
+                        const vfxManager = this.getVFXManager();
+                        await vfxManager.startCaptureAnimation(attackerUnit, unitToUpdate);
+                        return;
+                    } else {
+                        this.eventManager.emit(GAME_EVENTS.UNIT_DEATH, { unitId: unitId, unitName: unitToUpdate.name, unitType: unitToUpdate.type });
+                        console.log(`[BattleCalculationManager] Unit '${unitId}' has died.`);
+                    }
+                }
 
                 if (barrierDamageDealt > 0) {
                     this.eventManager.emit(GAME_EVENTS.DISPLAY_DAMAGE, { unitId: unitId, damage: barrierDamageDealt, color: 'yellow' });
@@ -36,11 +56,6 @@ export class BattleCalculationManager {
                 }
                 if (hpDamageDealt > 0) {
                     this.eventManager.emit(GAME_EVENTS.DISPLAY_DAMAGE, { unitId: unitId, damage: hpDamageDealt, color: 'red' });
-                }
-
-                if (newHp <= 0) {
-                    this.eventManager.emit(GAME_EVENTS.UNIT_DEATH, { unitId: unitId, unitName: unitToUpdate.name, unitType: unitToUpdate.type });
-                    console.log(`[BattleCalculationManager] Unit '${unitId}' has died.`);
                 }
             } else {
                 console.warn(`[BattleCalculationManager] Could not find unit '${unitId}' to update HP.`);
@@ -65,8 +80,7 @@ export class BattleCalculationManager {
         console.log(`[BattleCalculationManager] Final damage roll from DiceRollManager: ${finalDamageRoll}`);
 
         const payload = {
-            attackerStats: attackerUnit.fullUnitData ? attackerUnit.fullUnitData.baseStats : attackerUnit.baseStats,
-            targetStats: targetUnit.fullUnitData ? targetUnit.fullUnitData.baseStats : targetUnit.baseStats,
+            attackerUnitId: attackerUnitId,
             attackerStats: attackerUnit.fullUnitData ? attackerUnit.fullUnitData.baseStats : attackerUnit.baseStats,
             targetStats: targetUnit.fullUnitData ? targetUnit.fullUnitData.baseStats : targetUnit.baseStats,
             currentTargetHp: targetUnit.currentHp,

--- a/js/managers/StatusEffectManager.js
+++ b/js/managers/StatusEffectManager.js
@@ -4,12 +4,12 @@ import { STATUS_EFFECTS } from '../../data/statusEffects.js';
 import { GAME_EVENTS, ATTACK_TYPES } from '../constants.js';
 
 export class StatusEffectManager {
-    constructor(eventManager, idManager, turnCountManager, battleCalculationManager) {
+    constructor(eventManager, idManager, turnCountManager, getBattleCalculationManager) {
         console.log("\u2728 StatusEffectManager initialized. Managing unit status effects. \u2728");
         this.eventManager = eventManager;
         this.idManager = idManager;
         this.turnCountManager = turnCountManager;
-        this.battleCalculationManager = battleCalculationManager;
+        this.getBattleCalculationManager = getBattleCalculationManager;
         this._setupEventListeners();
     }
 
@@ -28,7 +28,7 @@ export class StatusEffectManager {
                     if (effect.effectData.effect.damagePerTurn) {
                         const damage = effect.effectData.effect.damagePerTurn;
                         console.log(`[StatusEffectManager] Unit ${unitId} takes ${damage} poison damage from ${effect.effectData.name}.`);
-                        this.battleCalculationManager.requestDamageCalculation('statusEffectSource', unitId, {
+                        this.getBattleCalculationManager().requestDamageCalculation('statusEffectSource', unitId, {
                             type: ATTACK_TYPES.STATUS_EFFECT, // ✨ 상수 사용
                             damageAmount: damage,
                             isFixedDamage: true

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -14,6 +14,8 @@ export class VFXManager {
         this.eventManager = eventManager;
 
         this.activeDamageNumbers = [];
+        // ✨ 포획 애니메이션 관리
+        this.activeCaptureAnimations = new Map();
 
         // ✨ 무기 드롭 애니메이션 관리
         this.eventManager.subscribe(GAME_EVENTS.WEAPON_DROPPED, this._onWeaponDropped.bind(this));
@@ -117,6 +119,50 @@ export class VFXManager {
             totalDuration: this.measureManager.get('vfx.weaponDropTotalDuration')
         });
         console.log(`[VFXManager] Weapon drop animation data added for unit ${data.unitId}.`);
+    }
+
+    /**
+     * 무장해제된 유닛을 포획하는 애니메이션을 시작합니다.
+     * @param {object} attackerUnit - 포획하는 유닛 (전사)
+     * @param {object} targetUnit - 포획되는 유닛 (좀비)
+     * @returns {Promise<void>} 애니메이션 완료 시 resolve
+     */
+    async startCaptureAnimation(attackerUnit, targetUnit) {
+        console.log(`[VFXManager] Starting capture animation for ${attackerUnit.name} capturing ${targetUnit.name}.`);
+
+        const captureId = `capture_${attackerUnit.id}_${targetUnit.id}_${performance.now()}`;
+
+        this.activeCaptureAnimations.set(captureId, {
+            attackerUnit: attackerUnit,
+            targetUnit: targetUnit,
+            originalAttackerImage: attackerUnit.image,
+            captureAttackerImage: this.battleSimulationManager.assetLoaderManager.getImage('sprite_warrior_finish'),
+            currentOffset: 0,
+            singleMoveDuration: 100,
+            oscillationAmount: 5,
+            totalOscillations: 10
+        });
+
+        const captureAnim = this.activeCaptureAnimations.get(captureId);
+
+        for (let i = 0; i < captureAnim.totalOscillations * 2; i++) {
+            captureAnim.currentOffset = (i % 2 === 0) ? captureAnim.oscillationAmount : -captureAnim.oscillationAmount;
+            if (i === captureAnim.totalOscillations * 2 - 1) {
+                captureAnim.currentOffset = 0;
+            }
+            await new Promise(r => setTimeout(r, captureAnim.singleMoveDuration));
+        }
+
+        captureAnim.currentOffset = 0;
+        this.activeCaptureAnimations.delete(captureId);
+
+        const index = this.battleSimulationManager.unitsOnGrid.findIndex(u => u.id === targetUnit.id);
+        if (index !== -1) {
+            this.battleSimulationManager.unitsOnGrid.splice(index, 1);
+            console.log(`[VFXManager] Captured unit '${targetUnit.id}' removed from grid.`);
+        }
+
+        attackerUnit.image = captureAnim.originalAttackerImage;
     }
 
     /**
@@ -254,7 +300,58 @@ export class VFXManager {
         console.log(`[VFXManager Debug] Drawing VFX Parameters: \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}`);
         // ✨ DEBUG LOG END FOR VFXManager Drawing Parameters
 
+        const unitsToDrawNormally = new Set(this.battleSimulationManager.unitsOnGrid.map(u => u.id));
+
+        // 포획 애니메이션 그리기
+        for (const [captureId, captureAnim] of this.activeCaptureAnimations.entries()) {
+            const attackerUnit = captureAnim.attackerUnit;
+            const targetUnit = captureAnim.targetUnit;
+
+            unitsToDrawNormally.delete(attackerUnit.id);
+            unitsToDrawNormally.delete(targetUnit.id);
+
+            const targetRenderPos = this.animationManager.getRenderPosition(
+                targetUnit.id,
+                targetUnit.gridX,
+                targetUnit.gridY,
+                effectiveTileSize,
+                gridOffsetX,
+                gridOffsetY
+            );
+            const targetImageSize = effectiveTileSize;
+            const targetImgOffsetX = (effectiveTileSize - targetImageSize) / 2;
+            const targetImgOffsetY = (effectiveTileSize - targetImageSize) / 2;
+            if (targetUnit.image) {
+                ctx.drawImage(targetUnit.image, targetRenderPos.drawX + targetImgOffsetX, targetRenderPos.drawY + targetImgOffsetY, targetImageSize, targetImageSize);
+            }
+
+            const attackerRenderPos = this.animationManager.getRenderPosition(
+                attackerUnit.id,
+                attackerUnit.gridX,
+                attackerUnit.gridY,
+                effectiveTileSize,
+                gridOffsetX,
+                gridOffsetY
+            );
+            const attackerImageSize = effectiveTileSize;
+            const attackerImgOffsetX = (effectiveTileSize - attackerImageSize) / 2;
+            const attackerImgOffsetY = (effectiveTileSize - attackerImageSize) / 2;
+
+            if (captureAnim.captureAttackerImage) {
+                ctx.drawImage(
+                    captureAnim.captureAttackerImage,
+                    attackerRenderPos.drawX + attackerImgOffsetX + captureAnim.currentOffset,
+                    attackerRenderPos.drawY + attackerImgOffsetY,
+                    attackerImageSize,
+                    attackerImageSize
+                );
+            }
+        }
+
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
+            if (!unitsToDrawNormally.has(unit.id)) {
+                continue;
+            }
             // ✨ AnimationManager를 통해 현재 애니메이션이 적용된 위치를 조회합니다.
             const { drawX, drawY } = this.animationManager.getRenderPosition(
                 unit.id,

--- a/js/workers/battleCalculationWorker.js
+++ b/js/workers/battleCalculationWorker.js
@@ -6,7 +6,7 @@ self.onmessage = (event) => {
     switch (type) {
         case 'CALCULATE_DAMAGE': {
             // ✨ payload에서 대상 유닛의 배리어 정보를 가져옵니다.
-            const { attackerStats, targetStats, skillData, currentTargetHp, currentTargetBarrier, maxBarrier, preCalculatedDamageRoll } = payload;
+            const { attackerStats, targetStats, skillData, currentTargetHp, currentTargetBarrier, maxBarrier, preCalculatedDamageRoll, attackerUnitId } = payload;
 
             // 최종 적용될 데미지 (방어력 적용 후)
             let finalDamageToApply = preCalculatedDamageRoll - targetStats.defense;
@@ -35,10 +35,11 @@ self.onmessage = (event) => {
             self.postMessage({
                 type: 'DAMAGE_CALCULATED',
                 unitId: payload.targetUnitId,
+                attackerUnitId: attackerUnitId,
                 newHp: newHp,
-                newBarrier: newBarrier,          // ✨ 업데이트된 배리어 값 반환
-                hpDamageDealt: hpDamageDealt,    // ✨ HP로 들어간 데미지 반환
-                barrierDamageDealt: barrierDamageDealt // ✨ 배리어로 흡수된 데미지 반환
+                newBarrier: newBarrier,
+                hpDamageDealt: hpDamageDealt,
+                barrierDamageDealt: barrierDamageDealt
             });
             break;
         }


### PR DESCRIPTION
## Summary
- add ATTEMPT_UNIT_CAPTURE constant
- expose manager getters early in `GameEngine`
- load `warrior-finish.png` for capture animation
- extend `BattleCalculationManager` and worker to report attacker and trigger capture
- update `StatusEffectManager` to accept a getter
- add capture animation rendering in `VFXManager`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687517e413cc8327b821860597fc24dd