### PR TITLE
Fix battle end timing for capture animation

### DIFF
--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -53,7 +53,8 @@ export class TurnEngine {
 
     async nextTurn() {
         const livingMercenaries = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === ATTACK_TYPES.MERCENARY && u.currentHp > 0); // ✨ 상수 사용
-        const livingEnemies = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === ATTACK_TYPES.ENEMY && u.currentHp > 0); // ✨ 상수 사용
+        // 포획 애니메이션을 보기 위해 HP가 0이 된 좀비도 전장에 남아 있는 동안은 전투가 지속되도록 합니다
+        const enemiesOnField = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === ATTACK_TYPES.ENEMY); // ✨ 상수 사용
 
         if (livingMercenaries.length === 0) {
             console.log("[TurnEngine] All mercenaries defeated! Battle Over.");
@@ -61,8 +62,8 @@ export class TurnEngine {
             this.eventManager.setGameRunningState(false);
             return;
         }
-        if (livingEnemies.length === 0) {
-            console.log("[TurnEngine] All enemies defeated! Battle Over.");
+        if (enemiesOnField.length === 0) {
+            console.log("[TurnEngine] All enemies defeated or captured! Battle Over.");
             this.eventManager.emit(GAME_EVENTS.BATTLE_END, { reason: 'allEnemiesDefeated' }); // ✨ 상수 사용
             this.eventManager.setGameRunningState(false);
             return;


### PR DESCRIPTION
## Summary
- prevent battle from ending while defeated zombies are still on the field
- allow capture animation to finish before emitting `BATTLE_END`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68751f5147088327bc0f64b346f62a93