### PR TITLE
Fix HeroEngine random generation

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -273,7 +273,7 @@
             // --- 버튼 이벤트 리스너 설정 ---
             document.getElementById('runAllEngineTestsBtn').addEventListener('click', () => {
                 // gameLoop는 gameEngine 내부에 있으므로 gameEngine.gameLoop로 전달 (혹은 getter)
-                runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceBotManager, eventManager);
+                runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceEngine, diceBotManager, eventManager);
                 runEventManagerTests(eventManager);
                 runGuardianManagerTests(guardianManager);
                 runMeasureManagerIntegrationTest(gameEngine);
@@ -396,7 +396,7 @@
             });
 
             document.getElementById("runHeroEngineUnitTestsBtn").addEventListener("click", () => {
-                runHeroEngineUnitTests(idManager, gameEngine.getAssetLoaderManager(), diceBotManager);
+                runHeroEngineUnitTests(idManager, gameEngine.getAssetLoaderManager(), diceEngine, diceBotManager);
             });
             // ✨ SynergyEngine 단위 테스트 버튼 리스너 추가
             document.getElementById('runSynergyEngineUnitTestsBtn').addEventListener('click', () => {
@@ -593,7 +593,7 @@
             };
 
             // 페이지 로드 시 기본 엔진 테스트 자동 실행
-            runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceBotManager, eventManager);
+            runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceEngine, diceBotManager, eventManager);
             runEventManagerTests(eventManager); // EventManager 테스트도 자동 실행
             runGuardianManagerTests(guardianManager); // GuardianManager 테스트도 자동 실행
             runMeasureManagerIntegrationTest(gameEngine); // MeasureManager 통합 테스트도 자동 실행

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -268,7 +268,12 @@ export class GameEngine {
         // 9. Game Content & Feature Engines
         // ------------------------------------------------------------------
         // HeroEngine 초기화
-        this.heroEngine = new HeroEngine(this.idManager, this.assetLoaderManager, this.diceBotManager);
+        this.heroEngine = new HeroEngine(
+            this.idManager,
+            this.assetLoaderManager,
+            this.diceEngine,
+            this.diceBotManager
+        );
 
         // ✨ SynergyEngine 초기화
         this.synergyEngine = new SynergyEngine(this.idManager, this.eventManager);

--- a/js/managers/HeroEngine.js
+++ b/js/managers/HeroEngine.js
@@ -7,10 +7,11 @@ export class HeroEngine {
      * @param {AssetLoaderManager} assetLoaderManager - 이미지 에셋 로드를 위한 AssetLoaderManager 인스턴스
      * @param {DiceBotManager} diceBotManager - 무작위 값 생성을 위한 DiceBotManager 인스턴스
      */
-    constructor(idManager, assetLoaderManager, diceBotManager) {
+    constructor(idManager, assetLoaderManager, diceEngine, diceBotManager) {
         console.log("\u2728 HeroEngine initialized. The foundation for all heroes begins here! \u2728");
         this.idManager = idManager;
         this.assetLoaderManager = assetLoaderManager;
+        this.diceEngine = diceEngine;
         this.diceBotManager = diceBotManager;
 
         this.heroes = new Map(); // key: heroId, value: heroData (생성된 영웅 인스턴스 저장)
@@ -61,7 +62,7 @@ export class HeroEngine {
      * @returns {Promise<object>} 생성된 영웅 객체
      */
     async generateHero(options) {
-        const heroId = options.heroId || `hero_${Date.now()}_${this.diceBotManager.getRandomInt(1000, 9999)}`;
+        const heroId = options.heroId || `hero_${Date.now()}_${this.diceEngine.getRandomInt(1000, 9999)}`;
         const heroName = options.name || '미지의 영웅';
         const classId = options.classId || 'class_warrior'; // 기본 전사 클래스
 
@@ -73,34 +74,34 @@ export class HeroEngine {
         // 2. 랜덤 스탯 생성 (DiceBotManager 활용)
         // 각 스탯에 대해 대략적인 범위 설정
         const baseStats = {
-            hp: this.diceBotManager.getRandomInt(70, 120),
-            valor: this.diceBotManager.getRandomInt(10, 60),
-            strength: this.diceBotManager.getRandomInt(5, 30),
-            endurance: this.diceBotManager.getRandomInt(5, 30),
-            agility: this.diceBotManager.getRandomInt(5, 30),
-            intelligence: this.diceBotManager.getRandomInt(5, 30),
-            wisdom: this.diceBotManager.getRandomInt(5, 30),
-            luck: this.diceBotManager.getRandomInt(5, 30),
-            weight: this.diceBotManager.getRandomInt(10, 40),
-            speed: this.diceBotManager.getRandomInt(30, 90)
+            hp: this.diceEngine.getRandomInt(70, 120),
+            valor: this.diceEngine.getRandomInt(10, 60),
+            strength: this.diceEngine.getRandomInt(5, 30),
+            endurance: this.diceEngine.getRandomInt(5, 30),
+            agility: this.diceEngine.getRandomInt(5, 30),
+            intelligence: this.diceEngine.getRandomInt(5, 30),
+            wisdom: this.diceEngine.getRandomInt(5, 30),
+            luck: this.diceEngine.getRandomInt(5, 30),
+            weight: this.diceEngine.getRandomInt(10, 40),
+            speed: this.diceEngine.getRandomInt(30, 90)
         };
 
         // 3. 랜덤한 세 가지 스킬 부여 (임시 스킬 ID 사용)
         const skills = [
-            `skill_${this.diceBotManager.getRandomInt(1, 3)}`, // 첫 번째 스킬
-            `skill_${this.diceBotManager.getRandomInt(4, 6)}`, // 두 번째 스킬
-            `skill_passive_${this.diceBotManager.getRandomInt(1, 2)}` // 세 번째 스킬 (패시브)
+            `skill_${this.diceEngine.getRandomInt(1, 3)}`, // 첫 번째 스킬
+            `skill_${this.diceEngine.getRandomInt(4, 6)}`, // 두 번째 스킬
+            `skill_passive_${this.diceEngine.getRandomInt(1, 2)}` // 세 번째 스킬 (패시브)
         ];
 
         // 4. 랜덤한 특성 부여 (임시 특성 ID 사용)
-        const traits = [`trait_${this.diceBotManager.getRandomInt(1, 3)}`];
+        const traits = [`trait_${this.diceEngine.getRandomInt(1, 3)}`];
 
         // ✨ 5. 랜덤한 2~3개의 시너지 부여
         const allPossibleSynergies = ['synergy_warrior', 'synergy_mage', 'synergy_healer', 'synergy_archer'];
-        const numSynergies = this.diceBotManager.getRandomInt(2, 3);
+        const numSynergies = this.diceEngine.getRandomInt(2, 3);
         const assignedSynergies = [];
         while (assignedSynergies.length < numSynergies) {
-            const randomIndex = this.diceBotManager.getRandomInt(0, allPossibleSynergies.length - 1);
+            const randomIndex = this.diceEngine.getRandomInt(0, allPossibleSynergies.length - 1);
             const selectedSynergy = allPossibleSynergies[randomIndex];
             if (!assignedSynergies.includes(selectedSynergy)) {
                 assignedSynergies.push(selectedSynergy);

--- a/tests/index.js
+++ b/tests/index.js
@@ -62,7 +62,17 @@ export { injectEventManagerFaults } from './fault_injection/eventManagerFaults.j
 export { injectGuardianManagerFaults } from './fault_injection/guardianManagerFaults.js';
 export { injectSceneEngineFaults } from './fault_injection/sceneEngineFaults.js';
 export { injectLogicManagerFaults } from './fault_injection/logicManagerFaults.js';
-export function runEngineTests(renderer, gameLoop, battleSimulationManager = null, battleGridManager = null, idManager = null, assetLoaderManager = null, diceBotManager = null, eventManager = null) {
+export function runEngineTests(
+    renderer,
+    gameLoop,
+    battleSimulationManager = null,
+    battleGridManager = null,
+    idManager = null,
+    assetLoaderManager = null,
+    diceEngine = null,
+    diceBotManager = null,
+    eventManager = null
+) {
     runRendererTests(renderer);
     runGameLoopTests(gameLoop);
     if (battleSimulationManager && battleGridManager) {
@@ -71,7 +81,7 @@ export function runEngineTests(renderer, gameLoop, battleSimulationManager = nul
     if (battleSimulationManager) {
         runTargetingManagerUnitTests(battleSimulationManager);
     }
-    runHeroEngineUnitTests(idManager, assetLoaderManager, diceBotManager);
+    runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine, diceBotManager);
     if (idManager && eventManager) {
         runSynergyEngineUnitTests(idManager, eventManager);
     }

--- a/tests/unit/heroEngineUnitTests.js
+++ b/tests/unit/heroEngineUnitTests.js
@@ -2,7 +2,7 @@
 
 import { HeroEngine } from '../../js/managers/HeroEngine.js';
 
-export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceBotManager) {
+export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine, diceBotManager) {
     console.log("--- HeroEngine Unit Test Start ---");
 
     let testCount = 0;
@@ -43,7 +43,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceBotMan
     // 테스트 1: 초기화 확인
     testCount++;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, mockDiceBotManager);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotManager);
         if (heroEngine.idManager === mockIdManager && heroEngine.heroes instanceof Map) {
             console.log("HeroEngine: Initialized correctly. [PASS]");
             passCount++;
@@ -59,7 +59,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceBotMan
     mockDiceBotManager.getRandomIntResults = [100, 50, 20, 10, 15, 5, 10, 20, 30, 60, 1, 4, 1];
     mockDiceBotManager.getRandomIntIndex = 0;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, mockDiceBotManager);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotManager);
         const hero = await heroEngine.generateHero({
             name: '테스트 영웅',
             classId: 'class_test',
@@ -81,7 +81,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceBotMan
     // 테스트 3: getHero - 존재하는 영웅 가져오기
     testCount++;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, mockDiceBotManager);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotManager);
         const generatedHero = await heroEngine.generateHero({ heroId: 'test_hero_get', name: '가져올 영웅' });
         heroEngine.heroes.set(generatedHero.id, generatedHero);
 
@@ -99,7 +99,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceBotMan
     // 테스트 4: getHero - 존재하지 않는 영웅 가져오기
     testCount++;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, mockDiceBotManager);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotManager);
         const nonExistentHero = heroEngine.getHero('non_existent_hero');
         if (nonExistentHero === undefined) {
             console.log("HeroEngine: getHero returned undefined for non-existent hero. [PASS]");
@@ -114,7 +114,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceBotMan
     // 테스트 5: getAllHeroes - 모든 영웅 목록 반환
     testCount++;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, mockDiceBotManager);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotManager);
         await heroEngine.generateHero({ heroId: 'hero_1', name: 'Hero One' });
         await heroEngine.generateHero({ heroId: 'hero_2', name: 'Hero Two' });
         const allHeroes = heroEngine.getAllHeroes();


### PR DESCRIPTION
## Summary
- update `HeroEngine` to depend on `DiceEngine` for random numbers
- pass `DiceEngine` when creating `HeroEngine`
- adjust unit tests and debug page for new API

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877bf8e32ac8327ba5c64a2a200f553