### PR TITLE
Fix shadow engine for visible 45-degree shadows

### DIFF
--- a/js/managers/ShadowEngine.js
+++ b/js/managers/ShadowEngine.js
@@ -21,6 +21,7 @@ export class ShadowEngine {
 
         this.shadowsEnabled = true; // \u2728 그림자 효과 활성화/비활성화 토글 기능
         this.baseShadowOpacity = 0.4; // 그림자 기본 투명도
+        // 그림자 타원 형태 비율
         this.shadowScaleY = 0.5; // 그림자의 Y축 스케일 (납작하게 만듦)
         // 그림자 오프셋 (유닛 타일 크기 대비 비율) - 45도 느낌
         this.shadowOffsetXRatio = 0.3;
@@ -73,28 +74,29 @@ export class ShadowEngine {
             );
 
             ctx.save();
-            ctx.globalAlpha = this.baseShadowOpacity; // 그림자 투명도 적용
-            // 그림자를 검은색으로 만들기 (간단한 방법: source-atop 합성)
+            ctx.globalAlpha = this.baseShadowOpacity;
             ctx.fillStyle = 'black';
 
-            // 45도 방향 오프셋 (유닛 타일 크기 대비)
             const offsetX = effectiveTileSize * this.shadowOffsetXRatio;
             const offsetY = effectiveTileSize * this.shadowOffsetYRatio;
-
-            // 그림자 그리기 위치
             const shadowDrawX = drawX + offsetX;
             const shadowDrawY = drawY + offsetY;
 
-            // 그림자를 Y축으로 납작하게 만들고 그립니다.
-            ctx.translate(shadowDrawX + effectiveTileSize / 2, shadowDrawY + effectiveTileSize / 2); // 중심을 기준으로 스케일링
-            ctx.scale(1, this.shadowScaleY); // Y축으로 납작하게
-            ctx.translate(-(shadowDrawX + effectiveTileSize / 2), -(shadowDrawY + effectiveTileSize / 2)); // 원래 위치로 이동
+            ctx.translate(shadowDrawX + effectiveTileSize / 2, shadowDrawY + effectiveTileSize / 2);
+            ctx.scale(1, this.shadowScaleY);
+            ctx.translate(-(shadowDrawX + effectiveTileSize / 2), -(shadowDrawY + effectiveTileSize / 2));
 
-            ctx.drawImage(unit.image, shadowDrawX, shadowDrawY, effectiveTileSize, effectiveTileSize);
-
-            // 그림자 이미지를 검은색으로 덮어씌움 (유닛 이미지의 형태를 유지하면서 검은색으로)
-            ctx.globalCompositeOperation = 'source-atop';
-            ctx.fillRect(shadowDrawX, shadowDrawY, effectiveTileSize, effectiveTileSize / this.shadowScaleY); // 스케일링 전의 높이로 사각형을 그려야 함
+            ctx.beginPath();
+            ctx.ellipse(
+                shadowDrawX + effectiveTileSize / 2,
+                shadowDrawY + effectiveTileSize * 0.9,
+                effectiveTileSize / 2,
+                (effectiveTileSize * this.shadowScaleY) / 2,
+                0,
+                0,
+                Math.PI * 2
+            );
+            ctx.fill();
 
             ctx.restore();
         }

--- a/tests/unit/shadowEngineUnitTests.js
+++ b/tests/unit/shadowEngineUnitTests.js
@@ -29,13 +29,18 @@ export function runShadowEngineUnitTests() {
     const mockCtx = {
         save: () => {},
         restore: () => {},
-        drawImage: function() { this.drawImageCalled = true; },
-        fillRect: function() { this.fillRectCalled = true; }, // 그림자를 검은색으로 채울 때 사용
+        beginPath: function() { this.beginPathCalled = true; },
+        ellipse: function() { this.ellipseCalled = true; },
+        fill: function() { this.fillCalled = true; },
         translate: () => {},
         scale: () => {},
         // 속성 추적
-        globalAlpha: 1, globalCompositeOperation: 'source-over', fillStyle: '',
-        drawImageCalled: false, fillRectCalled: false,
+        globalAlpha: 1,
+        globalCompositeOperation: 'source-over',
+        fillStyle: '',
+        beginPathCalled: false,
+        ellipseCalled: false,
+        fillCalled: false,
     };
 
 
@@ -78,14 +83,14 @@ export function runShadowEngineUnitTests() {
 
     // 테스트 3: draw - 그림자가 활성화되어 있을 때 그리기 호출 확인
     testCount++;
-    mockCtx.drawImageCalled = false;
-    mockCtx.fillRectCalled = false;
+    mockCtx.ellipseCalled = false;
+    mockCtx.fillCalled = false;
     try {
         const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
         se.setShadowsEnabled(true);
         se.draw(mockCtx);
 
-        if (mockCtx.drawImageCalled && mockCtx.fillRectCalled) {
+        if (mockCtx.ellipseCalled && mockCtx.fillCalled) {
             if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw called drawing operations when enabled. [PASS]"); // \u2728 조건부 로그
             passCount++;
         } else {
@@ -97,14 +102,14 @@ export function runShadowEngineUnitTests() {
 
     // 테스트 4: draw - 그림자가 비활성화되어 있을 때 그리기 호출 없음
     testCount++;
-    mockCtx.drawImageCalled = false;
-    mockCtx.fillRectCalled = false;
+    mockCtx.ellipseCalled = false;
+    mockCtx.fillCalled = false;
     try {
         const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
         se.setShadowsEnabled(false);
         se.draw(mockCtx);
 
-        if (!mockCtx.drawImageCalled && !mockCtx.fillRectCalled) {
+        if (!mockCtx.ellipseCalled && !mockCtx.fillCalled) {
             if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw correctly skipped drawing when disabled. [PASS]"); // \u2728 조건부 로그
             passCount++;
         } else {
@@ -119,14 +124,14 @@ export function runShadowEngineUnitTests() {
     const mockDeadUnit = { ...mockUnit, currentHp: 0 };
     const originalUnits = mockBattleSimulationManager.unitsOnGrid;
     mockBattleSimulationManager.unitsOnGrid = [mockDeadUnit];
-    mockCtx.drawImageCalled = false;
-    mockCtx.fillRectCalled = false;
+    mockCtx.ellipseCalled = false;
+    mockCtx.fillCalled = false;
     try {
         const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
         se.setShadowsEnabled(true);
         se.draw(mockCtx);
 
-        if (!mockCtx.drawImageCalled && !mockCtx.fillRectCalled) {
+        if (!mockCtx.ellipseCalled && !mockCtx.fillCalled) {
             if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw correctly skipped drawing for dead unit. [PASS]"); // \u2728 조건부 로그
             passCount++;
         } else {


### PR DESCRIPTION
## Summary
- make unit shadows use an ellipse instead of drawing the unit again
- update ShadowEngine unit tests for the new drawing calls

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877c6fe67248327bf82b34386a178cf