### PR TITLE
Add particle effects engine

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -17,6 +17,7 @@ import { AssetLoaderManager } from './managers/AssetLoaderManager.js';
 import { BattleSimulationManager } from './managers/BattleSimulationManager.js';
 import { AnimationManager } from './managers/AnimationManager.js';
 import { VFXManager } from './managers/VFXManager.js';
+import { ParticleEngine } from './managers/ParticleEngine.js'; // ✨ ParticleEngine 임포트
 import { DisarmManager } from './managers/DisarmManager.js'; // ✨ DisarmManager 임포트
 import { CanvasBridgeManager } from './managers/CanvasBridgeManager.js'; // ✨ CanvasBridgeManager 추가
 import { BindingManager } from './managers/BindingManager.js';
@@ -236,6 +237,16 @@ export class GameEngine {
             this.statusEffectManager
         );
 
+        // ✨ ParticleEngine 초기화 (VFXManager보다 먼저)
+        this.particleEngine = new ParticleEngine(
+            this.measureManager,
+            this.cameraEngine,
+            this.battleSimulationManager
+        );
+
+        // VFXManager에 ParticleEngine 전달
+        this.vfxManager.particleEngine = this.particleEngine;
+
         // ✨ sceneEngine에 UI_STATES 상수 사용
         this.sceneEngine.registerScene(UI_STATES.MAP_SCREEN, [this.territoryManager]);
         this.sceneEngine.registerScene(UI_STATES.COMBAT_SCREEN, [
@@ -387,6 +398,9 @@ export class GameEngine {
         this.sceneEngine.update(deltaTime);
         this.animationManager.update(deltaTime);
         this.vfxManager.update(deltaTime);
+        if (this.particleEngine) {
+            this.particleEngine.update(deltaTime); // ✨ ParticleEngine 업데이트 호출
+        }
     }
 
     _draw() {
@@ -441,6 +455,7 @@ export class GameEngine {
     getStatusEffectManager() { return this.statusEffectManager; }
     getWorkflowManager() { return this.workflowManager; }
     getDisarmManager() { return this.disarmManager; }
+    getParticleEngine() { return this.particleEngine; } // ✨ ParticleEngine getter 추가
 
     getButtonEngine() { return this.buttonEngine; }
 

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -76,6 +76,14 @@ export class MeasureManager {
                 weaponDropFadeDuration: 500,    // 무기 사라지는 시간 (ms)
                 weaponDropTotalDuration: 1300   // 무기 애니메이션 총 지속 시간 (ms)
             },
+            // ✨ 파티클 효과 관련 설정 추가
+            particle: {
+                baseSize: 4,      // 파티클 기본 크기 (픽셀)
+                count: 10,        // 생성될 파티클 개수
+                duration: 500,    // 파티클 지속 시간 (ms)
+                speedY: 2,        // 파티클 수직 이동 속도 (픽셀/프레임)
+                spread: 10        // 파티클 분산 범위 (x축)
+            },
             // ✨ 새로운 게임 설정 섹션
             gameConfig: {
                 enableDisarmSystem: true // 무장해제 시스템 활성화 여부

--- a/js/managers/ParticleEngine.js
+++ b/js/managers/ParticleEngine.js
@@ -1,0 +1,110 @@
+// js/managers/ParticleEngine.js
+
+export class ParticleEngine {
+    constructor(measureManager, cameraEngine, battleSimulationManager) {
+        console.log("\u2728 ParticleEngine initialized. Ready to create visual sparks. \u2728");
+        this.measureManager = measureManager;
+        this.cameraEngine = cameraEngine;
+        this.battleSimulationManager = battleSimulationManager; // 유닛 위치 정보를 얻기 위함
+
+        this.activeParticles = [];
+    }
+
+    /**
+     * 특정 유닛의 위치에서 파티클을 생성하여 추가합니다.
+     * @param {string} unitId - 파티클을 생성할 유닛의 ID
+     * @param {string} color - 파티클의 색상 (예: 'red')
+     */
+    addParticles(unitId, color) {
+        const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+        if (!unit) {
+            console.warn(`[ParticleEngine] Cannot add particles for unknown unit: ${unitId}`);
+            return;
+        }
+
+        const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions();
+        const canvasWidth = this.measureManager.get('gameResolution.width');
+        const canvasHeight = this.measureManager.get('gameResolution.height');
+
+        const gridContentWidth = sceneContentDimensions.width;
+        const gridContentHeight = sceneContentDimensions.height;
+        const effectiveTileSize = gridContentWidth / this.battleSimulationManager.gridCols;
+
+        const totalGridWidth = gridContentWidth;
+        const totalGridHeight = gridContentHeight;
+        const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
+        const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
+
+        const baseParticleSize = this.measureManager.get('particle.baseSize');
+        const particleCount = this.measureManager.get('particle.count');
+        const particleDuration = this.measureManager.get('particle.duration');
+        const particleSpeedY = this.measureManager.get('particle.speedY');
+        const particleSpread = this.measureManager.get('particle.spread');
+
+        for (let i = 0; i < particleCount; i++) {
+            const startX = gridOffsetX + unit.gridX * effectiveTileSize + effectiveTileSize / 2;
+            const startY = gridOffsetY + unit.gridY * effectiveTileSize + effectiveTileSize / 2;
+
+            const particle = {
+                x: startX + (Math.random() * particleSpread - particleSpread / 2),
+                y: startY,
+                size: baseParticleSize * (0.8 + Math.random() * 0.4), // 크기 변화
+                color: color,
+                speedX: (Math.random() - 0.5) * 2, // -1에서 1 사이의 랜덤 값
+                speedY: particleSpeedY * (0.8 + Math.random() * 0.4), // 위로 솟구치는 속도
+                alpha: 1,
+                startTime: performance.now(),
+                duration: particleDuration,
+                initialY: startY // 초기 y 위치 저장 (재계산을 위해)
+            };
+            this.activeParticles.push(particle);
+        }
+        console.log(`[ParticleEngine] Added ${particleCount} particles for unit ${unitId}.`);
+    }
+
+    /**
+     * 모든 활성 파티클의 상태를 업데이트합니다.
+     * @param {number} deltaTime - 지난 프레임과의 시간 차이 (ms)
+     */
+    update(deltaTime) {
+        const currentTime = performance.now();
+        this.activeParticles = this.activeParticles.filter(particle => {
+            const elapsed = currentTime - particle.startTime;
+            if (elapsed > particle.duration) {
+                return false; // 파티클 수명 만료
+            }
+
+            // 위치 업데이트
+            particle.x += particle.speedX * (deltaTime / 16); // 16ms를 기준으로 속도 조정
+            particle.y -= particle.speedY * (deltaTime / 16);
+
+            // 투명도 업데이트 (점점 사라지게)
+            particle.alpha = Math.max(0, 1 - (elapsed / particle.duration));
+            return true;
+        });
+    }
+
+    /**
+     * 모든 활성 파티클을 그립니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
+     */
+    draw(ctx) {
+        ctx.save();
+        // CameraEngine 변환은 LayerEngine에서 이미 적용될 것이므로 여기서 다시 적용하지 않습니다.
+        // 파티클은 배경 레이어 위에 그려지므로, 카메라 변환을 따라야 합니다.
+
+        for (const particle of this.activeParticles) {
+            ctx.globalAlpha = particle.alpha;
+            ctx.fillStyle = particle.color;
+
+            // 파티클은 사각형으로 그립니다.
+            ctx.fillRect(
+                particle.x - particle.size / 2,
+                particle.y - particle.size / 2,
+                particle.size,
+                particle.size
+            );
+        }
+        ctx.restore();
+    }
+}

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -4,7 +4,7 @@ import { GAME_EVENTS } from '../constants.js';
 
 export class VFXManager {
     // animationManager를 추가로 받아 유닛의 애니메이션 위치를 참조합니다.
-    constructor(renderer, measureManager, cameraEngine, battleSimulationManager, animationManager, eventManager) {
+    constructor(renderer, measureManager, cameraEngine, battleSimulationManager, animationManager, eventManager, particleEngine = null) { // ✨ particleEngine 추가
         console.log("\u2728 VFXManager initialized. Ready to render visual effects. \u2728");
         this.renderer = renderer;
         this.measureManager = measureManager;
@@ -12,6 +12,7 @@ export class VFXManager {
         this.battleSimulationManager = battleSimulationManager; // 유닛 데이터를 가져오기 위함
         this.animationManager = animationManager; // ✨ AnimationManager 저장
         this.eventManager = eventManager;
+        this.particleEngine = particleEngine; // ✨ ParticleEngine 저장
 
         this.activeDamageNumbers = [];
 
@@ -23,6 +24,10 @@ export class VFXManager {
         // ✨ subscribe to damage display events
         this.eventManager.subscribe(GAME_EVENTS.DISPLAY_DAMAGE, (data) => {
             this.addDamageNumber(data.unitId, data.damage, data.color);
+            // 피해를 입었을 때 파티클 생성
+            if (this.particleEngine && data.damage > 0) {
+                this.particleEngine.addParticles(data.unitId, 'red'); // 붉은색 파티클
+            }
         });
     }
 
@@ -317,6 +322,10 @@ export class VFXManager {
             ctx.globalAlpha = drop.opacity;
             ctx.drawImage(drop.sprite, drop.startX, drop.currentY, weaponSize, weaponSize);
             ctx.restore();
+        }
+        // ✨ 파티클 그리기 호출
+        if (this.particleEngine) {
+            this.particleEngine.draw(ctx);
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement `ParticleEngine` to render simple particles above damaged units
- expose particle parameters in `MeasureManager`
- update `VFXManager` to trigger and draw particles
- integrate `ParticleEngine` into `GameEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6875346922048327995a6549ed71362a