### PR TITLE
Fix missing WarriorSkillsAI import

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -58,6 +58,7 @@ import { CoordinateManager } from './managers/CoordinateManager.js';
 import { ButtonEngine } from './managers/ButtonEngine.js'; // ✨ ButtonEngine 임포트
 import { DetailInfoManager } from './managers/DetailInfoManager.js'; // ✨ DetailInfoManager 추가
 import { TagManager } from './managers/TagManager.js'; // ✨ TagManager 추가
+import { WarriorSkillsAI } from './managers/warriorSkillsAI.js'; // ✨ WarriorSkillsAI 추가
 
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';


### PR DESCRIPTION
## Summary
- import `WarriorSkillsAI` in `GameEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877be24461c83278ee836e2e16a92c5