### PR TITLE
Add placeholder skill icons fallback

### DIFF
--- a/js/managers/SkillIconManager.js
+++ b/js/managers/SkillIconManager.js
@@ -21,6 +21,12 @@ export class SkillIconManager {
         this.idManager = idManager;
         this.skillIcons = new Map(); // key: skillId, value: HTMLImageElement
 
+        // 아이콘 로드 실패 시 사용할 기본 플레이스홀더 이미지 생성
+        this.placeholderIcon = new Image();
+        // 투명한 1x1 png 데이터
+        this.placeholderIcon.src =
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+hHgAHggJ/p14WAAAAAElFTkSuQmCC';
+
         this._loadDefaultSkillIcons(); // 초기 스킬 아이콘 로드
     }
 
@@ -55,6 +61,7 @@ export class SkillIconManager {
                     })
                     .catch(error => {
                         console.error(`[SkillIconManager] Failed to load icon for ${skillId} from ${url}:`, error);
+                        this.skillIcons.set(skillId, this.placeholderIcon);
                     })
             );
         }
@@ -74,7 +81,8 @@ export class SkillIconManager {
         }
         const icon = this.skillIcons.get(skillId);
         if (!icon) {
-            if (GAME_DEBUG_MODE) console.warn(`[SkillIconManager] Icon not found for skill ID: ${skillId}.`);
+            if (GAME_DEBUG_MODE) console.warn(`[SkillIconManager] Icon not found for skill ID: ${skillId}. Using placeholder.`);
+            return this.placeholderIcon;
         }
         return icon;
     }

--- a/tests/unit/skillIconManagerUnitTests.js
+++ b/tests/unit/skillIconManagerUnitTests.js
@@ -71,11 +71,11 @@ export function runSkillIconManagerUnitTests(assetLoaderManager, idManager) {
         const sim = new SkillIconManager(mockAssetLoaderManager, mockIdManager);
         await sim._loadDefaultSkillIcons();
         const icon = sim.getSkillIcon('non_existent_skill_icon');
-        if (icon === undefined) {
-            console.log("SkillIconManager: getSkillIcon returned undefined for non-existent icon. [PASS]");
+        if (icon && icon.src && icon.src.startsWith('data:image')) {
+            console.log("SkillIconManager: getSkillIcon returned placeholder for non-existent icon. [PASS]");
             passCount++;
         } else {
-            console.error("SkillIconManager: getSkillIcon failed for non-existent icon. [FAIL]", icon);
+            console.error("SkillIconManager: getSkillIcon failed to return placeholder for non-existent icon. [FAIL]", icon);
         }
     } catch (e) {
         console.error("SkillIconManager: Error during getSkillIcon (non-existent) test. [FAIL]", e);


### PR DESCRIPTION
## Summary
- provide a placeholder image in `SkillIconManager`
- use the placeholder when loading a skill icon fails or when an icon is missing
- adjust unit tests for the new placeholder behaviour

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68779c1326948327b1ea47f13f82756a