### PR TITLE
Implement debug mode and asset loading progress

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -22,7 +22,9 @@ export const GAME_EVENTS = {
     SYNERGY_ACTIVATED: 'synergyActivated',   // 이전 요청에 의해 추가된 코드
     SYNERGY_DEACTIVATED: 'synergyDeactivated', // 이전 요청에 의해 추가된 코드
     CANVAS_MOUSE_MOVED: 'canvasMouseMoved', // ✨ 마우스 이동 이벤트 추가
-    CRITICAL_ERROR: 'criticalError' // ✨ 심각한 오류 발생 시 발행될 이벤트
+    CRITICAL_ERROR: 'criticalError', // ✨ 심각한 오류 발생 시 발행될 이벤트
+    ASSET_LOAD_PROGRESS: 'assetLoadProgress', // ✨ 에셋 로딩 진행 이벤트 추가
+    ASSETS_LOADED: 'assetsLoaded'             // ✨ 모든 에셋 로딩 완료 이벤트 추가
 };
 
 export const UI_STATES = {
@@ -48,3 +50,5 @@ export const ATTACK_TYPES = {
     MERCENARY: 'mercenary',
     ENEMY: 'enemy'
 };
+
+export const GAME_DEBUG_MODE = true; // ✨ 디버그 모드 플래그 (배포 시 false로 설정)

--- a/js/managers/ParticleEngine.js
+++ b/js/managers/ParticleEngine.js
@@ -1,8 +1,9 @@
 // js/managers/ParticleEngine.js
+import { GAME_DEBUG_MODE } from '../constants.js';
 
 export class ParticleEngine {
     constructor(measureManager, cameraEngine, battleSimulationManager) {
-        console.log("\u2728 ParticleEngine initialized. Ready to create visual sparks. \u2728");
+        if (GAME_DEBUG_MODE) console.log("\u2728 ParticleEngine initialized. Ready to create visual sparks. \u2728");
         this.measureManager = measureManager;
         this.cameraEngine = cameraEngine;
         this.battleSimulationManager = battleSimulationManager; // 유닛 위치 정보를 얻기 위함
@@ -66,7 +67,7 @@ export class ParticleEngine {
             };
             this.activeParticles.push(particle);
         }
-        console.log(`[ParticleEngine] Added ${particleCount} particles for unit ${unitId}.`);
+        if (GAME_DEBUG_MODE) console.log(`[ParticleEngine] Added ${particleCount} particles for unit ${unitId}.`);
     }
 
     /**
@@ -75,10 +76,13 @@ export class ParticleEngine {
      */
     update(deltaTime) {
         const currentTime = performance.now();
-        this.activeParticles = this.activeParticles.filter(particle => {
+        let i = this.activeParticles.length;
+        while (i--) {
+            const particle = this.activeParticles[i];
             const elapsed = currentTime - particle.startTime;
             if (elapsed > particle.duration) {
-                return false; // 파티클 수명 만료
+                this.activeParticles.splice(i, 1);
+                continue;
             }
 
             // 위치 업데이트 (speedY는 음수이므로 빼기)
@@ -87,8 +91,7 @@ export class ParticleEngine {
 
             // 투명도 업데이트 (점점 사라지게)
             particle.alpha = Math.max(0, 1 - (elapsed / particle.duration));
-            return true;
-        });
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `GAME_DEBUG_MODE` constant with asset progress events
- wire debug flag into `GameEngine` and subscribe to asset loading events
- extend `AssetLoaderManager` to report loading progress
- optimize `VFXManager` and `ParticleEngine` updates and guard debug logs

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68778d67b1d483278a1e5bc9cc08325c