### PR TITLE
Add TagManager and integrate unit tests

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -18,7 +18,8 @@ export const CLASSES = {
         role: CLASS_ROLES.MELEE_DPS,
         description: '강력한 근접 공격과 방어력을 겸비한 병종.',
         skills: ['skill_melee_attack', 'skill_shield_block'],
-        moveRange: 3 // 전사의 이동 거리
+        moveRange: 3, // 전사의 이동 거리
+        tags: ['근접', '방어', '용병_클래스'] // ✨ 태그 추가
     },
     // ✨ 새롭게 추가된 해골 클래스
     SKELETON: {
@@ -27,7 +28,8 @@ export const CLASSES = {
         role: CLASS_ROLES.MELEE_DPS,
         description: '다수로 몰려오는 기본적인 언데드 적.',
         skills: ['skill_melee_attack'],
-        moveRange: 2 // 해골의 이동 거리(예시)
+        moveRange: 2, // 해골의 이동 거리(예시)
+        tags: ['근접', '언데드', '적_클래스'] // ✨ 태그 추가
     }
     // 다른 클래스들이 여기에 추가됩니다.
     // MAGE: { id: 'class_mage', ... }

--- a/data/unit.js
+++ b/data/unit.js
@@ -30,7 +30,8 @@ export const UNITS = {
             luck: 15,
             weight: 30
         },
-        spriteId: 'sprite_warrior_default'
+        spriteId: 'sprite_warrior_default',
+        tags: ['용병', '남자'] // ✨ 유닛 자체의 태그
     }
     // 다른 유닛들이 여기에 추가됩니다.
     // ARCHER: { id: 'unit_archer_001', ... }

--- a/debug.html
+++ b/debug.html
@@ -102,6 +102,7 @@
         <button id="runWorkflowManagerUnitTestsBtn">WorkflowManager 유닛 테스트</button>
         <button id="runDisarmManagerUnitTestsBtn">DisarmManager 유닛 테스트</button>
         <button id="runCoordinateManagerUnitTestsBtn">CoordinateManager 유닛 테스트</button> <button id="runTargetingManagerUnitTestsBtn">TargetingManager 유닛 테스트</button> <button id="runHeroEngineUnitTestsBtn">HeroEngine 유닛 테스트</button> <button id="runSynergyEngineUnitTestsBtn">SynergyEngine 유닛 테스트</button> <button id="runDetailInfoManagerUnitTestsBtn">DetailInfoManager 유닛 테스트</button>
+        <button id="runTagManagerUnitTestsBtn">TagManager 유닛 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -185,7 +186,8 @@
             runCoordinateManagerUnitTests,
             runHeroEngineUnitTests,
             runSynergyEngineUnitTests,
-            runDetailInfoManagerUnitTests
+            runDetailInfoManagerUnitTests,
+            runTagManagerUnitTests
     } from './tests/index.js';
     import { STATUS_EFFECTS } from './data/statusEffects.js';
     // ✨ 상수 파일 임포트
@@ -393,6 +395,10 @@
             // ✨ DetailInfoManager 단위 테스트 버튼 리스너 추가
             document.getElementById('runDetailInfoManagerUnitTestsBtn').addEventListener('click', () => {
                 runDetailInfoManagerUnitTests(); // 목업 사용
+            });
+            // ✨ TagManager 단위 테스트 버튼 리스너 추가
+            document.getElementById('runTagManagerUnitTestsBtn').addEventListener('click', () => {
+                runTagManagerUnitTests(idManager);
             });
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
                 injectRendererFault(renderer);

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -53,6 +53,7 @@ import { BattleGridManager } from './managers/BattleGridManager.js';
 import { CoordinateManager } from './managers/CoordinateManager.js';
 import { ButtonEngine } from './managers/ButtonEngine.js'; // ✨ ButtonEngine 임포트
 import { DetailInfoManager } from './managers/DetailInfoManager.js'; // ✨ DetailInfoManager 추가
+import { TagManager } from './managers/TagManager.js'; // ✨ TagManager 추가
 
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES } from './constants.js';
@@ -206,6 +207,9 @@ export class GameEngine {
             this.heroEngine,
             this.idManager
         );
+
+        // ✨ TagManager 초기화
+        this.tagManager = new TagManager(this.idManager);
         // BattleCalculationManager는 DiceRollManager가 준비된 이후에 초기화합니다.
         this.battleCalculationManager = new BattleCalculationManager(
             this.eventManager,
@@ -521,4 +525,6 @@ export class GameEngine {
     getCoordinateManager() { return this.coordinateManager; }
     // ✨ TargetingManager getter 추가
     getTargetingManager() { return this.targetingManager; }
+    // ✨ TagManager getter 추가
+    getTagManager() { return this.tagManager; }
 }

--- a/js/managers/TagManager.js
+++ b/js/managers/TagManager.js
@@ -1,0 +1,144 @@
+export class TagManager {
+    /**
+     * TagManager를 초기화합니다.
+     * @param {IdManager} idManager - 데이터 정의를 조회할 IdManager 인스턴스
+     */
+    constructor(idManager) {
+        console.log("\ud83c\udff7\ufe0f TagManager initialized. Ready to enforce tag-based rules. \ud83c\udff7\ufe0f");
+        this.idManager = idManager;
+        // 유효한 태그 목록을 여기에 정의할 수 있습니다. (확장 가능성)
+        // 예: this.validTags = new Set(['근접', '원거리', '마법', '방어', '경갑', '중갑', '언데드', '무기', '방어구', '검', '활', '지팡이']);
+    }
+
+    /**
+     * 데이터 객체가 특정 태그를 가지고 있는지 확인합니다.
+     * @param {object} dataObject - 태그를 확인할 데이터 객체 (예: 클래스, 아이템, 스킬 정의)
+     * @param {string} tag - 확인할 단일 태그
+     * @returns {boolean} 데이터 객체가 해당 태그를 가지고 있으면 true
+     */
+    hasTag(dataObject, tag) {
+        if (!dataObject || !Array.isArray(dataObject.tags)) {
+            return false;
+        }
+        return dataObject.tags.includes(tag);
+    }
+
+    /**
+     * 데이터 객체가 필요한 모든 태그를 가지고 있는지 확인합니다.
+     * @param {object} dataObject - 태그를 확인할 데이터 객체
+     * @param {string[]} requiredTags - 필요한 모든 태그 배열
+     * @returns {boolean} 데이터 객체가 모든 필요한 태그를 가지고 있으면 true
+     */
+    hasAllTags(dataObject, requiredTags) {
+        if (!dataObject || !Array.isArray(dataObject.tags)) {
+            return requiredTags.length === 0; // 필요한 태그가 없으면 true 반환 (방어적)
+        }
+        return requiredTags.every(tag => dataObject.tags.includes(tag));
+    }
+
+    /**
+     * 데이터 객체가 필요한 태그 중 하나라도 가지고 있는지 확인합니다.
+     * @param {object} dataObject - 태그를 확인할 데이터 객체
+     * @param {string[]} anyTags - 필요한 태그 중 하나라도 있으면 되는 태그 배열
+     * @returns {boolean} 데이터 객체가 필요한 태그 중 하나라도 가지고 있으면 true
+     */
+    hasAnyTag(dataObject, anyTags) {
+        if (!dataObject || !Array.isArray(dataObject.tags)) {
+            return false;
+        }
+        return anyTags.some(tag => dataObject.tags.includes(tag));
+    }
+
+    /**
+     * 유닛(또는 클래스)이 특정 아이템을 장착할 수 있는지 태그를 기준으로 검사합니다.
+     * 아이템의 `requiredUnitTags` 배열에 있는 태그 중 **하나라도** 유닛의 `tags`에 포함되어야 장착 가능하다고 가정합니다.
+     * @param {object} unitOrClassData - 장착을 시도하는 유닛 또는 클래스 데이터 (tags 배열 포함)
+     * @param {object} itemData - 장착할 아이템 데이터 (requiredUnitTags 배열 포함)
+     * @returns {boolean} 유닛이 아이템을 장착할 수 있으면 true
+     */
+    canEquipItem(unitOrClassData, itemData) {
+        if (!unitOrClassData || !Array.isArray(unitOrClassData.tags)) {
+            console.warn(`[TagManager] Unit/Class data missing or invalid tags for equip check:`, unitOrClassData);
+            return false;
+        }
+        if (!itemData || !Array.isArray(itemData.requiredUnitTags)) {
+            console.warn(`[TagManager] Item data missing or invalid requiredUnitTags for equip check:`, itemData);
+            return false; // 아이템에 필요한 태그 정보가 없으면 장착 불가
+        }
+
+        // 아이템이 요구하는 태그 중 유닛이 하나라도 가지고 있다면 true
+        const canEquip = itemData.requiredUnitTags.some(requiredTag =>
+            unitOrClassData.tags.includes(requiredTag)
+        );
+
+        if (!canEquip) {
+            console.log(`[TagManager] Cannot equip '${itemData.id}'. Unit '${unitOrClassData.id}' tags [${unitOrClassData.tags.join(',')}] do not match required item tags [${itemData.requiredUnitTags.join(',')}]`);
+        } else {
+            console.log(`[TagManager] Unit '${unitOrClassData.id}' can equip '${itemData.id}'.`);
+        }
+        return canEquip;
+    }
+
+    /**
+     * 유닛(또는 클래스)이 특정 스킬을 사용할 수 있는지 태그를 기준으로 검사합니다.
+     * 스킬의 `requiredUserTags` 배열에 있는 태그 중 **모두** 유닛의 `tags`에 포함되어야 사용 가능하다고 가정합니다.
+     * @param {object} unitOrClassData - 스킬을 사용하려는 유닛 또는 클래스 데이터 (tags 배열 포함)
+     * @param {object} skillData - 사용할 스킬 데이터 (requiredUserTags 배열 포함)
+     * @returns {boolean} 유닛이 스킬을 사용할 수 있으면 true
+     */
+    canUseSkill(unitOrClassData, skillData) {
+        if (!unitOrClassData || !Array.isArray(unitOrClassData.tags)) {
+            console.warn(`[TagManager] Unit/Class data missing or invalid tags for skill check:`, unitOrClassData);
+            return false;
+        }
+        if (!skillData || !Array.isArray(skillData.requiredUserTags)) {
+            // 스킬에 사용자 요구 태그 정보가 없으면 기본적으로 사용 가능
+            return true;
+        }
+
+        // 스킬이 요구하는 모든 태그를 유닛이 가지고 있다면 true
+        const canUse = skillData.requiredUserTags.every(requiredTag =>
+            unitOrClassData.tags.includes(requiredTag)
+        );
+
+        if (!canUse) {
+            console.log(`[TagManager] Cannot use skill '${skillData.id}'. Unit '${unitOrClassData.id}' tags [${unitOrClassData.tags.join(',')}] do not match required skill tags [${skillData.requiredUserTags.join(',')}]`);
+        } else {
+            console.log(`[TagManager] Unit '${unitOrClassData.id}' can use skill '${skillData.id}'.`);
+        }
+        return canUse;
+    }
+
+    /**
+     * 특정 데이터 ID에 해당하는 객체의 태그가 예상 태그와 일치하는지 점검합니다.
+     * 주로 단위 테스트나 데이터 유효성 검사 시 사용됩니다.
+     * @param {string} dataId - 검사할 데이터의 ID (클래스, 스킬, 아이템 등)
+     * @param {string[]} expectedTags - 예상되는 태그 배열
+     * @returns {Promise<boolean>} 태그가 일치하면 true, 아니면 false
+     */
+    async validateDataTags(dataId, expectedTags) {
+        const data = await this.idManager.get(dataId);
+        if (!data) {
+            console.error(`[TagManager] Validation failed: Data for ID '${dataId}' not found.`);
+            return false;
+        }
+        if (!Array.isArray(data.tags)) {
+            console.error(`[TagManager] Validation failed: Data for ID '${dataId}' has no 'tags' array.`);
+            return false;
+        }
+
+        const missingExpected = expectedTags.filter(tag => !data.tags.includes(tag));
+        const unexpectedExisting = data.tags.filter(tag => !expectedTags.includes(tag));
+
+        if (missingExpected.length > 0) {
+            console.error(`[TagManager] Validation failed for '${dataId}': Missing expected tags: [${missingExpected.join(', ')}]`);
+            return false;
+        }
+        if (unexpectedExisting.length > 0) {
+            console.warn(`[TagManager] Validation warning for '${dataId}': Unexpected tags found: [${unexpectedExisting.join(', ')}]`);
+        }
+
+        console.log(`[TagManager] Validation successful for '${dataId}'. All expected tags found.`);
+        return true;
+    }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,6 +7,7 @@ export { runMapManagerUnitTests } from './unit/mapManagerUnitTests.js';
 export { runUIEngineUnitTests } from './unit/uiEngineUnitTests.js';
 export { runButtonEngineUnitTests } from './unit/buttonEngineUnitTests.js';
 export { runDetailInfoManagerUnitTests } from './unit/detailInfoManagerUnitTests.js'; // ✨ DetailInfoManager 단위 테스트 추가
+export { runTagManagerUnitTests } from './unit/tagManagerUnitTests.js'; // ✨ TagManager 단위 테스트 추가
 
 // new unit tests
 export { runSceneEngineUnitTests } from './unit/sceneEngineUnitTests.js';
@@ -70,4 +71,5 @@ export function runEngineTests(renderer, gameLoop, battleSimulationManager = nul
         runSynergyEngineUnitTests(idManager, eventManager);
     }
     runDetailInfoManagerUnitTests(); // 목업 사용
+    runTagManagerUnitTests(idManager);
 }

--- a/tests/unit/tagManagerUnitTests.js
+++ b/tests/unit/tagManagerUnitTests.js
@@ -1,0 +1,189 @@
+import { TagManager } from '../../js/managers/TagManager.js';
+
+export function runTagManagerUnitTests(idManager) {
+    console.log("--- TagManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // Mock IdManager for testing validateDataTags
+    const mockIdManager = idManager || {
+        get: async (id) => {
+            switch (id) {
+                case 'class_warrior':
+                    return { id: 'class_warrior', name: '전사', tags: ['근접', '방어', '용병'] };
+                case 'class_mage':
+                    return { id: 'class_mage', name: '마법사', tags: ['원거리', '마법', '용병'] };
+                case 'class_skeleton':
+                    return { id: 'class_skeleton', name: '해골', tags: ['근접', '언데드', '적'] };
+                case 'item_sword':
+                    return { id: 'item_sword', name: '강철 검', type: '무기', tags: ['무기', '검'], requiredUnitTags: ['근접'] };
+                case 'item_staff':
+                    return { id: 'item_staff', name: '마법 지팡이', type: '무기', tags: ['무기', '지팡이'], requiredUnitTags: ['마법'] };
+                case 'item_heavy_armor':
+                    return { id: 'item_heavy_armor', name: '중갑', type: '방어구', tags: ['방어구', '중갑'], requiredUnitTags: ['방어'] };
+                case 'skill_charge':
+                    return { id: 'skill_charge', name: '돌격', tags: ['이동', '공격'], requiredUserTags: ['근접'] };
+                case 'skill_fireball':
+                    return { id: 'skill_fireball', name: '화염구', tags: ['마법', '원거리', '공격'], requiredUserTags: ['마법'] };
+                default:
+                    return undefined;
+            }
+        }
+    };
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        if (tm.idManager === mockIdManager) {
+            console.log("TagManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: hasTag - 단일 태그 포함 여부
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const warriorData = await mockIdManager.get('class_warrior');
+        if (tm.hasTag(warriorData, '근접') && !tm.hasTag(warriorData, '마법')) {
+            console.log("TagManager: hasTag correctly identified tag presence. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: hasTag failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during hasTag test. [FAIL]", e);
+    }
+
+    // 테스트 3: hasAllTags - 모든 태그 포함 여부
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const warriorData = await mockIdManager.get('class_warrior');
+        if (tm.hasAllTags(warriorData, ['근접', '방어']) && !tm.hasAllTags(warriorData, ['근접', '마법'])) {
+            console.log("TagManager: hasAllTags correctly identified all tags presence. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: hasAllTags failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during hasAllTags test. [FAIL]", e);
+    }
+
+    // 테스트 4: hasAnyTag - 하나라도 태그 포함 여부
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const warriorData = await mockIdManager.get('class_warrior');
+        if (tm.hasAnyTag(warriorData, ['방어', '마법']) && !tm.hasAnyTag(warriorData, ['원거리', '지팡이'])) {
+            console.log("TagManager: hasAnyTag correctly identified any tag presence. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: hasAnyTag failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during hasAnyTag test. [FAIL]", e);
+    }
+
+    // 테스트 5: canEquipItem - 장착 가능 (전사-검)
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const warriorData = await mockIdManager.get('class_warrior');
+        const swordData = await mockIdManager.get('item_sword');
+        if (tm.canEquipItem(warriorData, swordData)) {
+            console.log("TagManager: canEquipItem correctly allowed Warrior to equip Sword. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: canEquipItem failed to allow Warrior to equip Sword. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during canEquipItem (Warrior-Sword) test. [FAIL]", e);
+    }
+
+    // 테스트 6: canEquipItem - 장착 불가 (전사-지팡이)
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const warriorData = await mockIdManager.get('class_warrior');
+        const staffData = await mockIdManager.get('item_staff');
+        if (!tm.canEquipItem(warriorData, staffData)) {
+            console.log("TagManager: canEquipItem correctly denied Warrior to equip Staff. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: canEquipItem failed to deny Warrior to equip Staff. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during canEquipItem (Warrior-Staff) test. [FAIL]", e);
+    }
+
+    // 테스트 7: canUseSkill - 사용 가능 (전사-돌격)
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const warriorData = await mockIdManager.get('class_warrior');
+        const chargeSkillData = await mockIdManager.get('skill_charge');
+        if (tm.canUseSkill(warriorData, chargeSkillData)) {
+            console.log("TagManager: canUseSkill correctly allowed Warrior to use Charge. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: canUseSkill failed to allow Warrior to use Charge. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during canUseSkill (Warrior-Charge) test. [FAIL]", e);
+    }
+
+    // 테스트 8: canUseSkill - 사용 불가 (전사-화염구)
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const warriorData = await mockIdManager.get('class_warrior');
+        const fireballSkillData = await mockIdManager.get('skill_fireball');
+        if (!tm.canUseSkill(warriorData, fireballSkillData)) {
+            console.log("TagManager: canUseSkill correctly denied Warrior to use Fireball. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: canUseSkill failed to deny Warrior to use Fireball. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during canUseSkill (Warrior-Fireball) test. [FAIL]", e);
+    }
+
+    // 테스트 9: validateDataTags - 태그 검증 성공
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const isValid = await tm.validateDataTags('class_warrior', ['근접', '방어', '용병']);
+        if (isValid) {
+            console.log("TagManager: validateDataTags succeeded for Warrior. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: validateDataTags failed for Warrior. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during validateDataTags (success) test. [FAIL]", e);
+    }
+
+    // 테스트 10: validateDataTags - 태그 검증 실패 (누락)
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const isValid = await tm.validateDataTags('class_warrior', ['근접', '방어', '치유']); // '치유' 누락
+        if (!isValid) {
+            console.log("TagManager: validateDataTags correctly failed for missing tag. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: validateDataTags unexpectedly passed for missing tag. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during validateDataTags (missing) test. [FAIL]", e);
+    }
+
+    console.log(`--- TagManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}


### PR DESCRIPTION
## Summary
- introduce `TagManager` for tag-based checks
- add unit tests for TagManager
- integrate TagManager into `GameEngine`
- expose TagManager via `GameEngine` getter
- register TagManager unit tests in test harness and debug UI
- include example tags in class and unit data

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68778a2df8988327abbdf612d315e201