### PR TITLE
Fix integration test to use zombie unit ID

### DIFF
--- a/tests/integration/battleSimulationIntegrationTest.js
+++ b/tests/integration/battleSimulationIntegrationTest.js
@@ -19,7 +19,7 @@ export function runBattleSimulationIntegrationTest(gameEngine) {
 
     function setupTestState() {
         const warrior = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_warrior_001');
-        const skeleton = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_skeleton_001');
+        const skeleton = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_zombie_001'); // unit_skeleton_001을 unit_zombie_001로 변경
 
         if (warrior) {
             warrior.currentHp = warrior.baseStats.hp;
@@ -57,7 +57,7 @@ export function runBattleSimulationIntegrationTest(gameEngine) {
         let allTestsPassed = true;
 
         const warrior = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_warrior_001');
-        const skeleton = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_skeleton_001');
+        const skeleton = battleSimulationManager.unitsOnGrid.find(u => u.id === 'unit_zombie_001'); // unit_skeleton_001을 unit_zombie_001로 변경
 
         testCount++;
         const warriorTookDamage = warrior && (warrior.currentHp < initialWarriorHp || warrior.currentBarrier < initialWarriorBarrier);


### PR DESCRIPTION
## Summary
- adjust battleSimulationIntegrationTest to look for `unit_zombie_001` instead of the old skeleton id

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68751c28ed3083278c70b32f1d04c112