### PR TITLE
Implement MovingManager and charge skill

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -105,6 +105,8 @@
         <button id="runTagManagerUnitTestsBtn">TagManager 유닛 테스트</button>
         <button id="runSkillIconManagerUnitTestsBtn">SkillIconManager 유닛 테스트</button>
         <button id="runStatusIconManagerUnitTestsBtn">StatusIconManager 유닛 테스트</button>
+        <button id="runMovingManagerUnitTestsBtn">MovingManager 유닛 테스트</button>
+        <button id="runWarriorSkillsAIUnitTestsBtn">WarriorSkillsAI 유닛 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -411,6 +413,12 @@
             // ✨ StatusIconManager 단위 테스트 버튼 리스너
             document.getElementById('runStatusIconManagerUnitTestsBtn').addEventListener('click', () => {
                 runStatusIconManagerUnitTests();
+            });
+            document.getElementById('runMovingManagerUnitTestsBtn').addEventListener('click', () => {
+                runMovingManagerUnitTests();
+            });
+            document.getElementById('runWarriorSkillsAIUnitTestsBtn').addEventListener('click', () => {
+                runWarriorSkillsAIUnitTests();
             });
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
                 injectRendererFault(renderer);

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -18,6 +18,7 @@ import { BattleSimulationManager } from './managers/BattleSimulationManager.js';
 import { AnimationManager } from './managers/AnimationManager.js';
 import { VFXManager } from './managers/VFXManager.js';
 import { ParticleEngine } from './managers/ParticleEngine.js'; // ✨ ParticleEngine 임포트
+import { MovingManager } from './managers/MovingManager.js'; // ✨ MovingManager 추가
 import { DisarmManager } from './managers/DisarmManager.js'; // ✨ DisarmManager 임포트
 import { CanvasBridgeManager } from './managers/CanvasBridgeManager.js'; // ✨ CanvasBridgeManager 추가
 import { SkillIconManager } from './managers/SkillIconManager.js'; // ✨ SkillIconManager 추가
@@ -186,6 +187,14 @@ export class GameEngine {
         this.battleGridManager = new BattleGridManager(this.measureManager, this.logicManager);
         // ✨ CoordinateManager 초기화 - BattleSimulationManager 후
         this.coordinateManager = new CoordinateManager(this.battleSimulationManager, this.battleGridManager);
+
+        // ✨ MovingManager 초기화
+        this.movingManager = new MovingManager(
+            this.battleSimulationManager,
+            this.animationManager,
+            this.delayEngine,
+            this.coordinateManager
+        );
         // VFXManager에 AnimationManager를 전달하여 HP 바 위치를 애니메이션과 동기화합니다.
         this.vfxManager = new VFXManager(
             this.renderer,
@@ -296,6 +305,7 @@ export class GameEngine {
             this.cameraEngine,
             this.battleSimulationManager
         );
+        this.animationManager.particleEngine = this.particleEngine; // AnimationManager에 ParticleEngine 전달
 
         // VFXManager에 ParticleEngine 전달
         this.vfxManager.particleEngine = this.particleEngine;
@@ -314,7 +324,8 @@ export class GameEngine {
             workflowManager: this.workflowManager,
             animationManager: this.animationManager,
             measureManager: this.measureManager,
-            idManager: this.idManager
+            idManager: this.idManager,
+            movingManager: this.movingManager
         };
         this.warriorSkillsAI = new WarriorSkillsAI(commonManagersForSkills);
 
@@ -571,6 +582,7 @@ export class GameEngine {
     getWorkflowManager() { return this.workflowManager; }
     getDisarmManager() { return this.disarmManager; }
     getParticleEngine() { return this.particleEngine; } // ✨ ParticleEngine getter 추가
+    getMovingManager() { return this.movingManager; } // ✨ MovingManager getter 추가
 
     getButtonEngine() { return this.buttonEngine; }
 

--- a/js/managers/AnimationManager.js
+++ b/js/managers/AnimationManager.js
@@ -1,11 +1,18 @@
 // js/managers/AnimationManager.js
 
+import { GAME_DEBUG_MODE } from '../constants.js'; // ✨ GAME_DEBUG_MODE 임포트
+
 export class AnimationManager {
-    constructor(measureManager, battleSimulationManager = null) {
-        console.log("\uD83C\uDFC3 AnimationManager initialized. Ready to animate movements. \uD83C\uDFC3");
+    // ✨ particleEngine을 추가로 받습니다.
+    constructor(measureManager, battleSimulationManager = null, particleEngine) {
+        if (GAME_DEBUG_MODE) console.log("\uD83C\uDFC3 AnimationManager initialized. Ready to animate movements. \uD83C\uDFC3");
+        if (!particleEngine) {
+            throw new Error("[AnimationManager] Missing ParticleEngine. Cannot initialize.");
+        }
         this.measureManager = measureManager;
         this.battleSimulationManager = battleSimulationManager;
-        this.activeAnimations = new Map(); // { unitId: { startPixelX, startPixelY, endPixelX, endPixelY, startTime, duration, resolve, currentPixelX, currentPixelY } }
+        this.particleEngine = particleEngine; // ✨ ParticleEngine 저장
+        this.activeAnimations = new Map();
         this.animationSpeed = 0.005; // Tiles per millisecond
     }
 
@@ -55,7 +62,80 @@ export class AnimationManager {
                 currentPixelX: startPixelX,
                 currentPixelY: startPixelY
             });
-            console.log(`[AnimationManager] Queued move animation for unit ${unitId} from (${startGridX},${startGridY}) to (${endGridX},${endGridY}) with duration ${duration.toFixed(0)}ms.`);
+            if (GAME_DEBUG_MODE) console.log(`[AnimationManager] Queued move animation for unit ${unitId} from (${startGridX},${startGridY}) to (${endGridX},${endGridY}) with duration ${duration.toFixed(0)}ms.`);
+        });
+    }
+
+    /**
+     * 이동 애니메이션의 지속 시간을 반환합니다.
+     * @param {number} startGridX
+     * @param {number} startGridY
+     * @param {number} endGridX
+     * @param {number} endGridY
+     * @returns {number} 애니메이션 지속 시간 (ms)
+     */
+    getAnimationDuration(startGridX, startGridY, endGridX, endGridY) {
+        const dist = Math.sqrt(
+            Math.pow(endGridX - startGridX, 2) +
+            Math.pow(endGridY - startGridY, 2)
+        );
+        return dist / this.animationSpeed;
+    }
+
+    /**
+     * ✨ 유닛 대시 애니메이션을 큐에 추가합니다.
+     * 돌진처럼 빠르게 이동하고 잔상을 남기는 효과를 포함합니다.
+     */
+    queueDashAnimation(unitId, startGridX, startGridY, endGridX, endGridY) {
+        return new Promise(resolve => {
+            if (!this.battleSimulationManager) {
+                if (GAME_DEBUG_MODE) console.warn("[AnimationManager] Cannot queue dash animation: BattleSimulationManager not set.");
+                resolve();
+                return;
+            }
+
+            const sceneContentDimensions = this.battleSimulationManager.logicManager.getCurrentSceneContentDimensions();
+            const canvasWidth = this.measureManager.get('gameResolution.width') || sceneContentDimensions.width;
+            const canvasHeight = this.measureManager.get('gameResolution.height') || sceneContentDimensions.height;
+
+            const gridContentWidth = sceneContentDimensions.width;
+            const gridContentHeight = sceneContentDimensions.height;
+
+            const effectiveTileSize = gridContentWidth / this.battleSimulationManager.gridCols;
+            const totalGridWidth = gridContentWidth;
+            const totalGridHeight = gridContentHeight;
+            const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
+            const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
+
+            const startPixelX = gridOffsetX + startGridX * effectiveTileSize;
+            const startPixelY = gridOffsetY + startGridY * effectiveTileSize;
+            const endPixelX = gridOffsetX + endGridX * effectiveTileSize;
+            const endPixelY = gridOffsetY + endGridY * effectiveTileSize;
+
+            const dashSpeedMultiplier = 3;
+            const dashDuration = this.getAnimationDuration(startGridX, startGridY, endGridX, endGridY) / dashSpeedMultiplier;
+
+            const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+
+            this.activeAnimations.set(unitId, {
+                startPixelX,
+                startPixelY,
+                endPixelX,
+                endPixelY,
+                startTime: performance.now(),
+                duration: dashDuration,
+                resolve,
+                currentPixelX: startPixelX,
+                currentPixelY: startPixelY,
+                type: 'dash',
+                afterimageInterval: setInterval(() => {
+                    if (unit && unit.image) {
+                        this.particleEngine.addUnitAfterimage(unitId, unit.image, unit.gridX, unit.gridY);
+                    }
+                }, 50)
+            });
+
+            if (GAME_DEBUG_MODE) console.log(`[AnimationManager] Queued dash animation for unit ${unitId} from (${startGridX},${startGridY}) to (${endGridX},${endGridY}) with duration ${dashDuration.toFixed(0)}ms.`);
         });
     }
 
@@ -72,8 +152,11 @@ export class AnimationManager {
             if (progress >= 1) {
                 animation.currentPixelX = animation.endPixelX;
                 animation.currentPixelY = animation.endPixelY;
-                console.log(`[AnimationManager] Animation for unit ${unitId} completed.`);
+                if (GAME_DEBUG_MODE) console.log(`[AnimationManager] Animation for unit ${unitId} completed.`);
                 this.activeAnimations.delete(unitId);
+                if (animation.afterimageInterval) {
+                    clearInterval(animation.afterimageInterval);
+                }
                 if (animation.resolve) {
                     animation.resolve();
                 }

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -95,6 +95,20 @@ export class BattleSimulationManager {
     }
 
     /**
+     * 특정 그리드 좌표에 있는 유닛을 반환합니다. (죽은 유닛은 제외)
+     * @param {number} gridX
+     * @param {number} gridY
+     * @returns {object | undefined} 해당 위치의 유닛 객체 또는 없으면 undefined
+     */
+    getUnitAt(gridX, gridY) {
+        return this.unitsOnGrid.find(u =>
+            u.gridX === gridX &&
+            u.gridY === gridY &&
+            u.currentHp > 0
+        );
+    }
+
+    /**
      * 유닛 렌더링에 필요한 그리드 관련 파라미터를 반환합니다.
      * 이 값들은 BattleGridManager와 VFXManager에서도 사용됩니다.
      * @returns {{effectiveTileSize: number, gridOffsetX: number, gridOffsetY: number, totalGridWidth: number, totalGridHeight: number}}

--- a/js/managers/MovingManager.js
+++ b/js/managers/MovingManager.js
@@ -1,0 +1,92 @@
+// js/managers/MovingManager.js
+
+import { GAME_DEBUG_MODE } from '../constants.js'; // 디버그 모드 상수 임포트
+
+export class MovingManager {
+    /**
+     * MovingManager를 초기화합니다.
+     * @param {BattleSimulationManager} battleSimulationManager - 유닛 데이터 및 그리드 업데이트를 위한 인스턴스
+     * @param {AnimationManager} animationManager - 이동 애니메이션 처리를 위한 인스턴스
+     * @param {DelayEngine} delayEngine - 애니메이션 지연을 위한 인스턴스
+     * @param {CoordinateManager} coordinateManager - 좌표 유효성 검사를 위한 인스턴스
+     */
+    constructor(battleSimulationManager, animationManager, delayEngine, coordinateManager) {
+        if (GAME_DEBUG_MODE) console.log("\uD83D\uDE80 MovingManager initialized. Ready for special unit movements. \uD83D\uDE80");
+        if (!battleSimulationManager || !animationManager || !delayEngine || !coordinateManager) {
+            throw new Error("[MovingManager] Missing essential dependencies. Cannot initialize.");
+        }
+        this.battleSimulationManager = battleSimulationManager;
+        this.animationManager = animationManager;
+        this.delayEngine = delayEngine;
+        this.coordinateManager = coordinateManager;
+    }
+
+    /**
+     * 유닛을 지정된 목표 그리드 타일로 '돌진'시킵니다.
+     * 이동 범위 내에서 대상에게 가장 가까운 비어있는 타일로 즉시 이동하는 것을 시뮬레이션합니다.
+     * @param {object} unit - 이동할 유닛 객체
+     * @param {number} targetGridX - 목표 유닛/지점의 X 좌표
+     * @param {number} targetGridY - 목표 유닛/지점의 Y 좌표
+     * @param {number} moveRange - 유닛의 이동 가능 범위
+     * @returns {Promise<boolean>} 이동 성공 여부 Promise
+     */
+    async chargeMove(unit, targetGridX, targetGridY, moveRange) {
+        if (!unit) {
+            if (GAME_DEBUG_MODE) console.warn("[MovingManager] Charge move failed: Unit is null.");
+            return false;
+        }
+
+        const currentX = unit.gridX;
+        const currentY = unit.gridY;
+
+        const potentialDestinations = [];
+        for (let dx = -1; dx <= 1; dx++) {
+            for (let dy = -1; dy <= 1; dy++) {
+                if (dx === 0 && dy === 0) continue;
+
+                const potentialX = targetGridX + dx;
+                const potentialY = targetGridY + dy;
+
+                if (potentialX >= 0 && potentialX < this.battleSimulationManager.gridCols &&
+                    potentialY >= 0 && potentialY < this.battleSimulationManager.gridRows) {
+
+                    const distToTarget = Math.abs(targetGridX - potentialX) + Math.abs(targetGridY - potentialY);
+                    if (distToTarget > 1) continue;
+
+                    const distFromSource = Math.abs(currentX - potentialX) + Math.abs(currentY - potentialY);
+                    if (distFromSource > moveRange) continue;
+
+                    if (!this.coordinateManager.isTileOccupied(potentialX, potentialY, unit.id)) {
+                        potentialDestinations.push({ x: potentialX, y: potentialY, dist: distFromSource });
+                    }
+                }
+            }
+        }
+
+        if (potentialDestinations.length === 0) {
+            if (GAME_DEBUG_MODE) console.log(`[MovingManager] Unit ${unit.name}: No available clear tile near target (${targetGridX},${targetGridY}) within move range ${moveRange}.`);
+            return false;
+        }
+
+        potentialDestinations.sort((a, b) => a.dist - b.dist);
+        const finalDest = potentialDestinations[0];
+
+        if (finalDest.x === currentX && finalDest.y === currentY) {
+            if (GAME_DEBUG_MODE) console.log(`[MovingManager] Unit ${unit.name}: Already at optimal position for charge.`);
+            return false;
+        }
+
+        const movedSuccessfully = this.battleSimulationManager.moveUnit(unit.id, finalDest.x, finalDest.y);
+
+        if (movedSuccessfully) {
+            await this.animationManager.queueDashAnimation(unit.id, currentX, currentY, finalDest.x, finalDest.y);
+            await this.delayEngine.waitFor(this.animationManager.getAnimationDuration(currentX, currentY, finalDest.x, finalDest.y) / 3);
+            if (GAME_DEBUG_MODE) console.log(`[MovingManager] Unit ${unit.name} charged from (${currentX},${currentY}) to (${finalDest.x},${finalDest.y}).`);
+            return true;
+        } else {
+            if (GAME_DEBUG_MODE) console.warn(`[MovingManager] Unit ${unit.name} failed to move to (${finalDest.x},${finalDest.y}) during charge.`);
+            return false;
+        }
+    }
+}
+

--- a/tests/index.js
+++ b/tests/index.js
@@ -10,6 +10,8 @@ export { runDetailInfoManagerUnitTests } from './unit/detailInfoManagerUnitTests
 export { runTagManagerUnitTests } from './unit/tagManagerUnitTests.js'; // ✨ TagManager 단위 테스트 추가
 export { runSkillIconManagerUnitTests } from './unit/skillIconManagerUnitTests.js'; // ✨ SkillIconManager 단위 테스트 추가
 export { runStatusIconManagerUnitTests } from './unit/statusIconManagerUnitTests.js'; // ✨ StatusIconManager 단위 테스트 추가
+export { runMovingManagerUnitTests } from './unit/movingManagerUnitTests.js'; // ✨ MovingManager 단위 테스트 추가
+export { runWarriorSkillsAIUnitTests } from './unit/warriorSkillsAIUnitTests.js'; // ✨ WarriorSkillsAI 테스트 임포트 확인
 
 // new unit tests
 export { runSceneEngineUnitTests } from './unit/sceneEngineUnitTests.js';
@@ -76,4 +78,6 @@ export function runEngineTests(renderer, gameLoop, battleSimulationManager = nul
     runTagManagerUnitTests(idManager);
     runSkillIconManagerUnitTests(assetLoaderManager, idManager);
     runStatusIconManagerUnitTests(); // 목업 사용
+    runMovingManagerUnitTests();
+    runWarriorSkillsAIUnitTests();
 }

--- a/tests/unit/movingManagerUnitTests.js
+++ b/tests/unit/movingManagerUnitTests.js
@@ -1,0 +1,132 @@
+// tests/unit/movingManagerUnitTests.js
+
+import { MovingManager } from '../../js/managers/MovingManager.js';
+import { GAME_DEBUG_MODE } from '../../js/constants.js'; // 디버그 모드 상수 임포트
+
+export function runMovingManagerUnitTests() {
+    if (GAME_DEBUG_MODE) console.log("--- MovingManager Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // Mock Dependencies
+    const mockUnit = { id: 'testUnit', name: 'Test Unit', gridX: 0, gridY: 0, currentHp: 100 };
+    const mockTargetUnit = { id: 'targetUnit', name: 'Target Unit', gridX: 3, gridY: 0, currentHp: 50 };
+
+    const mockBattleSimulationManager = {
+        unitsOnGrid: [mockUnit, mockTargetUnit],
+        gridCols: 10,
+        gridRows: 10,
+        moveUnit: (unitId, newX, newY) => {
+            const unit = mockBattleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+            if (unit) {
+                unit.gridX = newX;
+                unit.gridY = newY;
+                return true;
+            }
+            return false;
+        },
+        isTileOccupied: (x, y, excludeId = null) => {
+            return mockBattleSimulationManager.unitsOnGrid.some(u =>
+                u.id !== excludeId && u.gridX === x && u.gridY === y && u.currentHp > 0
+            );
+        }
+    };
+    mockBattleSimulationManager.getUnitAt = (x, y) => {
+        return mockBattleSimulationManager.unitsOnGrid.find(u => u.gridX === x && u.gridY === y && u.currentHp > 0);
+    };
+
+    const mockAnimationManager = {
+        queueMoveAnimation: async (unitId, startX, startY, endX, endY) => {
+            if (GAME_DEBUG_MODE) console.log(`[MockAnimationManager] Animating move for ${unitId} from (${startX},${startY}) to (${endX},${endY})`);
+        },
+        getAnimationDuration: (startX, startY, endX, endY) => 100,
+        queueDashAnimation: async (unitId, startX, startY, endX, endY) => {
+            if (GAME_DEBUG_MODE) console.log(`[MockAnimationManager] Dash move for ${unitId} from (${startX},${startY}) to (${endX},${endY})`);
+        }
+    };
+    const mockDelayEngine = {
+        waitFor: async (ms) => {
+            await new Promise(resolve => setTimeout(resolve, ms));
+            if (GAME_DEBUG_MODE) console.log(`[MockDelayEngine] Waited for ${ms}ms.`);
+        }
+    };
+    const mockCoordinateManager = {
+        isTileOccupied: (x, y, excludeId = null) => {
+            return mockBattleSimulationManager.isTileOccupied(x, y, excludeId);
+        }
+    };
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const mm = new MovingManager(mockBattleSimulationManager, mockAnimationManager, mockDelayEngine, mockCoordinateManager);
+        if (mm.battleSimulationManager === mockBattleSimulationManager) {
+            if (GAME_DEBUG_MODE) console.log("MovingManager: Initialized correctly. [PASS]");
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("MovingManager: Initialization failed. [FAIL]");
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("MovingManager: Error during initialization. [FAIL]", e);
+    }
+
+    // 테스트 2: chargeMove - 대상 옆으로 성공적으로 돌진
+    testCount++;
+    mockUnit.gridX = 0;
+    mockUnit.gridY = 0;
+    mockBattleSimulationManager.unitsOnGrid = [mockUnit, mockTargetUnit];
+    try {
+        const mm = new MovingManager(mockBattleSimulationManager, mockAnimationManager, mockDelayEngine, mockCoordinateManager);
+        const moved = await mm.chargeMove(mockUnit, mockTargetUnit.gridX, mockTargetUnit.gridY, 5);
+        if (moved && mockUnit.gridX === 2 && mockUnit.gridY === 0) {
+            if (GAME_DEBUG_MODE) console.log("MovingManager: chargeMove successfully moved to target side. [PASS]");
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("MovingManager: chargeMove failed to move to target side. [FAIL]", { moved, x: mockUnit.gridX, y: mockUnit.gridY });
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("MovingManager: Error during chargeMove (success) test. [FAIL]", e);
+    }
+
+    // 테스트 3: chargeMove - 이동 범위 부족으로 돌진 실패
+    testCount++;
+    mockUnit.gridX = 0;
+    mockUnit.gridY = 0;
+    mockBattleSimulationManager.unitsOnGrid = [mockUnit, mockTargetUnit];
+    try {
+        const mm = new MovingManager(mockBattleSimulationManager, mockAnimationManager, mockDelayEngine, mockCoordinateManager);
+        const moved = await mm.chargeMove(mockUnit, mockTargetUnit.gridX, mockTargetUnit.gridY, 1);
+        if (!moved && mockUnit.gridX === 0 && mockUnit.gridY === 0) {
+            if (GAME_DEBUG_MODE) console.log("MovingManager: chargeMove correctly failed due to insufficient move range. [PASS]");
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("MovingManager: chargeMove failed on insufficient range. [FAIL]", { moved, x: mockUnit.gridX, y: mockUnit.gridY });
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("MovingManager: Error during chargeMove (insufficient range) test. [FAIL]", e);
+    }
+
+    // 테스트 4: chargeMove - 목표 옆 타일이 점유되어 돌진 실패
+    testCount++;
+    const mockOccupyingUnit = { id: 'occupy', name: 'Occupier', gridX: 2, gridY: 0, currentHp: 100 };
+    mockUnit.gridX = 0;
+    mockUnit.gridY = 0;
+    mockBattleSimulationManager.unitsOnGrid = [mockUnit, mockTargetUnit, mockOccupyingUnit];
+    try {
+        const mm = new MovingManager(mockBattleSimulationManager, mockAnimationManager, mockDelayEngine, mockCoordinateManager);
+        const moved = await mm.chargeMove(mockUnit, mockTargetUnit.gridX, mockTargetUnit.gridY, 5);
+        if (!moved && mockUnit.gridX === 0 && mockUnit.gridY === 0) {
+            if (GAME_DEBUG_MODE) console.log("MovingManager: chargeMove correctly failed due to occupied destination. [PASS]");
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("MovingManager: chargeMove failed on occupied destination. [FAIL]", { moved, x: mockUnit.gridX, y: mockUnit.gridY });
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("MovingManager: Error during chargeMove (occupied destination) test. [FAIL]", e);
+    } finally {
+        mockBattleSimulationManager.unitsOnGrid = [mockUnit, mockTargetUnit];
+    }
+
+    if (GAME_DEBUG_MODE) console.log(`--- MovingManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}

--- a/tests/unit/warriorSkillsAIUnitTests.js
+++ b/tests/unit/warriorSkillsAIUnitTests.js
@@ -1,0 +1,109 @@
+// tests/unit/warriorSkillsAIUnitTests.js
+
+import { WarriorSkillsAI } from '../../js/managers/warriorSkillsAI.js';
+import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
+import { GAME_EVENTS, ATTACK_TYPES, GAME_DEBUG_MODE } from '../../js/constants.js'; // ✨ GAME_DEBUG_MODE 임포트
+
+export function runWarriorSkillsAIUnitTests() {
+    if (GAME_DEBUG_MODE) console.log("--- WarriorSkillsAI Unit Test Start ---");
+
+    let testCount = 0;
+    let passCount = 0;
+
+    const mockUserUnit = {
+        id: 'w1', name: 'Test Warrior', currentHp: 100, baseStats: { attack: 20 }, classId: 'class_warrior', gridX: 0, gridY: 0
+    };
+    const mockTargetUnit = {
+        id: 'e1', name: 'Test Enemy', currentHp: 50, baseStats: { defense: 10 }, classId: 'class_goblin', gridX: 3, gridY: 0
+    };
+
+    const mockManagers = {
+        battleSimulationManager: {
+            unitsOnGrid: [mockUserUnit, mockTargetUnit],
+            moveUnit: (unitId, x, y) => {
+                const unit = mockManagers.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+                if (unit) { unit.gridX = x; unit.gridY = y; return true; } return false;
+            },
+            getGridRenderParameters: () => ({ effectiveTileSize: 100, gridOffsetX: 0, gridOffsetY: 0 })
+        },
+        battleCalculationManager: {
+            requestDamageCalculation: (attackerId, targetId, skillData) => {
+                if (GAME_DEBUG_MODE) console.log(`[MockBattleCalculationManager] Damage requested: ${attackerId} -> ${targetId}`);
+            }
+        },
+        eventManager: {
+            emit: (eventName, data) => {
+                if (GAME_DEBUG_MODE) console.log(`[MockEventManager] Emitted: ${eventName}`, data);
+            }
+        },
+        delayEngine: {
+            waitFor: async (ms) => {
+                await new Promise(resolve => setTimeout(resolve, ms));
+                if (GAME_DEBUG_MODE) console.log(`[MockDelayEngine] Waited ${ms}ms.`);
+            }
+        },
+        statusEffectManager: {
+            applyStatusEffectCalled: false,
+            applyStatusEffect: (unitId, effectId) => {
+                mockManagers.statusEffectManager.applyStatusEffectCalled = true;
+                if (GAME_DEBUG_MODE) console.log(`[MockStatusEffectManager] Applied ${effectId} to ${unitId}`);
+            }
+        },
+        coordinateManager: {
+            isTileOccupied: (x, y, excludeId) => false
+        },
+        targetingManager: {},
+        vfxManager: {},
+        diceEngine: { getRandomFloat: () => 0.1 },
+        workflowManager: { triggerStatusEffectApplication: (unitId, effectId) => {
+            mockManagers.statusEffectManager.applyStatusEffect(unitId, effectId);
+        }},
+        animationManager: {
+            queueMoveAnimation: async (unitId, startX, startY, endX, endY) => {
+                if (GAME_DEBUG_MODE) console.log(`[MockAnimationManager] Queued move for ${unitId} from (${startX},${startY}) to (${endX},${endY})`);
+            },
+            getAnimationDuration: (startX, startY, endX, endY) => 100
+        },
+        measureManager: {},
+        idManager: {
+            get: async (id) => {
+                if (id === 'class_warrior') return { id: 'class_warrior', name: '전사', moveRange: 3 };
+                return undefined;
+            }
+        },
+        movingManager: {
+            chargeMove: async (unit, targetX, targetY, moveRange) => {
+                const movedX = targetX > unit.gridX ? targetX - 1 : (targetX < unit.gridX ? targetX + 1 : targetX);
+                const movedY = targetY > unit.gridY ? targetY - 1 : (targetY < unit.gridY ? targetY + 1 : targetY);
+                if (Math.abs(unit.gridX - movedX) + Math.abs(unit.gridY - movedY) <= moveRange) {
+                    unit.gridX = movedX;
+                    unit.gridY = movedY;
+                    if (GAME_DEBUG_MODE) console.log(`[MockMovingManager] Unit ${unit.name} actually moved to (${movedX},${movedY})`);
+                    await mockManagers.delayEngine.waitFor(100);
+                    return true;
+                }
+                return false;
+            }
+        }
+    };
+
+    testCount++;
+    mockUserUnit.gridX = 0; mockUserUnit.gridY = 0;
+    mockTargetUnit.gridX = 3; mockTargetUnit.gridY = 0;
+    mockManagers.statusEffectManager.applyStatusEffectCalled = false;
+    try {
+        const warriorSkillsAI = new WarriorSkillsAI(mockManagers);
+        await warriorSkillsAI.charge(mockUserUnit, mockTargetUnit, WARRIOR_SKILLS.CHARGE);
+
+        if (mockUserUnit.gridX === 2 && mockUserUnit.gridY === 0 && mockManagers.statusEffectManager.applyStatusEffectCalled) {
+            if (GAME_DEBUG_MODE) console.log("WarriorSkillsAI: Charge skill executed correctly with movement and stun. [PASS]");
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("WarriorSkillsAI: Charge skill failed movement or stun. [FAIL]", { x: mockUserUnit.gridX, y: mockUserUnit.gridY, stunCalled: mockManagers.statusEffectManager.applyStatusEffectCalled });
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("WarriorSkillsAI: Error during Charge skill test. [FAIL]", e);
+    }
+
+    if (GAME_DEBUG_MODE) console.log(`--- WarriorSkillsAI Unit Test End: ${passCount}/${testCount} tests passed ---`);
+}


### PR DESCRIPTION
## Summary
- add `MovingManager` for special movement
- extend `BattleSimulationManager` with `getUnitAt`
- update `AnimationManager` and `ParticleEngine` for dash animations and afterimages
- integrate moving logic in `warriorSkillsAI` and `GameEngine`
- hook unit tests for new managers and add buttons in debug page

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68779d708984832791868ef5df3cbe9b