### PR TITLE
Add ShadowEngine for unit shadows

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -107,6 +107,7 @@
         <button id="runStatusIconManagerUnitTestsBtn">StatusIconManager 유닛 테스트</button>
         <button id="runMovingManagerUnitTestsBtn">MovingManager 유닛 테스트</button>
         <button id="runWarriorSkillsAIUnitTestsBtn">WarriorSkillsAI 유닛 테스트</button>
+        <button id="runShadowEngineUnitTestsBtn">ShadowEngine 유닛 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -126,6 +127,7 @@
 
         <h4>시스템 제어</h4>
         <button id="toggleDisarmSystemBtn">무장해제 시스템 활성화/비활성화</button>
+        <button id="toggleShadowsBtn">그림자 효과 활성화/비활성화</button>
 
         <h4>상태 이상 테스트</h4>
         <button id="applyPoisonToSkeletonBtn">해골에 독 적용 (3턴)</button>
@@ -193,7 +195,8 @@
             runDetailInfoManagerUnitTests,
             runTagManagerUnitTests,
             runSkillIconManagerUnitTests,
-            runStatusIconManagerUnitTests
+            runStatusIconManagerUnitTests,
+            runShadowEngineUnitTests
     } from './tests/index.js';
     import { STATUS_EFFECTS } from './data/statusEffects.js';
     // ✨ 상수 파일 임포트
@@ -231,6 +234,7 @@
             const idManager = gameEngine.getIdManager();
             const basicAIManager = gameEngine.getBasicAIManager();
             const animationManager = gameEngine.getAnimationManager();
+            const shadowEngine = gameEngine.getShadowEngine(); // ✨ ShadowEngine 인스턴스 가져오기
             const turnCountManager = gameEngine.getTurnCountManager();
             const statusEffectManager = gameEngine.getStatusEffectManager();
             const workflowManager = gameEngine.getWorkflowManager();
@@ -420,6 +424,10 @@
             document.getElementById('runWarriorSkillsAIUnitTestsBtn').addEventListener('click', () => {
                 runWarriorSkillsAIUnitTests();
             });
+            // ✨ ShadowEngine 단위 테스트 버튼 리스너
+            document.getElementById('runShadowEngineUnitTestsBtn').addEventListener('click', () => {
+                runShadowEngineUnitTests();
+            });
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
                 injectRendererFault(renderer);
             });
@@ -486,6 +494,16 @@
                 toggleDisarmSystemBtn.textContent = `무장해제 시스템: ${!currentState ? '활성화됨' : '비활성화됨'}`;
                 console.log(`[Debug Main] 무장해제 시스템이 ${!currentState ? '활성화' : '비활성화'}되었습니다.`);
             });
+
+            // ✨ 그림자 토글 버튼 리스너
+            const toggleShadowsBtn = document.getElementById('toggleShadowsBtn');
+            if (toggleShadowsBtn) {
+                toggleShadowsBtn.textContent = `그림자 효과: ${shadowEngine.shadowsEnabled ? '활성화됨' : '비활성화됨'}`;
+                toggleShadowsBtn.addEventListener('click', () => {
+                    const newState = shadowEngine.toggleShadows();
+                    toggleShadowsBtn.textContent = `그림자 효과: ${newState ? '활성화됨' : '비활성화됨'}`;
+                });
+            }
 
             document.getElementById('applyPoisonToSkeletonBtn').addEventListener('click', () => {
                 workflowManager.triggerStatusEffectApplication('unit_skeleton_001', STATUS_EFFECTS.POISON.id);

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -18,6 +18,7 @@ import { BattleSimulationManager } from './managers/BattleSimulationManager.js';
 import { AnimationManager } from './managers/AnimationManager.js';
 import { VFXManager } from './managers/VFXManager.js';
 import { ParticleEngine } from './managers/ParticleEngine.js'; // ✨ ParticleEngine 임포트
+import { ShadowEngine } from './managers/ShadowEngine.js'; // ✨ ShadowEngine 추가
 import { MovingManager } from './managers/MovingManager.js'; // ✨ MovingManager 추가
 import { DisarmManager } from './managers/DisarmManager.js'; // ✨ DisarmManager 임포트
 import { CanvasBridgeManager } from './managers/CanvasBridgeManager.js'; // ✨ CanvasBridgeManager 추가
@@ -121,6 +122,13 @@ export class GameEngine {
         );
         // 생성 후 상호 참조 설정
         this.animationManager.battleSimulationManager = this.battleSimulationManager;
+
+        // ✨ ShadowEngine 초기화
+        this.shadowEngine = new ShadowEngine(
+            this.battleSimulationManager,
+            this.animationManager,
+            this.measureManager
+        );
 
         // MercenaryPanelManager는 별도 캔버스를 사용하지 않고 UIEngine을 통해 그려집니다.
         this.mercenaryPanelManager = new MercenaryPanelManager(
@@ -340,6 +348,12 @@ export class GameEngine {
 
         // ✨ sceneEngine 초기 상태 설정에 UI_STATES 상수 사용
         this.sceneEngine.setCurrentScene(UI_STATES.MAP_SCREEN);
+
+        // ✨ LayerEngine에 ShadowEngine 그리기 레이어 등록
+        // sceneLayer(10)보다 낮게, 배경보다 높도록 5로 설정
+        this.layerEngine.registerLayer('shadowLayer', (ctx) => {
+            this.shadowEngine.draw(ctx);
+        }, 5);
 
         this.layerEngine.registerLayer('sceneLayer', (ctx) => {
             this.sceneEngine.draw(ctx);
@@ -607,4 +621,5 @@ export class GameEngine {
     getSkillIconManager() { return this.skillIconManager; }
     // ✨ StatusIconManager getter 추가
     getStatusIconManager() { return this.statusIconManager; }
+    getShadowEngine() { return this.shadowEngine; } // ✨ ShadowEngine getter 추가
 }

--- a/js/managers/ShadowEngine.js
+++ b/js/managers/ShadowEngine.js
@@ -1,0 +1,102 @@
+// js/managers/ShadowEngine.js
+
+import { GAME_DEBUG_MODE } from '../constants.js'; // 디버그 모드 상수 임포트
+
+export class ShadowEngine {
+    /**
+     * ShadowEngine을 초기화합니다.
+     * @param {BattleSimulationManager} battleSimulationManager - 유닛 데이터 및 그리드 조회를 위한 인스턴스
+     * @param {AnimationManager} animationManager - 유닛의 현재 렌더링 위치(애니메이션 적용) 조회를 위한 인스턴스
+     * @param {MeasureManager} measureManager - 크기 관련 설정을 위한 인스턴스
+     */
+    constructor(battleSimulationManager, animationManager, measureManager) {
+        if (GAME_DEBUG_MODE) console.log("\ud83c\udf11 ShadowEngine initialized. Ready to cast dynamic shadows. \ud83c\udf11");
+        if (!battleSimulationManager || !animationManager || !measureManager) {
+            throw new Error("[ShadowEngine] Missing essential dependencies. Cannot initialize.");
+        }
+
+        this.battleSimulationManager = battleSimulationManager;
+        this.animationManager = animationManager;
+        this.measureManager = measureManager;
+
+        this.shadowsEnabled = true; // \u2728 그림자 효과 활성화/비활성화 토글 기능
+        this.baseShadowOpacity = 0.4; // 그림자 기본 투명도
+        this.shadowScaleY = 0.5; // 그림자의 Y축 스케일 (납작하게 만듦)
+        // 그림자 오프셋 (유닛 타일 크기 대비 비율) - 45도 느낌
+        this.shadowOffsetXRatio = 0.3;
+        this.shadowOffsetYRatio = 0.3;
+    }
+
+    /**
+     * 그림자 효과를 켜거나 끕니다.
+     * @param {boolean} enable - true면 켜고, false면 끕니다.
+     */
+    setShadowsEnabled(enable) {
+        this.shadowsEnabled = enable;
+        if (GAME_DEBUG_MODE) console.log(`[ShadowEngine] Shadows are now ${this.shadowsEnabled ? 'ENABLED' : 'DISABLED'}.`); // \u2728 조건부 로그
+    }
+
+    /**
+     * 현재 그림자 효과 활성화 상태를 토글합니다.
+     * @returns {boolean} 새로운 그림자 활성화 상태
+     */
+    toggleShadows() {
+        this.shadowsEnabled = !this.shadowsEnabled;
+        if (GAME_DEBUG_MODE) console.log(`[ShadowEngine] Toggled shadows to: ${this.shadowsEnabled}.`); // \u2728 조건부 로그
+        return this.shadowsEnabled;
+    }
+
+    /**
+     * 모든 유닛의 그림자를 캔버스에 그립니다. LayerEngine에 의해 호출됩니다.
+     * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
+     */
+    draw(ctx) {
+        if (!this.shadowsEnabled) {
+            return; // 그림자 효과가 비활성화되어 있으면 그리지 않습니다.
+        }
+
+        const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
+
+        for (const unit of this.battleSimulationManager.unitsOnGrid) {
+            if (unit.currentHp <= 0 || !unit.image) {
+                continue; // 죽었거나 이미지가 없는 유닛은 그림자를 그리지 않습니다.
+            }
+
+            // 유닛의 현재 렌더링 위치(애니메이션 적용된 위치)를 가져옵니다.
+            const { drawX, drawY } = this.animationManager.getRenderPosition(
+                unit.id,
+                unit.gridX,
+                unit.gridY,
+                effectiveTileSize,
+                gridOffsetX,
+                gridOffsetY
+            );
+
+            ctx.save();
+            ctx.globalAlpha = this.baseShadowOpacity; // 그림자 투명도 적용
+            // 그림자를 검은색으로 만들기 (간단한 방법: source-atop 합성)
+            ctx.fillStyle = 'black';
+
+            // 45도 방향 오프셋 (유닛 타일 크기 대비)
+            const offsetX = effectiveTileSize * this.shadowOffsetXRatio;
+            const offsetY = effectiveTileSize * this.shadowOffsetYRatio;
+
+            // 그림자 그리기 위치
+            const shadowDrawX = drawX + offsetX;
+            const shadowDrawY = drawY + offsetY;
+
+            // 그림자를 Y축으로 납작하게 만들고 그립니다.
+            ctx.translate(shadowDrawX + effectiveTileSize / 2, shadowDrawY + effectiveTileSize / 2); // 중심을 기준으로 스케일링
+            ctx.scale(1, this.shadowScaleY); // Y축으로 납작하게
+            ctx.translate(-(shadowDrawX + effectiveTileSize / 2), -(shadowDrawY + effectiveTileSize / 2)); // 원래 위치로 이동
+
+            ctx.drawImage(unit.image, shadowDrawX, shadowDrawY, effectiveTileSize, effectiveTileSize);
+
+            // 그림자 이미지를 검은색으로 덮어씌움 (유닛 이미지의 형태를 유지하면서 검은색으로)
+            ctx.globalCompositeOperation = 'source-atop';
+            ctx.fillRect(shadowDrawX, shadowDrawY, effectiveTileSize, effectiveTileSize / this.shadowScaleY); // 스케일링 전의 높이로 사각형을 그려야 함
+
+            ctx.restore();
+        }
+    }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,6 +12,7 @@ export { runSkillIconManagerUnitTests } from './unit/skillIconManagerUnitTests.j
 export { runStatusIconManagerUnitTests } from './unit/statusIconManagerUnitTests.js'; // ✨ StatusIconManager 단위 테스트 추가
 export { runMovingManagerUnitTests } from './unit/movingManagerUnitTests.js'; // ✨ MovingManager 단위 테스트 추가
 export { runWarriorSkillsAIUnitTests } from './unit/warriorSkillsAIUnitTests.js'; // ✨ WarriorSkillsAI 테스트 임포트 확인
+export { runShadowEngineUnitTests } from './unit/shadowEngineUnitTests.js'; // ✨ ShadowEngine 단위 테스트 추가
 
 // new unit tests
 export { runSceneEngineUnitTests } from './unit/sceneEngineUnitTests.js';
@@ -80,4 +81,5 @@ export function runEngineTests(renderer, gameLoop, battleSimulationManager = nul
     runStatusIconManagerUnitTests(); // 목업 사용
     runMovingManagerUnitTests();
     runWarriorSkillsAIUnitTests();
+    runShadowEngineUnitTests();
 }

--- a/tests/unit/shadowEngineUnitTests.js
+++ b/tests/unit/shadowEngineUnitTests.js
@@ -1,0 +1,142 @@
+// tests/unit/shadowEngineUnitTests.js
+
+import { ShadowEngine } from '../../js/managers/ShadowEngine.js';
+import { GAME_DEBUG_MODE } from '../../js/constants.js'; // 디버그 모드 상수 임포트
+
+export function runShadowEngineUnitTests() {
+    if (GAME_DEBUG_MODE) console.log("--- ShadowEngine Unit Test Start ---"); // \u2728 조건부 로그
+
+    let testCount = 0;
+    let passCount = 0;
+
+    // Mock Dependencies
+    const mockUnit = {
+        id: 'u1', name: 'Test Unit', gridX: 5, gridY: 5, currentHp: 100,
+        image: { width: 64, height: 64, src: 'mock_unit.png' } // 목업 이미지 객체
+    };
+    const mockBattleSimulationManager = {
+        unitsOnGrid: [mockUnit],
+        getGridRenderParameters: () => ({ effectiveTileSize: 100, gridOffsetX: 0, gridOffsetY: 0 })
+    };
+    const mockAnimationManager = {
+        getRenderPosition: (unitId, gridX, gridY, effectiveTileSize, gridOffsetX, gridOffsetY) => ({
+            drawX: gridX * effectiveTileSize + gridOffsetX,
+            drawY: gridY * effectiveTileSize + gridOffsetY
+        })
+    };
+    const mockMeasureManager = {};
+
+    const mockCtx = {
+        save: () => {},
+        restore: () => {},
+        drawImage: function() { this.drawImageCalled = true; },
+        fillRect: function() { this.fillRectCalled = true; }, // 그림자를 검은색으로 채울 때 사용
+        translate: () => {},
+        scale: () => {},
+        // 속성 추적
+        globalAlpha: 1, globalCompositeOperation: 'source-over', fillStyle: '',
+        drawImageCalled: false, fillRectCalled: false,
+    };
+
+
+    // 테스트 1: 초기화 확인
+    testCount++;
+    try {
+        const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
+        if (se.battleSimulationManager === mockBattleSimulationManager && se.shadowsEnabled === true) {
+            if (GAME_DEBUG_MODE) console.log("ShadowEngine: Initialized correctly. [PASS]"); // \u2728 조건부 로그
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("ShadowEngine: Initialization failed. [FAIL]"); // \u2728 조건부 로그
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("ShadowEngine: Error during initialization. [FAIL]", e); // \u2728 조건부 로그
+    }
+
+    // 테스트 2: setShadowsEnabled 및 toggleShadows
+    testCount++;
+    try {
+        const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
+        se.setShadowsEnabled(false);
+        if (se.shadowsEnabled === false) {
+            if (GAME_DEBUG_MODE) console.log("ShadowEngine: setShadowsEnabled works. [PASS]"); // \u2728 조건부 로그
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("ShadowEngine: setShadowsEnabled failed. [FAIL]"); // \u2728 조건부 로그
+        }
+
+        se.toggleShadows();
+        if (se.shadowsEnabled === true) {
+            if (GAME_DEBUG_MODE) console.log("ShadowEngine: toggleShadows works. [PASS]"); // \u2728 조건부 로그
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("ShadowEngine: toggleShadows failed. [FAIL]"); // \u2728 조건부 로그
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("ShadowEngine: Error during toggle/set test. [FAIL]", e); // \u2728 조건부 로그
+    }
+
+    // 테스트 3: draw - 그림자가 활성화되어 있을 때 그리기 호출 확인
+    testCount++;
+    mockCtx.drawImageCalled = false;
+    mockCtx.fillRectCalled = false;
+    try {
+        const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
+        se.setShadowsEnabled(true);
+        se.draw(mockCtx);
+
+        if (mockCtx.drawImageCalled && mockCtx.fillRectCalled) {
+            if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw called drawing operations when enabled. [PASS]"); // \u2728 조건부 로그
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("ShadowEngine: draw failed to call drawing operations when enabled. [FAIL]"); // \u2728 조건부 로그
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("ShadowEngine: Error during draw (enabled) test. [FAIL]", e); // \u2728 조건부 로그
+    }
+
+    // 테스트 4: draw - 그림자가 비활성화되어 있을 때 그리기 호출 없음
+    testCount++;
+    mockCtx.drawImageCalled = false;
+    mockCtx.fillRectCalled = false;
+    try {
+        const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
+        se.setShadowsEnabled(false);
+        se.draw(mockCtx);
+
+        if (!mockCtx.drawImageCalled && !mockCtx.fillRectCalled) {
+            if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw correctly skipped drawing when disabled. [PASS]"); // \u2728 조건부 로그
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("ShadowEngine: draw unexpectedly called drawing operations when disabled. [FAIL]"); // \u2728 조건부 로그
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("ShadowEngine: Error during draw (disabled) test. [FAIL]", e); // \u2728 조건부 로그
+    }
+
+    // 테스트 5: draw - 죽은 유닛의 그림자는 그리지 않음
+    testCount++;
+    const mockDeadUnit = { ...mockUnit, currentHp: 0 };
+    const originalUnits = mockBattleSimulationManager.unitsOnGrid;
+    mockBattleSimulationManager.unitsOnGrid = [mockDeadUnit];
+    mockCtx.drawImageCalled = false;
+    mockCtx.fillRectCalled = false;
+    try {
+        const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
+        se.setShadowsEnabled(true);
+        se.draw(mockCtx);
+
+        if (!mockCtx.drawImageCalled && !mockCtx.fillRectCalled) {
+            if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw correctly skipped drawing for dead unit. [PASS]"); // \u2728 조건부 로그
+            passCount++;
+        } else {
+            if (GAME_DEBUG_MODE) console.error("ShadowEngine: draw unexpectedly called drawing operations for dead unit. [FAIL]"); // \u2728 조건부 로그
+        }
+    } catch (e) {
+        if (GAME_DEBUG_MODE) console.error("ShadowEngine: Error during draw (dead unit) test. [FAIL]", e); // \u2728 조건부 로그
+    } finally {
+        mockBattleSimulationManager.unitsOnGrid = originalUnits; // 원본 복구
+    }
+
+    if (GAME_DEBUG_MODE) console.log(`--- ShadowEngine Unit Test End: ${passCount}/${testCount} tests passed ---`); // \u2728 조건부 로그
+}


### PR DESCRIPTION
## Summary
- add `ShadowEngine` manager to render simple unit shadows
- hook `ShadowEngine` into `GameEngine` and layer system
- expose controls and unit tests in debug tools
- include ShadowEngine unit tests in `tests/index.js`

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877a3cef95c8327b7538952f3080f03