### PR TITLE
Implement TargetingManager module with tests

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -101,7 +101,7 @@
         <button id="runStatusEffectManagerUnitTestsBtn">StatusEffectManager 유닛 테스트</button>
         <button id="runWorkflowManagerUnitTestsBtn">WorkflowManager 유닛 테스트</button>
         <button id="runDisarmManagerUnitTestsBtn">DisarmManager 유닛 테스트</button>
-        <button id="runCoordinateManagerUnitTestsBtn">CoordinateManager 유닛 테스트</button>
+        <button id="runCoordinateManagerUnitTestsBtn">CoordinateManager 유닛 테스트</button> <button id="runTargetingManagerUnitTestsBtn">TargetingManager 유닛 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -374,6 +374,10 @@
             // ✨ CoordinateManager 단위 테스트 버튼 리스너 추가
             document.getElementById('runCoordinateManagerUnitTestsBtn').addEventListener('click', () => {
                 runCoordinateManagerUnitTests(battleSimulationManager, gameEngine.getBattleGridManager());
+            });
+            // ✨ TargetingManager 단위 테스트 버튼 리스너 추가
+            document.getElementById('runTargetingManagerUnitTestsBtn').addEventListener('click', () => {
+                runTargetingManagerUnitTests(battleSimulationManager);
             });
 
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -33,6 +33,7 @@ import { BattleLogManager } from './managers/BattleLogManager.js'; // ✨ 새롭
 import { TurnOrderManager } from './managers/TurnOrderManager.js'; // ✨ 새롭게 추가
 import { ClassAIManager } from './managers/ClassAIManager.js';   // ✨ 새롭게 추가
 import { BasicAIManager } from './managers/BasicAIManager.js'; // ✨ 새롭게 추가
+import { TargetingManager } from './managers/TargetingManager.js'; // ✨ TargetingManager 추가
 import { ValorEngine } from './managers/ValorEngine.js';   // ✨ ValorEngine 추가
 import { WeightEngine } from './managers/WeightEngine.js'; // ✨ WeightEngine 추가
 import { StatManager } from './managers/StatManager.js'; // ✨ StatManager 추가
@@ -226,6 +227,8 @@ export class GameEngine {
             this.weightEngine // ✨ weightEngine 추가
         );
         this.classAIManager = new ClassAIManager(this.idManager, this.battleSimulationManager, this.measureManager, this.basicAIManager);
+        // ✨ TargetingManager 초기화
+        this.targetingManager = new TargetingManager(this.battleSimulationManager); // BattleSimulationManager를 의존성으로 전달
 
         // ✨ TurnEngine에 새로운 의존성 전달
         this.turnEngine = new TurnEngine(
@@ -474,4 +477,6 @@ export class GameEngine {
     getDiceBotManager() { return this.diceBotManager; }
     // ✨ CoordinateManager getter 추가
     getCoordinateManager() { return this.coordinateManager; }
+    // ✨ TargetingManager getter 추가
+    getTargetingManager() { return this.targetingManager; }
 }

--- a/js/managers/TargetingManager.js
+++ b/js/managers/TargetingManager.js
@@ -1,0 +1,116 @@
+// js/managers/TargetingManager.js
+
+import { ATTACK_TYPES } from '../constants.js'; // ATTACK_TYPES 상수를 활용
+
+export class TargetingManager {
+    /**
+     * TargetingManager를 초기화합니다.
+     * @param {BattleSimulationManager} battleSimulationManager - 유닛 데이터를 가져오기 위한 BattleSimulationManager 인스턴스
+     */
+    constructor(battleSimulationManager) {
+        console.log("\uD83C\uDFC6 TargetingManager initialized. Ready to scout for specific units. \uD83C\uDFC6");
+        this.battleSimulationManager = battleSimulationManager;
+    }
+
+    /**
+     * 현재 전장에 있는 유닛들 중에서 특정 조건에 맞는 유닛들을 필터링합니다.
+     * @param {function(object): boolean} conditionFn - 각 유닛에 대해 실행될 조건 함수. true를 반환하면 포함됩니다.
+     * @param {string | null} [typeFilter=null] - 필터링할 유닛 타입 (예: ATTACK_TYPES.ENEMY, ATTACK_TYPES.MERCENARY). null이면 모든 타입을 포함합니다.
+     * @returns {object[]} 조건에 맞는 유닛들의 배열
+     */
+    getUnitsByCondition(conditionFn, typeFilter = null) {
+        const matchingUnits = [];
+        for (const unit of this.battleSimulationManager.unitsOnGrid) {
+            if (unit.currentHp <= 0) continue; // 죽은 유닛은 제외
+
+            if (typeFilter && unit.type !== typeFilter) {
+                continue; // 타입 필터가 있고 일치하지 않으면 건너뛰기
+            }
+
+            if (conditionFn(unit)) {
+                matchingUnits.push(unit);
+            }
+        }
+        console.log(`[TargetingManager] Found ${matchingUnits.length} units matching condition (Type filter: ${typeFilter || 'none'}).`);
+        return matchingUnits;
+    }
+
+    /**
+     * 특정 타입의 유닛 중 현재 체력이 가장 낮은 유닛을 찾습니다.
+     * @param {string | null} [typeFilter=null] - 필터링할 유닛 타입 (예: ATTACK_TYPES.ENEMY, ATTACK_TYPES.MERCENARY)
+     * @returns {object | null} 체력이 가장 낮은 유닛 또는 찾을 수 없는 경우 null
+     */
+    getLowestHpUnit(typeFilter = null) {
+        let lowestHpUnit = null;
+        let minHp = Infinity;
+
+        this.getUnitsByCondition(unit => {
+            if (unit.currentHp < minHp) {
+                minHp = unit.currentHp;
+                lowestHpUnit = unit;
+            }
+            return false; // 모든 유닛을 순회하며 비교만 하므로 항상 false 반환
+        }, typeFilter);
+
+        if (lowestHpUnit) {
+            console.log(`[TargetingManager] Lowest HP unit (${typeFilter || 'any'}): ${lowestHpUnit.name} (${lowestHpUnit.currentHp} HP).`);
+        } else {
+            console.log(`[TargetingManager] No lowest HP unit found for type '${typeFilter || 'any'}'.`);
+        }
+        return lowestHpUnit;
+    }
+
+    /**
+     * 특정 타입의 유닛 중 기본 공격력이 가장 높은 유닛을 찾습니다.
+     * (참고: 현재 '피해량'은 누적된 값이 없으므로, '기본 공격 스탯' 기준으로 색적합니다.)
+     * @param {string | null} [typeFilter=null] - 필터링할 유닛 타입
+     * @returns {object | null} 공격력이 가장 높은 유닛 또는 찾을 수 없는 경우 null
+     */
+    getHighestAttackUnit(typeFilter = null) {
+        let highestAttackUnit = null;
+        let maxAttack = -1;
+
+        this.getUnitsByCondition(unit => {
+            const attackStat = unit.baseStats ? unit.baseStats.attack || 0 : 0;
+            if (attackStat > maxAttack) {
+                maxAttack = attackStat;
+                highestAttackUnit = unit;
+            }
+            return false;
+        }, typeFilter);
+
+        if (highestAttackUnit) {
+            console.log(`[TargetingManager] Highest Attack unit (${typeFilter || 'any'}): ${highestAttackUnit.name} (${highestAttackUnit.baseStats.attack} Attack).`);
+        } else {
+            console.log(`[TargetingManager] No highest Attack unit found for type '${typeFilter || 'any'}'.`);
+        }
+        return highestAttackUnit;
+    }
+
+    /**
+     * 특정 타입의 유닛 중 기본 마법 공격력이 가장 높은 유닛을 찾습니다.
+     * @param {string | null} [typeFilter=null] - 필터링할 유닛 타입
+     * @returns {object | null} 마법 공격력이 가장 높은 유닛 또는 찾을 수 없는 경우 null
+     */
+    getHighestMagicUnit(typeFilter = null) {
+        let highestMagicUnit = null;
+        let maxMagic = -1;
+
+        this.getUnitsByCondition(unit => {
+            const magicStat = unit.baseStats ? unit.baseStats.magic || 0 : 0;
+            if (magicStat > maxMagic) {
+                maxMagic = magicStat;
+                highestMagicUnit = unit;
+            }
+            return false;
+        }, typeFilter);
+
+        if (highestMagicUnit) {
+            console.log(`[TargetingManager] Highest Magic unit (${typeFilter || 'any'}): ${highestMagicUnit.name} (${highestMagicUnit.baseStats.magic} Magic).`);
+        } else {
+            console.log(`[TargetingManager] No highest Magic unit found for type '${typeFilter || 'any'}'.`);
+        }
+        return highestMagicUnit;
+    }
+}
+

--- a/tests/index.js
+++ b/tests/index.js
@@ -42,6 +42,7 @@ export { runStatusEffectManagerUnitTests } from './unit/statusEffectManagerUnitT
 export { runWorkflowManagerUnitTests } from './unit/workflowManagerUnitTests.js';
 export { runDisarmManagerUnitTests } from './unit/disarmManagerUnitTests.js';
 export { runCoordinateManagerUnitTests } from './unit/coordinateManagerUnitTests.js';
+export { runTargetingManagerUnitTests } from './unit/targetingManagerUnitTests.js'; // ✨ TargetingManager 단위 테스트 추가
 
 export { runMeasureManagerIntegrationTest } from './integration/measureManagerIntegrationTests.js';
 export { runBattleSimulationIntegrationTest } from './integration/battleSimulationIntegrationTest.js';
@@ -54,7 +55,15 @@ export { injectSceneEngineFaults } from './fault_injection/sceneEngineFaults.js'
 export { injectLogicManagerFaults } from './fault_injection/logicManagerFaults.js';
 export { injectCompatibilityManagerFaults } from './fault_injection/compatibilityManagerFaults.js';
 
-export function runEngineTests(renderer, gameLoop) {
+export function runEngineTests(renderer, gameLoop, battleSimulationManager = null, battleGridManager = null) {
     runRendererTests(renderer);
     runGameLoopTests(gameLoop);
+    // 이전 요청에 의해 추가된 코드
+    if (battleSimulationManager && battleGridManager) {
+        runCoordinateManagerUnitTests(battleSimulationManager, battleGridManager);
+    }
+    // ✨ TargetingManager 단위 테스트 추가
+    if (battleSimulationManager) {
+        runTargetingManagerUnitTests(battleSimulationManager);
+    }
 }

--- a/tests/unit/targetingManagerUnitTests.js
+++ b/tests/unit/targetingManagerUnitTests.js
@@ -1,0 +1,198 @@
+// tests/unit/targetingManagerUnitTests.js
+
+import { TargetingManager } from '../../js/managers/TargetingManager.js';
+import { ATTACK_TYPES } from '../../js/constants.js';
+
+export function runTargetingManagerUnitTests(battleSimulationManager) {
+    console.log("--- TargetingManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // 테스트를 위한 Mock 유닛 데이터
+    const mockUnits = [
+        { id: 'hero1', name: 'Tank', type: ATTACK_TYPES.MERCENARY, currentHp: 50, baseStats: { hp: 100, attack: 10, magic: 5 } },
+        { id: 'hero2', name: 'DPS', type: ATTACK_TYPES.MERCENARY, currentHp: 20, baseStats: { hp: 80, attack: 30, magic: 0 } },
+        { id: 'hero3', name: 'Healer', type: ATTACK_TYPES.MERCENARY, currentHp: 80, baseStats: { hp: 90, attack: 5, magic: 25 } },
+        { id: 'enemy1', name: 'Bruiser', type: ATTACK_TYPES.ENEMY, currentHp: 30, baseStats: { hp: 60, attack: 25, magic: 0 } },
+        { id: 'enemy2', name: 'Caster', type: ATTACK_TYPES.ENEMY, currentHp: 10, baseStats: { hp: 40, attack: 5, magic: 40 } },
+        { id: 'enemy3_dead', name: 'Dead', type: ATTACK_TYPES.ENEMY, currentHp: 0, baseStats: { hp: 10, attack: 1, magic: 1 } },
+    ];
+
+    // Mock BattleSimulationManager (테스트마다 초기화)
+    const mockBattleSimulationManager = {
+        unitsOnGrid: []
+    };
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = []; // 초기화
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        if (tm.battleSimulationManager === mockBattleSimulationManager) {
+            console.log("TargetingManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: getUnitsByCondition - 체력 50 이하인 모든 유닛
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [...mockUnits];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const lowHpUnits = tm.getUnitsByCondition(unit => unit.currentHp <= 50);
+        const lowHpUnitIds = lowHpUnits.map(u => u.id).sort();
+        // hero1 (50), hero2 (20), enemy1 (30), enemy2 (10)
+        if (lowHpUnitIds.length === 4 && lowHpUnitIds.includes('hero1') && lowHpUnitIds.includes('hero2') && lowHpUnitIds.includes('enemy1') && lowHpUnitIds.includes('enemy2')) {
+            console.log("TargetingManager: getUnitsByCondition found correct low HP units. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getUnitsByCondition failed for low HP units. [FAIL]", lowHpUnitIds);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getUnitsByCondition test. [FAIL]", e);
+    }
+
+    // 테스트 3: getUnitsByCondition - 적군 중 마법 공격력 20 이상인 유닛
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [...mockUnits];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const highMagicEnemies = tm.getUnitsByCondition(unit => unit.baseStats.magic >= 20, ATTACK_TYPES.ENEMY);
+        const highMagicEnemyIds = highMagicEnemies.map(u => u.id).sort();
+        // enemy2 (40)
+        if (highMagicEnemyIds.length === 1 && highMagicEnemyIds.includes('enemy2')) {
+            console.log("TargetingManager: getUnitsByCondition found correct high magic enemies. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getUnitsByCondition failed for high magic enemies. [FAIL]", highMagicEnemyIds);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getUnitsByCondition (filtered) test. [FAIL]", e);
+    }
+
+    // 테스트 4: getLowestHpUnit - 아군 중 가장 체력이 낮은 유닛
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [...mockUnits];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const lowestHpAlly = tm.getLowestHpUnit(ATTACK_TYPES.MERCENARY);
+        // hero1 (50), hero2 (20), hero3 (80) -> hero2
+        if (lowestHpAlly && lowestHpAlly.id === 'hero2') {
+            console.log("TargetingManager: getLowestHpUnit found correct lowest HP ally. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getLowestHpUnit failed for lowest HP ally. [FAIL]", lowestHpAlly);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getLowestHpUnit (ally) test. [FAIL]", e);
+    }
+
+    // 테스트 5: getLowestHpUnit - 적군 중 가장 체력이 낮은 유닛
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [...mockUnits];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const lowestHpEnemy = tm.getLowestHpUnit(ATTACK_TYPES.ENEMY);
+        // enemy1 (30), enemy2 (10) -> enemy2
+        if (lowestHpEnemy && lowestHpEnemy.id === 'enemy2') {
+            console.log("TargetingManager: getLowestHpUnit found correct lowest HP enemy. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getLowestHpUnit failed for lowest HP enemy. [FAIL]", lowestHpEnemy);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getLowestHpUnit (enemy) test. [FAIL]", e);
+    }
+
+    // 테스트 6: getLowestHpUnit - 유닛이 없을 때
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const noUnit = tm.getLowestHpUnit(ATTACK_TYPES.MERCENARY);
+        if (noUnit === null) {
+            console.log("TargetingManager: getLowestHpUnit returned null for no units. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getLowestHpUnit failed for no units. [FAIL]", noUnit);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getLowestHpUnit (no units) test. [FAIL]", e);
+    }
+
+    // 테스트 7: getHighestAttackUnit - 아군 중 가장 공격력이 높은 유닛
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [...mockUnits];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const highestAttackAlly = tm.getHighestAttackUnit(ATTACK_TYPES.MERCENARY);
+        // hero1 (10), hero2 (30), hero3 (5) -> hero2
+        if (highestAttackAlly && highestAttackAlly.id === 'hero2') {
+            console.log("TargetingManager: getHighestAttackUnit found correct highest attack ally. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getHighestAttackUnit failed for highest attack ally. [FAIL]", highestAttackAlly);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getHighestAttackUnit (ally) test. [FAIL]", e);
+    }
+
+    // 테스트 8: getHighestAttackUnit - 적군 중 가장 공격력이 높은 유닛
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [...mockUnits];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const highestAttackEnemy = tm.getHighestAttackUnit(ATTACK_TYPES.ENEMY);
+        // enemy1 (25), enemy2 (5) -> enemy1
+        if (highestAttackEnemy && highestAttackEnemy.id === 'enemy1') {
+            console.log("TargetingManager: getHighestAttackUnit found correct highest attack enemy. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getHighestAttackUnit failed for highest attack enemy. [FAIL]", highestAttackEnemy);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getHighestAttackUnit (enemy) test. [FAIL]", e);
+    }
+
+    // 테스트 9: getHighestMagicUnit - 아군 중 가장 마법 공격력이 높은 유닛
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [...mockUnits];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const highestMagicAlly = tm.getHighestMagicUnit(ATTACK_TYPES.MERCENARY);
+        // hero1 (5), hero2 (0), hero3 (25) -> hero3
+        if (highestMagicAlly && highestMagicAlly.id === 'hero3') {
+            console.log("TargetingManager: getHighestMagicUnit found correct highest magic ally. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getHighestMagicUnit failed for highest magic ally. [FAIL]", highestMagicAlly);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getHighestMagicUnit (ally) test. [FAIL]", e);
+    }
+
+    // 테스트 10: getHighestMagicUnit - 적군 중 가장 마법 공격력이 높은 유닛
+    testCount++;
+    try {
+        mockBattleSimulationManager.unitsOnGrid = [...mockUnits];
+        const tm = new TargetingManager(mockBattleSimulationManager);
+        const highestMagicEnemy = tm.getHighestMagicUnit(ATTACK_TYPES.ENEMY);
+        // enemy1 (0), enemy2 (40) -> enemy2
+        if (highestMagicEnemy && highestMagicEnemy.id === 'enemy2') {
+            console.log("TargetingManager: getHighestMagicUnit found correct highest magic enemy. [PASS]");
+            passCount++;
+        } else {
+            console.error("TargetingManager: getHighestMagicUnit failed for highest magic enemy. [FAIL]", highestMagicEnemy);
+        }
+    } catch (e) {
+        console.error("TargetingManager: Error during getHighestMagicUnit (enemy) test. [FAIL]", e);
+    }
+
+    console.log(`--- TargetingManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}
+


### PR DESCRIPTION
## Summary
- add `TargetingManager` for unit selection and filtering
- integrate `TargetingManager` into `GameEngine`
- expose helper in `tests/index.js` and extend `runEngineTests`
- provide unit tests for `TargetingManager`
- update debug interface with button to run these tests

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687772c8f90883278c42d582668e0c1b