### PR TITLE
Add SynergyEngine and integration

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -101,7 +101,7 @@
         <button id="runStatusEffectManagerUnitTestsBtn">StatusEffectManager 유닛 테스트</button>
         <button id="runWorkflowManagerUnitTestsBtn">WorkflowManager 유닛 테스트</button>
         <button id="runDisarmManagerUnitTestsBtn">DisarmManager 유닛 테스트</button>
-        <button id="runCoordinateManagerUnitTestsBtn">CoordinateManager 유닛 테스트</button> <button id="runTargetingManagerUnitTestsBtn">TargetingManager 유닛 테스트</button> <button id="runHeroEngineUnitTestsBtn">HeroEngine 유닛 테스트</button>
+        <button id="runCoordinateManagerUnitTestsBtn">CoordinateManager 유닛 테스트</button> <button id="runTargetingManagerUnitTestsBtn">TargetingManager 유닛 테스트</button> <button id="runHeroEngineUnitTestsBtn">HeroEngine 유닛 테스트</button> <button id="runSynergyEngineUnitTestsBtn">SynergyEngine 유닛 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -183,7 +183,8 @@
             runWorkflowManagerUnitTests,
             runDisarmManagerUnitTests,
             runCoordinateManagerUnitTests,
-            runHeroEngineUnitTests
+            runHeroEngineUnitTests,
+            runSynergyEngineUnitTests
     } from './tests/index.js';
     import { STATUS_EFFECTS } from './data/statusEffects.js';
     // ✨ 상수 파일 임포트
@@ -259,7 +260,7 @@
             // --- 버튼 이벤트 리스너 설정 ---
             document.getElementById('runAllEngineTestsBtn').addEventListener('click', () => {
                 // gameLoop는 gameEngine 내부에 있으므로 gameEngine.gameLoop로 전달 (혹은 getter)
-                runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceBotManager);
+                runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceBotManager, eventManager);
                 runEventManagerTests(eventManager);
                 runGuardianManagerTests(guardianManager);
                 runMeasureManagerIntegrationTest(gameEngine);
@@ -383,6 +384,10 @@
 
             document.getElementById("runHeroEngineUnitTestsBtn").addEventListener("click", () => {
                 runHeroEngineUnitTests(idManager, gameEngine.getAssetLoaderManager(), diceBotManager);
+            });
+            // ✨ SynergyEngine 단위 테스트 버튼 리스너 추가
+            document.getElementById('runSynergyEngineUnitTestsBtn').addEventListener('click', () => {
+                runSynergyEngineUnitTests(idManager, eventManager);
             });
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
                 injectRendererFault(renderer);
@@ -539,7 +544,7 @@
             };
 
             // 페이지 로드 시 기본 엔진 테스트 자동 실행
-            runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceBotManager);
+            runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceBotManager, eventManager);
             runEventManagerTests(eventManager); // EventManager 테스트도 자동 실행
             runGuardianManagerTests(guardianManager); // GuardianManager 테스트도 자동 실행
             runMeasureManagerIntegrationTest(gameEngine); // MeasureManager 통합 테스트도 자동 실행

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -44,6 +44,7 @@ import { TurnCountManager } from './managers/TurnCountManager.js';
 import { StatusEffectManager } from './managers/StatusEffectManager.js';
 import { WorkflowManager } from './managers/WorkflowManager.js';
 import { HeroEngine } from "./managers/HeroEngine.js"; // HeroEngine 추가
+import { SynergyEngine } from './managers/SynergyEngine.js'; // ✨ SynergyEngine 추가
 import { STATUS_EFFECTS } from '../data/statusEffects.js';
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
@@ -190,6 +191,9 @@ export class GameEngine {
 
         // HeroEngine 초기화
         this.heroEngine = new HeroEngine(this.idManager, this.assetLoaderManager, this.diceBotManager);
+
+        // ✨ SynergyEngine 초기화
+        this.synergyEngine = new SynergyEngine(this.idManager, this.eventManager);
         // BattleCalculationManager는 DiceRollManager가 준비된 이후에 초기화합니다.
         this.battleCalculationManager = new BattleCalculationManager(
             this.eventManager,
@@ -478,6 +482,8 @@ export class GameEngine {
     getDiceEngine() { return this.diceEngine; }
     getDiceRollManager() { return this.diceRollManager; }
     getHeroEngine() { return this.heroEngine; }
+    // ✨ SynergyEngine getter 추가
+    getSynergyEngine() { return this.synergyEngine; }
     getDiceBotManager() { return this.diceBotManager; }
     // ✨ CoordinateManager getter 추가
     getCoordinateManager() { return this.coordinateManager; }

--- a/js/constants.js
+++ b/js/constants.js
@@ -18,7 +18,9 @@ export const GAME_EVENTS = {
     DRAG_START: 'dragStart',
     DRAG_MOVE: 'dragMove',
     DROP: 'drop',
-    DRAG_CANCEL: 'dragCancel'
+    DRAG_CANCEL: 'dragCancel',
+    SYNERGY_ACTIVATED: 'synergyActivated',
+    SYNERGY_DEACTIVATED: 'synergyDeactivated'
 };
 
 export const UI_STATES = {

--- a/js/managers/HeroEngine.js
+++ b/js/managers/HeroEngine.js
@@ -95,7 +95,20 @@ export class HeroEngine {
         // 4. 랜덤한 특성 부여 (임시 특성 ID 사용)
         const traits = [`trait_${this.diceBotManager.getRandomInt(1, 3)}`];
 
-        // 5. 장비 아이템 및 퍽 (초기에는 비어있음)
+        // ✨ 5. 랜덤한 2~3개의 시너지 부여
+        const allPossibleSynergies = ['synergy_warrior', 'synergy_mage', 'synergy_healer', 'synergy_archer'];
+        const numSynergies = this.diceBotManager.getRandomInt(2, 3);
+        const assignedSynergies = [];
+        while (assignedSynergies.length < numSynergies) {
+            const randomIndex = this.diceBotManager.getRandomInt(0, allPossibleSynergies.length - 1);
+            const selectedSynergy = allPossibleSynergies[randomIndex];
+            if (!assignedSynergies.includes(selectedSynergy)) {
+                assignedSynergies.push(selectedSynergy);
+            }
+        }
+        const synergies = assignedSynergies;
+
+        // 6. 장비 아이템 및 퍽 (초기에는 비어있음)
         const equippedItems = [];
         const perks = [];
 
@@ -108,6 +121,7 @@ export class HeroEngine {
             baseStats: baseStats,
             skills: skills,
             traits: traits,
+            synergies: synergies, // ✨ 영웅 시너지 추가
             equippedItems: equippedItems,
             perks: perks,
             currentHp: baseStats.hp,

--- a/js/managers/SynergyEngine.js
+++ b/js/managers/SynergyEngine.js
@@ -1,0 +1,152 @@
+import { GAME_EVENTS } from '../constants.js'; // 이벤트 상수를 사용
+
+export class SynergyEngine {
+    /**
+     * SynergyEngine을 초기화합니다.
+     * @param {IdManager} idManager - 시너지 정의 데이터를 가져올 IdManager 인스턴스
+     * @param {EventManager} eventManager - 시너지 활성화/비활성화 이벤트를 발행할 EventManager 인스턴스
+     */
+    constructor(idManager, eventManager) {
+        console.log("\ud83d\udd17 SynergyEngine initialized. Ready to weave powerful team effects. \ud83d\udd17");
+        this.idManager = idManager;
+        this.eventManager = eventManager;
+        this.synergyDefinitions = new Map(); // key: synergyId, value: synergyDefinition
+
+        this._loadSynergyDefinitions(); // 초기 시너지 정의 로드
+    }
+
+    /**
+     * 시너지 정의 데이터를 로드합니다.
+     * 실제 게임에서는 데이터 파일에서 로드하게 될 것입니다.
+     * @private
+     */
+    _loadSynergyDefinitions() {
+        // 임시 시너지 정의 (나중에 data/synergies.js 등으로 분리)
+        const tempSynergies = [
+            {
+                id: 'synergy_warrior',
+                name: '전사',
+                tiers: [
+                    { count: 2, effect: { attackBonus: 10 } },
+                    { count: 4, effect: { attackBonus: 25 } },
+                    { count: 6, effect: { attackBonus: 50 } }
+                ],
+                description: '전사 영웅들의 강인함이 팀의 공격력을 증폭시킵니다.'
+            },
+            {
+                id: 'synergy_mage',
+                name: '마법사',
+                tiers: [
+                    { count: 2, effect: { magicPowerBonus: 15 } },
+                    { count: 4, effect: { magicPowerBonus: 40 } }
+                ],
+                description: '마법사 영웅들이 모여 강력한 마법 에너지를 방출합니다.'
+            },
+            {
+                id: 'synergy_healer',
+                name: '치유사',
+                tiers: [
+                    { count: 1, effect: { hpRegenPerTurn: 5 } },
+                    { count: 2, effect: { hpRegenPerTurn: 15 } }
+                ],
+                description: '치유사 영웅들이 아군을 보호하고 생명력을 회복시킵니다.'
+            },
+            {
+                id: 'synergy_archer',
+                name: '궁수',
+                tiers: [
+                    { count: 2, effect: { criticalChanceBonus: 0.10 } }
+                ],
+                description: '궁수 영웅들이 적의 약점을 노려 치명적인 일격을 가합니다.'
+            }
+        ];
+
+        tempSynergies.forEach(synergy => this.registerSynergyDefinition(synergy.id, synergy));
+        console.log(`[SynergyEngine] Loaded ${this.synergyDefinitions.size} synergy definitions.`);
+    }
+
+    /**
+     * 새로운 시너지 정의를 등록합니다.
+     * @param {string} synergyId - 시너지의 고유 ID
+     * @param {object} definition - 시너지 정의 객체 (id, name, tiers, description 포함)
+     */
+    registerSynergyDefinition(synergyId, definition) {
+        if (this.synergyDefinitions.has(synergyId)) {
+            console.warn(`[SynergyEngine] Synergy '${synergyId}' already registered. Overwriting.`);
+        }
+        this.synergyDefinitions.set(synergyId, definition);
+        console.log(`[SynergyEngine] Registered synergy: ${synergyId}`);
+    }
+
+    /**
+     * 주어진 영웅들의 목록에서 활성화된 시너지를 계산합니다.
+     * @param {object[]} heroesOnTeam - 현재 팀에 있는 영웅 객체들의 배열 (각 영웅은 .synergies 배열을 가져야 함)
+     * @returns {{synergyId: string, tier: number, effect: object}[]} 활성화된 시너지와 그 효과의 배열
+     */
+    calculateActiveSynergies(heroesOnTeam) {
+        const synergyCounts = new Map();
+
+        for (const hero of heroesOnTeam) {
+            if (hero.synergies && Array.isArray(hero.synergies)) {
+                for (const synergyId of hero.synergies) {
+                    synergyCounts.set(synergyId, (synergyCounts.get(synergyId) || 0) + 1);
+                }
+            }
+        }
+
+        const activeSynergies = [];
+        for (const [synergyId, count] of synergyCounts.entries()) {
+            const definition = this.synergyDefinitions.get(synergyId);
+            if (!definition) {
+                console.warn(`[SynergyEngine] Unknown synergy ID encountered: ${synergyId}`);
+                continue;
+            }
+
+            let activatedTier = null;
+            const sortedTiers = [...definition.tiers].sort((a, b) => b.count - a.count);
+
+            for (const tier of sortedTiers) {
+                if (count >= tier.count) {
+                    activatedTier = tier;
+                    break;
+                }
+            }
+
+            if (activatedTier) {
+                activeSynergies.push({
+                    synergyId: synergyId,
+                    name: definition.name,
+                    tier: activatedTier.count,
+                    effect: activatedTier.effect,
+                    description: definition.description
+                });
+            }
+        }
+
+        console.log(`[SynergyEngine] Calculated Active Synergies:`, activeSynergies.map(s => `${s.name} (${s.tier}\uBA85)`));
+        return activeSynergies;
+    }
+
+    /**
+     * 활성화된 시너지 정보를 이벤트로 발행하여 다른 매니저들이 효과를 적용하도록 합니다.
+     * @param {{synergyId: string, tier: number, effect: object}[]} activeSynergies - 활성화된 시너지 배열
+     */
+    emitActiveSynergyEvents(activeSynergies) {
+        if (activeSynergies.length === 0) {
+            this.eventManager.emit(GAME_EVENTS.SYNERGY_DEACTIVATED, { reason: 'noSynergiesActive' });
+            console.log("[SynergyEngine] No synergies active. Emitted SYNERGY_DEACTIVATED event.");
+            return;
+        }
+
+        for (const synergy of activeSynergies) {
+            this.eventManager.emit(GAME_EVENTS.SYNERGY_ACTIVATED, {
+                synergyId: synergy.synergyId,
+                name: synergy.name,
+                tier: synergy.tier,
+                effect: synergy.effect,
+                description: synergy.description
+            });
+            console.log(`[SynergyEngine] Emitted SYNERGY_ACTIVATED event for ${synergy.name} (Tier ${synergy.tier}).`);
+        }
+    }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -44,6 +44,7 @@ export { runDisarmManagerUnitTests } from './unit/disarmManagerUnitTests.js';
 export { runCoordinateManagerUnitTests } from './unit/coordinateManagerUnitTests.js';
 export { runTargetingManagerUnitTests } from './unit/targetingManagerUnitTests.js'; // ✨ TargetingManager 단위 테스트 추가
 export { runHeroEngineUnitTests } from "./unit/heroEngineUnitTests.js"; // ✨ HeroEngine 단위 테스트 추가
+export { runSynergyEngineUnitTests } from './unit/synergyEngineUnitTests.js'; // ✨ SynergyEngine 단위 테스트 추가
 
 export { runMeasureManagerIntegrationTest } from './integration/measureManagerIntegrationTests.js';
 export { runBattleSimulationIntegrationTest } from './integration/battleSimulationIntegrationTest.js';
@@ -54,7 +55,7 @@ export { injectEventManagerFaults } from './fault_injection/eventManagerFaults.j
 export { injectGuardianManagerFaults } from './fault_injection/guardianManagerFaults.js';
 export { injectSceneEngineFaults } from './fault_injection/sceneEngineFaults.js';
 export { injectLogicManagerFaults } from './fault_injection/logicManagerFaults.js';
-export function runEngineTests(renderer, gameLoop, battleSimulationManager = null, battleGridManager = null, idManager = null, assetLoaderManager = null, diceBotManager = null) {
+export function runEngineTests(renderer, gameLoop, battleSimulationManager = null, battleGridManager = null, idManager = null, assetLoaderManager = null, diceBotManager = null, eventManager = null) {
     runRendererTests(renderer);
     runGameLoopTests(gameLoop);
     if (battleSimulationManager && battleGridManager) {
@@ -64,4 +65,7 @@ export function runEngineTests(renderer, gameLoop, battleSimulationManager = nul
         runTargetingManagerUnitTests(battleSimulationManager);
     }
     runHeroEngineUnitTests(idManager, assetLoaderManager, diceBotManager);
+    if (idManager && eventManager) {
+        runSynergyEngineUnitTests(idManager, eventManager);
+    }
 }

--- a/tests/unit/synergyEngineUnitTests.js
+++ b/tests/unit/synergyEngineUnitTests.js
@@ -1,0 +1,172 @@
+// tests/unit/synergyEngineUnitTests.js
+
+import { SynergyEngine } from '../../js/managers/SynergyEngine.js';
+import { EventManager } from '../../js/managers/EventManager.js';
+import { GAME_EVENTS } from '../../js/constants.js';
+
+export function runSynergyEngineUnitTests(idManager, eventManager) {
+    console.log("--- SynergyEngine Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockIdManager = idManager || {};
+
+    const mockEventManager = eventManager || new EventManager();
+    let emittedEvents = [];
+    const originalEmit = mockEventManager.emit;
+    mockEventManager.emit = (eventName, data) => {
+        emittedEvents.push({ eventName, data });
+        originalEmit.call(mockEventManager, eventName, data);
+    };
+
+    testCount++;
+    try {
+        const se = new SynergyEngine(mockIdManager, mockEventManager);
+        if (se.idManager === mockIdManager && se.eventManager === mockEventManager && se.synergyDefinitions instanceof Map && se.synergyDefinitions.size > 0) {
+            console.log("SynergyEngine: Initialized correctly and loaded definitions. [PASS]");
+            passCount++;
+        } else {
+            console.error("SynergyEngine: Initialization failed or no definitions loaded. [FAIL]");
+        }
+    } catch (e) {
+        console.error("SynergyEngine: Error during initialization. [FAIL]", e);
+    }
+
+    testCount++;
+    emittedEvents = [];
+    try {
+        const se = new SynergyEngine(mockIdManager, mockEventManager);
+        const team = [
+            { id: 'h1', synergies: ['synergy_warrior'] },
+            { id: 'h2', synergies: ['synergy_warrior'] },
+            { id: 'h3', synergies: ['synergy_mage'] }
+        ];
+        const activeSynergies = se.calculateActiveSynergies(team);
+
+        if (activeSynergies.length === 2 &&
+            activeSynergies.some(s => s.synergyId === 'synergy_warrior' && s.tier === 2) &&
+            activeSynergies.some(s => s.synergyId === 'synergy_mage' && s.tier === 1)
+        ) {
+            console.log("SynergyEngine: calculateActiveSynergies correctly identified active synergies (Tier 1). [PASS]");
+            passCount++;
+        } else {
+            console.error("SynergyEngine: calculateActiveSynergies failed for Tier 1. [FAIL]", activeSynergies);
+        }
+    } catch (e) {
+        console.error("SynergyEngine: Error during calculateActiveSynergies (Tier 1) test. [FAIL]", e);
+    }
+
+    testCount++;
+    emittedEvents = [];
+    try {
+        const se = new SynergyEngine(mockIdManager, mockEventManager);
+        const team = [
+            { id: 'h1', synergies: ['synergy_warrior'] },
+            { id: 'h2', synergies: ['synergy_warrior'] },
+            { id: 'h3', synergies: ['synergy_warrior'] },
+            { id: 'h4', synergies: ['synergy_warrior'] }
+        ];
+        const activeSynergies = se.calculateActiveSynergies(team);
+
+        if (activeSynergies.length === 1 &&
+            activeSynergies[0].synergyId === 'synergy_warrior' &&
+            activeSynergies[0].tier === 4 &&
+            activeSynergies[0].effect.attackBonus === 25) {
+            console.log("SynergyEngine: calculateActiveSynergies correctly identified highest active tier. [PASS]");
+            passCount++;
+        } else {
+            console.error("SynergyEngine: calculateActiveSynergies failed for high tier. [FAIL]", activeSynergies);
+        }
+    } catch (e) {
+        console.error("SynergyEngine: Error during calculateActiveSynergies (high tier) test. [FAIL]", e);
+    }
+
+    testCount++;
+    emittedEvents = [];
+    try {
+        const se = new SynergyEngine(mockIdManager, mockEventManager);
+        const team = [
+            { id: 'h1', synergies: ['synergy_warrior'] },
+            { id: 'h2', synergies: ['synergy_warrior'] },
+            { id: 'h3', synergies: ['synergy_mage'] },
+            { id: 'h4', synergies: ['synergy_mage'] }
+        ];
+        const activeSynergies = se.calculateActiveSynergies(team);
+
+        const warriorSynergy = activeSynergies.find(s => s.synergyId === 'synergy_warrior');
+        const mageSynergy = activeSynergies.find(s => s.synergyId === 'synergy_mage');
+
+        if (activeSynergies.length === 2 &&
+            warriorSynergy && warriorSynergy.tier === 2 &&
+            mageSynergy && mageSynergy.tier === 2) {
+            console.log("SynergyEngine: calculateActiveSynergies correctly identified multiple active synergies. [PASS]");
+            passCount++;
+        } else {
+            console.error("SynergyEngine: calculateActiveSynergies failed for multiple synergies. [FAIL]", activeSynergies);
+        }
+    } catch (e) {
+        console.error("SynergyEngine: Error during calculateActiveSynergies (multiple) test. [FAIL]", e);
+    }
+
+    testCount++;
+    emittedEvents = [];
+    try {
+        const se = new SynergyEngine(mockIdManager, mockEventManager);
+        const team = [
+            { id: 'h1', synergies: ['synergy_unique_1'] },
+            { id: 'h2', synergies: ['synergy_unique_2'] }
+        ];
+        const activeSynergies = se.calculateActiveSynergies(team);
+
+        if (activeSynergies.length === 0) {
+            console.log("SynergyEngine: calculateActiveSynergies correctly returned no active synergies. [PASS]");
+            passCount++;
+        } else {
+            console.error("SynergyEngine: calculateActiveSynergies failed to return no active synergies. [FAIL]", activeSynergies);
+        }
+    } catch (e) {
+        console.error("SynergyEngine: Error during calculateActiveSynergies (none active) test. [FAIL]", e);
+    }
+
+    testCount++;
+    emittedEvents = [];
+    try {
+        const se = new SynergyEngine(mockIdManager, mockEventManager);
+        const active = se.calculateActiveSynergies([
+            { id: 'h1', synergies: ['synergy_warrior'] },
+            { id: 'h2', synergies: ['synergy_warrior'] }
+        ]);
+        se.emitActiveSynergyEvents(active);
+
+        const activatedEvents = emittedEvents.filter(e => e.eventName === GAME_EVENTS.SYNERGY_ACTIVATED);
+        if (activatedEvents.length === 1 && activatedEvents[0].data.synergyId === 'synergy_warrior') {
+            console.log("SynergyEngine: emitActiveSynergyEvents correctly emitted SYNERGY_ACTIVATED. [PASS]");
+            passCount++;
+        } else {
+            console.error("SynergyEngine: emitActiveSynergyEvents failed to emit SYNERGY_ACTIVATED. [FAIL]", activatedEvents);
+        }
+    } catch (e) {
+        console.error("SynergyEngine: Error during emitActiveSynergyEvents (active) test. [FAIL]", e);
+    }
+
+    testCount++;
+    emittedEvents = [];
+    try {
+        const se = new SynergyEngine(mockIdManager, mockEventManager);
+        const active = se.calculateActiveSynergies([]);
+        se.emitActiveSynergyEvents(active);
+
+        const deactivatedEvents = emittedEvents.filter(e => e.eventName === GAME_EVENTS.SYNERGY_DEACTIVATED);
+        if (deactivatedEvents.length === 1 && deactivatedEvents[0].data.reason === 'noSynergiesActive') {
+            console.log("SynergyEngine: emitActiveSynergyEvents correctly emitted SYNERGY_DEACTIVATED when no synergies are active. [PASS]");
+            passCount++;
+        } else {
+            console.error("SynergyEngine: emitActiveSynergyEvents failed to emit SYNERGY_DEACTIVATED. [FAIL]", deactivatedEvents);
+        }
+    } catch (e) {
+        console.error("SynergyEngine: Error during emitActiveSynergyEvents (no active) test. [FAIL]", e);
+    }
+
+    console.log(`--- SynergyEngine Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}


### PR DESCRIPTION
## Summary
- implement `SynergyEngine` to manage team synergies
- generate random synergies for heroes
- integrate SynergyEngine into GameEngine and expose getter
- add new game events for synergy activation
- create unit tests for SynergyEngine and hook them into test runner
- extend debug page with SynergyEngine tests and update runEngineTests

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68777e372f58832794bc55343a3a98c6