### PR TITLE
Add DetailInfoManager and hover tooltip support

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -101,7 +101,7 @@
         <button id="runStatusEffectManagerUnitTestsBtn">StatusEffectManager 유닛 테스트</button>
         <button id="runWorkflowManagerUnitTestsBtn">WorkflowManager 유닛 테스트</button>
         <button id="runDisarmManagerUnitTestsBtn">DisarmManager 유닛 테스트</button>
-        <button id="runCoordinateManagerUnitTestsBtn">CoordinateManager 유닛 테스트</button> <button id="runTargetingManagerUnitTestsBtn">TargetingManager 유닛 테스트</button> <button id="runHeroEngineUnitTestsBtn">HeroEngine 유닛 테스트</button> <button id="runSynergyEngineUnitTestsBtn">SynergyEngine 유닛 테스트</button>
+        <button id="runCoordinateManagerUnitTestsBtn">CoordinateManager 유닛 테스트</button> <button id="runTargetingManagerUnitTestsBtn">TargetingManager 유닛 테스트</button> <button id="runHeroEngineUnitTestsBtn">HeroEngine 유닛 테스트</button> <button id="runSynergyEngineUnitTestsBtn">SynergyEngine 유닛 테스트</button> <button id="runDetailInfoManagerUnitTestsBtn">DetailInfoManager 유닛 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -184,7 +184,8 @@
             runDisarmManagerUnitTests,
             runCoordinateManagerUnitTests,
             runHeroEngineUnitTests,
-            runSynergyEngineUnitTests
+            runSynergyEngineUnitTests,
+            runDetailInfoManagerUnitTests
     } from './tests/index.js';
     import { STATUS_EFFECTS } from './data/statusEffects.js';
     // ✨ 상수 파일 임포트
@@ -388,6 +389,10 @@
             // ✨ SynergyEngine 단위 테스트 버튼 리스너 추가
             document.getElementById('runSynergyEngineUnitTestsBtn').addEventListener('click', () => {
                 runSynergyEngineUnitTests(idManager, eventManager);
+            });
+            // ✨ DetailInfoManager 단위 테스트 버튼 리스너 추가
+            document.getElementById('runDetailInfoManagerUnitTestsBtn').addEventListener('click', () => {
+                runDetailInfoManagerUnitTests(); // 목업 사용
             });
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
                 injectRendererFault(renderer);

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -52,6 +52,7 @@ import { BattleStageManager } from './managers/BattleStageManager.js';
 import { BattleGridManager } from './managers/BattleGridManager.js';
 import { CoordinateManager } from './managers/CoordinateManager.js';
 import { ButtonEngine } from './managers/ButtonEngine.js'; // ✨ ButtonEngine 임포트
+import { DetailInfoManager } from './managers/DetailInfoManager.js'; // ✨ DetailInfoManager 추가
 
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES } from './constants.js';
@@ -148,8 +149,8 @@ export class GameEngine {
         );
 
         this.cameraEngine = new CameraEngine(this.renderer, this.logicManager, this.sceneEngine);
-        // ✨ InputManager 초기화 시 buttonEngine을 함께 전달
-        this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine, this.buttonEngine);
+        // ✨ InputManager 초기화 시 buttonEngine과 eventManager를 함께 전달
+        this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine, this.buttonEngine, this.eventManager);
 
         const mainGameCanvasElement = document.getElementById(canvasId);
         this.canvasBridgeManager = new CanvasBridgeManager(
@@ -194,6 +195,15 @@ export class GameEngine {
 
         // ✨ SynergyEngine 초기화
         this.synergyEngine = new SynergyEngine(this.idManager, this.eventManager);
+
+        // ✨ DetailInfoManager 초기화
+        this.detailInfoManager = new DetailInfoManager(
+            this.eventManager,
+            this.measureManager,
+            this.battleSimulationManager,
+            this.heroEngine,
+            this.idManager
+        );
         // BattleCalculationManager는 DiceRollManager가 준비된 이후에 초기화합니다.
         this.battleCalculationManager = new BattleCalculationManager(
             this.eventManager,
@@ -279,6 +289,11 @@ export class GameEngine {
         this.layerEngine.registerLayer('uiLayer', (ctx) => {
             this.uiEngine.draw(ctx);
         }, 100);
+
+        // ✨ DetailInfoManager의 draw 메서드를 별도의 레이어로 등록 (가장 위에 오도록 높은 Z-Index)
+        this.layerEngine.registerLayer('detailInfoLayer', (ctx) => {
+            this.detailInfoManager.draw(ctx);
+        }, 200); // 100보다 높게 설정
 
 
         this._update = this._update.bind(this);
@@ -420,6 +435,8 @@ export class GameEngine {
         this.animationManager.update(deltaTime);
         this.vfxManager.update(deltaTime);
         this.particleEngine.update(deltaTime); // ✨ ParticleEngine 업데이트 호출
+        // ✨ DetailInfoManager 업데이트 호출
+        this.detailInfoManager.update(deltaTime);
     }
 
     _draw() {
@@ -484,6 +501,8 @@ export class GameEngine {
     getHeroEngine() { return this.heroEngine; }
     // ✨ SynergyEngine getter 추가
     getSynergyEngine() { return this.synergyEngine; }
+    // ✨ DetailInfoManager getter 추가
+    getDetailInfoManager() { return this.detailInfoManager; }
     getDiceBotManager() { return this.diceBotManager; }
     // ✨ CoordinateManager getter 추가
     getCoordinateManager() { return this.coordinateManager; }

--- a/js/constants.js
+++ b/js/constants.js
@@ -19,8 +19,9 @@ export const GAME_EVENTS = {
     DRAG_MOVE: 'dragMove',
     DROP: 'drop',
     DRAG_CANCEL: 'dragCancel',
-    SYNERGY_ACTIVATED: 'synergyActivated',
-    SYNERGY_DEACTIVATED: 'synergyDeactivated'
+    SYNERGY_ACTIVATED: 'synergyActivated',   // 이전 요청에 의해 추가된 코드
+    SYNERGY_DEACTIVATED: 'synergyDeactivated', // 이전 요청에 의해 추가된 코드
+    CANVAS_MOUSE_MOVED: 'canvasMouseMoved' // ✨ 마우스 이동 이벤트 추가
 };
 
 export const UI_STATES = {

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -95,6 +95,38 @@ export class BattleSimulationManager {
     }
 
     /**
+     * 유닛 렌더링에 필요한 그리드 관련 파라미터를 반환합니다.
+     * 이 값들은 BattleGridManager와 VFXManager에서도 사용됩니다.
+     * @returns {{effectiveTileSize: number, gridOffsetX: number, gridOffsetY: number, totalGridWidth: number, totalGridHeight: number}}
+     */
+    getGridRenderParameters() {
+        const sceneContentDimensions = this.logicManager.getCurrentSceneContentDimensions();
+        const canvasWidth = this.measureManager.get('gameResolution.width');
+        const canvasHeight = this.measureManager.get('gameResolution.height');
+
+        const gridContentWidth = sceneContentDimensions.width;
+        const gridContentHeight = sceneContentDimensions.height;
+
+        const tileSizeBasedOnWidth = gridContentWidth / this.gridCols;
+        const tileSizeBasedOnHeight = gridContentHeight / this.gridRows;
+        const effectiveTileSize = Math.min(tileSizeBasedOnWidth, tileSizeBasedOnHeight);
+
+        const totalGridWidth = effectiveTileSize * this.gridCols;
+        const totalGridHeight = effectiveTileSize * this.gridRows;
+
+        const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
+        const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
+
+        return {
+            effectiveTileSize,
+            gridOffsetX,
+            gridOffsetY,
+            totalGridWidth,
+            totalGridHeight
+        };
+    }
+
+    /**
      * 배틀 그리드에 배치된 모든 유닛을 그립니다.
      * @param {CanvasRenderingContext2D} ctx
      */

--- a/js/managers/DetailInfoManager.js
+++ b/js/managers/DetailInfoManager.js
@@ -1,0 +1,256 @@
+// js/managers/DetailInfoManager.js
+
+import { GAME_EVENTS } from '../constants.js'; // 이벤트 상수를 사용
+
+export class DetailInfoManager {
+    /**
+     * DetailInfoManager를 초기화합니다.
+     * @param {EventManager} eventManager - 이벤트 구독을 위한 EventManager 인스턴스
+     * @param {MeasureManager} measureManager - UI 크기 및 위치 계산을 위한 MeasureManager 인스턴스
+     * @param {BattleSimulationManager} battleSimulationManager - 유닛 정보 및 위치 조회를 위한 BattleSimulationManager 인스턴스
+     * @param {HeroEngine} heroEngine - 영웅별 상세 데이터(스킬, 시너지) 조회를 위한 HeroEngine 인스턴스
+     * @param {IdManager} idManager - 클래스, 스킬, 시너지 이름 조회를 위한 IdManager 인스턴스
+     */
+    constructor(eventManager, measureManager, battleSimulationManager, heroEngine, idManager) {
+        console.log("🔍 DetailInfoManager initialized. Ready to show unit details on hover. 🔍");
+        this.eventManager = eventManager;
+        this.measureManager = measureManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.heroEngine = heroEngine;
+        this.idManager = idManager;
+
+        this.hoveredUnit = null;       // 현재 마우스가 올라간 유닛
+        this.lastMouseX = 0;           // 마우스의 마지막 X 좌표 (논리적 캔버스 좌표)
+        this.lastMouseY = 0;           // 마우스의 마지막 Y 좌표 (논리적 캔버스 좌표)
+        this.tooltipAlpha = 0;         // 툴팁 투명도 (페이드 효과)
+        this.tooltipVisible = false;   // 툴팁 표시 여부
+
+        this.tooltipFadeSpeed = 0.05;  // 툴팁 페이드 속도
+
+        this._setupEventListeners();
+    }
+
+    /**
+     * 이벤트 리스너를 설정합니다.
+     * @private
+     */
+    _setupEventListeners() {
+        // InputManager에서 발행하는 마우스 이동 이벤트 구독
+        this.eventManager.subscribe(GAME_EVENTS.CANVAS_MOUSE_MOVED, this._onCanvasMouseMove.bind(this));
+        console.log("[DetailInfoManager] Subscribed to CANVAS_MOUSE_MOVED event.");
+    }
+
+    /**
+     * 캔버스 내 마우스 이동 이벤트를 처리합니다.
+     * @param {{x: number, y: number}} data - 캔버스 내부의 논리적 마우스 X, Y 좌표
+     * @private
+     */
+    _onCanvasMouseMove(data) {
+        this.lastMouseX = data.x;
+        this.lastMouseY = data.y;
+    }
+
+    /**
+     * 매 프레임마다 호출되어 마우스 오버 유닛을 감지하고 툴팁 상태를 업데이트합니다.
+     * @param {number} deltaTime - 지난 프레임과의 시간 차이 (밀리초)
+     */
+    update(deltaTime) {
+        const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
+
+        let currentHoveredUnit = null;
+
+        for (const unit of this.battleSimulationManager.unitsOnGrid) {
+            if (unit.currentHp <= 0) continue; // 죽은 유닛은 감지하지 않음
+
+            // AnimationManager로부터 유닛의 실제 렌더링 위치를 가져옵니다.
+            const { drawX, drawY } = this.battleSimulationManager.animationManager.getRenderPosition(
+                unit.id,
+                unit.gridX,
+                unit.gridY,
+                effectiveTileSize,
+                gridOffsetX,
+                gridOffsetY
+            );
+
+            // 유닛 이미지의 실제 렌더링 영역
+            const unitRenderWidth = effectiveTileSize;
+            const unitRenderHeight = effectiveTileSize;
+
+            // 마우스 좌표가 유닛의 렌더링 영역 안에 있는지 확인
+            if (
+                this.lastMouseX >= drawX && this.lastMouseX <= drawX + unitRenderWidth &&
+                this.lastMouseY >= drawY && this.lastMouseY <= drawY + unitRenderHeight
+            ) {
+                currentHoveredUnit = unit;
+                break; // 한 유닛에만 호버링 가능
+            }
+        }
+
+        if (currentHoveredUnit && currentHoveredUnit !== this.hoveredUnit) {
+            // 새로운 유닛에 호버링 시작
+            this.hoveredUnit = currentHoveredUnit;
+            this.tooltipVisible = true;
+            this.tooltipAlpha = 0; // 새로 시작
+            console.log(`[DetailInfoManager] Hovering over: ${this.hoveredUnit.name}`);
+        } else if (!currentHoveredUnit && this.hoveredUnit) {
+            // 호버링 중이던 유닛에서 벗어남
+            this.tooltipVisible = false;
+            // this.hoveredUnit = null; // 페이드 아웃 후 null 처리
+        }
+
+        // 툴팁 페이드 인/아웃
+        if (this.tooltipVisible) {
+            this.tooltipAlpha = Math.min(1, this.tooltipAlpha + this.tooltipFadeSpeed * (deltaTime / 16));
+        } else {
+            this.tooltipAlpha = Math.max(0, this.tooltipAlpha - this.tooltipFadeSpeed * (deltaTime / 16));
+            if (this.tooltipAlpha <= 0 && this.hoveredUnit) {
+                this.hoveredUnit = null; // 완전히 사라지면 null 처리
+            }
+        }
+    }
+
+    /**
+     * 툴팁 UI를 캔버스에 그립니다. LayerEngine에 의해 호출됩니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
+     */
+    async draw(ctx) {
+        if (!this.hoveredUnit || this.tooltipAlpha <= 0) {
+            return;
+        }
+
+        ctx.save();
+        ctx.globalAlpha = this.tooltipAlpha; // 전체 툴팁 투명도 적용
+
+        // 툴팁 위치 계산 (마우스 커서 근처에 표시)
+        const tooltipWidth = 300; // 고정 너비
+        const padding = 10;
+        const lineHeight = 20;
+        let currentYOffset = padding;
+
+        let tooltipX = this.lastMouseX + 15; // 커서 오른쪽으로 살짝 이동
+        let tooltipY = this.lastMouseY + 15; // 커서 아래로 살짝 이동
+
+        // 캔버스 경계를 넘어가지 않도록 조정 (툴팁 높이는 내용에 따라 동적으로 계산)
+        const canvasWidth = ctx.canvas.width / (window.devicePixelRatio || 1);
+        const canvasHeight = ctx.canvas.height / (window.devicePixelRatio || 1);
+
+        // 먼저 내용을 그려보고 높이를 대략적으로 측정
+        let contentHeight = 0;
+        contentHeight += lineHeight; // 이름
+        contentHeight += lineHeight; // 클래스/타입
+        contentHeight += lineHeight * 2; // HP/Barrier
+        contentHeight += lineHeight * 4; // 주요 스탯 묶음 (공격, 방어, 속도, 용맹)
+
+        const heroDetails = await this.heroEngine.getHero(this.hoveredUnit.id); // 영웅 스킬/시너지 가져오기
+        let classData = null;
+        if (this.hoveredUnit.classId) {
+             classData = await this.idManager.get(this.hoveredUnit.classId);
+        }
+
+        // 스킬 및 시너지 줄 수 계산
+        if (heroDetails && heroDetails.skills && heroDetails.skills.length > 0) {
+            contentHeight += lineHeight * (heroDetails.skills.length + 1); // 스킬 제목 + 각 스킬
+        } else if (classData && classData.skills && classData.skills.length > 0) {
+            contentHeight += lineHeight * (classData.skills.length + 1); // 스킬 제목 + 각 스킬
+        }
+        if (heroDetails && heroDetails.synergies && heroDetails.synergies.length > 0) {
+            contentHeight += lineHeight * (heroDetails.synergies.length + 1); // 시너지 제목 + 각 시너지
+        }
+
+        const tooltipHeight = contentHeight + padding * 2;
+
+        if (tooltipX + tooltipWidth > canvasWidth) {
+            tooltipX = canvasWidth - tooltipWidth - padding;
+        }
+        if (tooltipY + tooltipHeight > canvasHeight) {
+            tooltipY = canvasHeight - tooltipHeight - padding;
+        }
+        if (tooltipX < padding) tooltipX = padding;
+        if (tooltipY < padding) tooltipY = padding;
+
+
+        // 툴팁 배경
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.8)';
+        ctx.fillRect(tooltipX, tooltipY, tooltipWidth, tooltipHeight);
+
+        // 툴팁 테두리
+        ctx.strokeStyle = '#FFFFFF';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(tooltipX, tooltipY, tooltipWidth, tooltipHeight);
+
+        // 텍스트 그리기
+        ctx.fillStyle = '#FFFFFF';
+        ctx.font = 'bold 18px Arial';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+
+        // 유닛 이름
+        ctx.fillText(this.hoveredUnit.name, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight + 5; // 다음 줄과의 간격
+
+        // 클래스 및 타입
+        const className = classData ? classData.name : '알 수 없음';
+        ctx.font = '14px Arial';
+        ctx.fillText(`클래스: ${className} | 타입: ${this.hoveredUnit.type}`, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight;
+
+        ctx.font = '14px Arial';
+        // HP 및 배리어
+        ctx.fillStyle = '#FF4500'; // 빨간색
+        ctx.fillText(`HP: ${this.hoveredUnit.currentHp}/${this.hoveredUnit.baseStats.hp}`, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight;
+
+        ctx.fillStyle = '#FFFF00'; // 노란색
+        ctx.fillText(`배리어: ${this.hoveredUnit.currentBarrier}/${this.hoveredUnit.maxBarrier}`, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight + 5; // 다음 섹션과의 간격
+
+        ctx.fillStyle = '#FFFFFF';
+        ctx.font = '14px Arial';
+        ctx.fillText(`공격: ${this.hoveredUnit.baseStats.attack || 0} | 방어: ${this.hoveredUnit.baseStats.defense || 0}`, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight;
+        ctx.fillText(`속도: ${this.hoveredUnit.baseStats.speed || 0} | 용맹: ${this.hoveredUnit.baseStats.valor || 0}`, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight;
+        ctx.fillText(`힘: ${this.hoveredUnit.baseStats.strength || 0} | 인내: ${this.hoveredUnit.baseStats.endurance || 0}`, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight;
+        ctx.fillText(`민첩: ${this.hoveredUnit.baseStats.agility || 0} | 지능: ${this.hoveredUnit.baseStats.intelligence || 0}`, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight;
+        ctx.fillText(`지혜: ${this.hoveredUnit.baseStats.wisdom || 0} | 운: ${this.hoveredUnit.baseStats.luck || 0}`, tooltipX + padding, tooltipY + currentYOffset);
+        currentYOffset += lineHeight + 5;
+
+        // 스킬 정보 (HeroEngine에서 가져온 heroDetails에 스킬이 있다면)
+        let skillsToList = [];
+        if (heroDetails && heroDetails.skills && heroDetails.skills.length > 0) {
+            skillsToList = heroDetails.skills;
+        } else if (classData && classData.skills && classData.skills.length > 0) {
+            skillsToList = classData.skills;
+        }
+
+        if (skillsToList.length > 0) {
+            ctx.font = 'bold 16px Arial';
+            ctx.fillText('스킬:', tooltipX + padding, tooltipY + currentYOffset);
+            currentYOffset += lineHeight;
+            ctx.font = '14px Arial';
+            for (const skillId of skillsToList) {
+                // 스킬 ID에서 "skill_" 프리픽스 제거하여 표시 (예: "skill_1" -> "1")
+                ctx.fillText(`- ${skillId.replace('skill_', '').replace('passive_', '패시브-')}`, tooltipX + padding, tooltipY + currentYOffset);
+                currentYOffset += lineHeight;
+            }
+            currentYOffset += 5; // 다음 섹션과의 간격
+        }
+
+        // 시너지 정보 (HeroEngine에서 가져온 heroDetails에 시너지가 있다면)
+        if (heroDetails && heroDetails.synergies && heroDetails.synergies.length > 0) {
+            ctx.font = 'bold 16px Arial';
+            ctx.fillText('시너지:', tooltipX + padding, tooltipY + currentYOffset);
+            currentYOffset += lineHeight;
+            ctx.font = '14px Arial';
+            for (const synergyId of heroDetails.synergies) {
+                // 시너지 ID에서 "synergy_" 프리픽스 제거하여 표시
+                ctx.fillText(`- ${synergyId.replace('synergy_', '')}`, tooltipX + padding, tooltipY + currentYOffset);
+                currentYOffset += lineHeight;
+            }
+        }
+
+        ctx.restore();
+    }
+}

--- a/js/managers/InputManager.js
+++ b/js/managers/InputManager.js
@@ -4,12 +4,13 @@
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS } from '../constants.js';
 
 export class InputManager {
-    constructor(renderer, cameraEngine, uiEngine, buttonEngine) { // ✨ buttonEngine 추가
+    constructor(renderer, cameraEngine, uiEngine, buttonEngine, eventManager) { // ✨ buttonEngine 추가
         console.log("🎮 InputManager initialized. Ready to process user input. 🎮");
         this.renderer = renderer;
         this.cameraEngine = cameraEngine;
         this.uiEngine = uiEngine;
         this.buttonEngine = buttonEngine; // ✨ ButtonEngine 인스턴스 저장
+        this.eventManager = eventManager;
 
         this.canvas = this.renderer.canvas;
 
@@ -55,6 +56,16 @@ export class InputManager {
             this.cameraEngine.pan(dx, dy);
             this.lastMouseX = event.clientX;
             this.lastMouseY = event.clientY;
+        }
+
+        // ✨ 캔버스 내 논리적 마우스 좌표 계산
+        const rect = this.canvas.getBoundingClientRect();
+        const mouseX = event.clientX - rect.left;
+        const mouseY = event.clientY - rect.top;
+
+        // ✨ DetailInfoManager가 마우스 이동을 감지할 수 있도록 이벤트 발행
+        if (this.eventManager) {
+            this.eventManager.emit(GAME_EVENTS.CANVAS_MOUSE_MOVED, { x: mouseX, y: mouseY });
         }
     }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -6,6 +6,7 @@ export { runMeasureManagerUnitTests } from './unit/measureManagerUnitTests.js';
 export { runMapManagerUnitTests } from './unit/mapManagerUnitTests.js';
 export { runUIEngineUnitTests } from './unit/uiEngineUnitTests.js';
 export { runButtonEngineUnitTests } from './unit/buttonEngineUnitTests.js';
+export { runDetailInfoManagerUnitTests } from './unit/detailInfoManagerUnitTests.js'; // ✨ DetailInfoManager 단위 테스트 추가
 
 // new unit tests
 export { runSceneEngineUnitTests } from './unit/sceneEngineUnitTests.js';
@@ -68,4 +69,5 @@ export function runEngineTests(renderer, gameLoop, battleSimulationManager = nul
     if (idManager && eventManager) {
         runSynergyEngineUnitTests(idManager, eventManager);
     }
+    runDetailInfoManagerUnitTests(); // 목업 사용
 }

--- a/tests/unit/detailInfoManagerUnitTests.js
+++ b/tests/unit/detailInfoManagerUnitTests.js
@@ -1,0 +1,228 @@
+// tests/unit/detailInfoManagerUnitTests.js
+
+import { DetailInfoManager } from '../../js/managers/DetailInfoManager.js';
+import { EventManager } from '../../js/managers/EventManager.js';
+import { MeasureManager } from '../../js/managers/MeasureManager.js';
+import { BattleSimulationManager } from '../../js/managers/BattleSimulationManager.js';
+import { HeroEngine } from '../../js/managers/HeroEngine.js'; // HeroEngine 임포트
+import { IdManager } from '../../js/managers/IdManager.js'; // IdManager 임포트
+import { AnimationManager } from '../../js/managers/AnimationManager.js'; // AnimationManager도 필요
+
+export function runDetailInfoManagerUnitTests() {
+    console.log("--- DetailInfoManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // Mock Dependencies
+    const mockEventManager = new EventManager();
+    // emit을 목업하여 이벤트 발행 여부 확인
+    let emittedEvents = [];
+    const originalEmit = mockEventManager.emit;
+    mockEventManager.emit = (eventName, data) => {
+        emittedEvents.push({ eventName, data });
+        originalEmit.call(mockEventManager, eventName, data);
+    };
+
+    const mockMeasureManager = new MeasureManager();
+    const mockAnimationManager = new AnimationManager(mockMeasureManager); // AnimationManager 필요
+    const mockBattleSimulationManager = {
+        unitsOnGrid: [],
+        animationManager: mockAnimationManager, // BattleSimulationManager가 AnimationManager를 가지고 있다고 가정
+        getGridRenderParameters: () => ({ effectiveTileSize: 100, gridOffsetX: 0, gridOffsetY: 0 })
+    };
+    const mockHeroEngine = {
+        heroes: new Map(),
+        getHero: async (heroId) => {
+            if (heroId === 'hero_warrior_001') {
+                return {
+                    id: 'hero_warrior_001',
+                    name: '테스트 영웅',
+                    skills: ['skill_charge', 'skill_cleave', 'skill_passive_toughness'],
+                    synergies: ['synergy_warrior', 'synergy_melee']
+                };
+            }
+            return undefined;
+        }
+    };
+    const mockIdManager = {
+        get: async (id) => {
+            if (id === 'class_warrior') return { id: 'class_warrior', name: '전사', skills: ['skill_default_attack'] };
+            if (id === 'class_zombie') return { id: 'class_zombie', name: '좀비' };
+            return undefined;
+        }
+    };
+
+    const mockCtx = {
+        save: () => {},
+        restore: () => {},
+        fillRect: function() { this.fillRectCalled = true; },
+        strokeRect: function() { this.strokeRectCalled = true; },
+        fillText: function() { this.fillTextCalled = true; },
+        clearRect: () => {},
+        globalAlpha: 1, fillStyle: '', font: '', textAlign: '', textBaseline: '',
+        fillRectCalled: false, strokeRectCalled: false, fillTextCalled: false
+    };
+
+    // 테스트 유닛 데이터
+    const mockWarriorUnit = {
+        id: 'unit_warrior_001', name: '용맹한 전사', type: 'mercenary',
+        gridX: 1, gridY: 1, currentHp: 80, baseStats: { hp: 100, attack: 20, defense: 10, speed: 50, valor: 30, strength: 25, endurance: 20, agility: 15, intelligence: 5, wisdom: 10, luck: 10, weight: 30 },
+        classId: 'class_warrior', currentBarrier: 60, maxBarrier: 60
+    };
+    const mockZombieUnit = {
+        id: 'unit_zombie_001', name: '끔찍한 좀비', type: 'enemy',
+        gridX: 5, gridY: 5, currentHp: 40, baseStats: { hp: 80, attack: 15, defense: 5, speed: 30, valor: 10, strength: 10, endurance: 8, agility: 12, intelligence: 5, wisdom: 5, luck: 15, weight: 10 },
+        classId: 'class_zombie', currentBarrier: 20, maxBarrier: 20
+    };
+    const mockDeadUnit = {
+        id: 'unit_dead_001', name: '죽은 유닛', type: 'enemy',
+        gridX: 2, gridY: 2, currentHp: 0, baseStats: { hp: 50 },
+        classId: 'class_dead', currentBarrier: 0, maxBarrier: 0
+    };
+
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const dim = new DetailInfoManager(mockEventManager, mockMeasureManager, mockBattleSimulationManager, mockHeroEngine, mockIdManager);
+        if (dim.eventManager === mockEventManager && dim.hoveredUnit === null) {
+            console.log("DetailInfoManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("DetailInfoManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("DetailInfoManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: _onCanvasMouseMove - 마우스 좌표 업데이트 확인
+    testCount++;
+    try {
+        const dim = new DetailInfoManager(mockEventManager, mockMeasureManager, mockBattleSimulationManager, mockHeroEngine, mockIdManager);
+        dim._onCanvasMouseMove({ x: 100, y: 150 });
+        if (dim.lastMouseX === 100 && dim.lastMouseY === 150) {
+            console.log("DetailInfoManager: _onCanvasMouseMove updated mouse coordinates. [PASS]");
+            passCount++;
+        } else {
+            console.error("DetailInfoManager: _onCanvasMouseMove failed to update coordinates. [FAIL]");
+        }
+    } catch (e) {
+        console.error("DetailInfoManager: Error during _onCanvasMouseMove test. [FAIL]", e);
+    }
+
+    // 테스트 3: update - 유닛 호버링 감지 (새로운 유닛)
+    testCount++;
+    mockBattleSimulationManager.unitsOnGrid = [mockWarriorUnit, mockZombieUnit];
+    mockAnimationManager.getRenderPosition = (unitId) => {
+        if (unitId === 'unit_warrior_001') return { drawX: 100, drawY: 100 };
+        if (unitId === 'unit_zombie_001') return { drawX: 500, drawY: 500 };
+        return { drawX: 0, drawY: 0 };
+    };
+    try {
+        const dim = new DetailInfoManager(mockEventManager, mockMeasureManager, mockBattleSimulationManager, mockHeroEngine, mockIdManager);
+        dim._onCanvasMouseMove({ x: 120, y: 120 }); // warrior 위에 마우스
+        dim.update(16); // 델타 타임
+
+        if (dim.hoveredUnit && dim.hoveredUnit.id === 'unit_warrior_001' && dim.tooltipVisible) {
+            console.log("DetailInfoManager: update correctly detected new unit hover. [PASS]");
+            passCount++;
+        } else {
+            console.error("DetailInfoManager: update failed to detect new unit hover. [FAIL]", dim.hoveredUnit);
+        }
+    } catch (e) {
+        console.error("DetailInfoManager: Error during update (new hover) test. [FAIL]", e);
+    }
+
+    // 테스트 4: update - 호버링 해제
+    testCount++;
+    try {
+        const dim = new DetailInfoManager(mockEventManager, mockMeasureManager, mockBattleSimulationManager, mockHeroEngine, mockIdManager);
+        dim.hoveredUnit = mockWarriorUnit; // 이미 호버링 중
+        dim.tooltipVisible = true;
+        dim.tooltipAlpha = 1;
+
+        dim._onCanvasMouseMove({ x: 0, y: 0 }); // 유닛 밖으로 마우스 이동
+        dim.update(16);
+
+        if (!dim.tooltipVisible && dim.tooltipAlpha < 1) {
+            console.log("DetailInfoManager: update correctly initiated hover end (fade out). [PASS]");
+            passCount++;
+        } else {
+            console.error("DetailInfoManager: update failed to end hover. [FAIL]", dim.tooltipVisible, dim.tooltipAlpha);
+        }
+    } catch (e) {
+        console.error("DetailInfoManager: Error during update (hover end) test. [FAIL]", e);
+    }
+
+    // 테스트 5: update - 죽은 유닛 호버링 무시
+    testCount++;
+    mockBattleSimulationManager.unitsOnGrid = [mockDeadUnit];
+    mockAnimationManager.getRenderPosition = (unitId) => {
+        if (unitId === 'unit_dead_001') return { drawX: 100, drawY: 100 };
+        return { drawX: 0, drawY: 0 };
+    };
+    try {
+        const dim = new DetailInfoManager(mockEventManager, mockMeasureManager, mockBattleSimulationManager, mockHeroEngine, mockIdManager);
+        dim._onCanvasMouseMove({ x: 120, y: 120 }); // 죽은 유닛 위에 마우스
+        dim.update(16);
+
+        if (dim.hoveredUnit === null) {
+            console.log("DetailInfoManager: update correctly ignored dead unit hover. [PASS]");
+            passCount++;
+        } else {
+            console.error("DetailInfoManager: update failed to ignore dead unit hover. [FAIL]", dim.hoveredUnit);
+        }
+    } catch (e) {
+        console.error("DetailInfoManager: Error during update (dead unit) test. [FAIL]", e);
+    }
+
+    // 테스트 6: draw - 툴팁 그리기 호출 확인 (호버링 중인 유닛이 있을 때)
+    testCount++;
+    mockBattleSimulationManager.unitsOnGrid = [mockWarriorUnit];
+    mockAnimationManager.getRenderPosition = () => ({ drawX: 100, drawY: 100 }); // 목업
+    mockCtx.fillRectCalled = false;
+    mockCtx.strokeRectCalled = false;
+    mockCtx.fillTextCalled = false;
+    try {
+        const dim = new DetailInfoManager(mockEventManager, mockMeasureManager, mockBattleSimulationManager, mockHeroEngine, mockIdManager);
+        dim.hoveredUnit = mockWarriorUnit;
+        dim.tooltipVisible = true;
+        dim.tooltipAlpha = 1; // 완전 표시 상태
+        await dim.draw(mockCtx);
+
+        if (mockCtx.fillRectCalled && mockCtx.strokeRectCalled && mockCtx.fillTextCalled) {
+            console.log("DetailInfoManager: draw called drawing operations when unit is hovered. [PASS]");
+            passCount++;
+        } else {
+            console.error("DetailInfoManager: draw failed to call drawing operations. [FAIL]", mockCtx);
+        }
+    } catch (e) {
+        console.error("DetailInfoManager: Error during draw test. [FAIL]", e);
+    }
+
+    // 테스트 7: draw - 툴팁 그리기 호출 없음 (호버링 유닛이 없거나 알파가 0일 때)
+    testCount++;
+    mockCtx.fillRectCalled = false;
+    mockCtx.strokeRectCalled = false;
+    mockCtx.fillTextCalled = false;
+    try {
+        const dim = new DetailInfoManager(mockEventManager, mockMeasureManager, mockBattleSimulationManager, mockHeroEngine, mockIdManager);
+        dim.hoveredUnit = null;
+        dim.tooltipVisible = false;
+        dim.tooltipAlpha = 0;
+        await dim.draw(mockCtx);
+
+        if (!mockCtx.fillRectCalled && !mockCtx.strokeRectCalled && !mockCtx.fillTextCalled) {
+            console.log("DetailInfoManager: draw correctly skipped drawing when no unit is hovered or alpha is 0. [PASS]");
+            passCount++;
+        } else {
+            console.error("DetailInfoManager: draw unexpectedly called drawing operations. [FAIL]", mockCtx);
+        }
+    } catch (e) {
+        console.error("DetailInfoManager: Error during draw (no hover) test. [FAIL]", e);
+    }
+
+
+    console.log(`--- DetailInfoManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}


### PR DESCRIPTION
## Summary
- introduce `DetailInfoManager` for unit hover tooltips
- publish mouse move events from `InputManager`
- expose grid render parameters via `BattleSimulationManager`
- integrate detail info manager into `GameEngine`
- wire up new test utilities and debug page button
- add unit tests for `DetailInfoManager`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68778255ebe083279edf43d4ee1c55ba