### PR TITLE
Implement RevertManager for reversible unit animations

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -257,6 +257,12 @@ export class GameEngine {
         this.delayEngine = new DelayEngine();
         this.timingEngine = new TimingEngine(this.delayEngine);
 
+        // ✨ RevertManager 초기화
+        this.revertManager = new RevertManager(
+            this.battleSimulationManager,
+            this.timingEngine,
+            this.delayEngine
+        );
         // ✨ MovingManager 초기화 - delayEngine이 준비된 이후
         this.movingManager = new MovingManager(
             this.battleSimulationManager,
@@ -302,7 +308,8 @@ export class GameEngine {
             this.eventManager,
             this.battleSimulationManager,
             this.diceRollManager,
-            this.delayEngine
+            this.delayEngine,
+            this.revertManager
         );
 
         // Status effect 관련 매니저 초기화
@@ -374,6 +381,8 @@ export class GameEngine {
             vfxManager: this.vfxManager,
             diceEngine: this.diceEngine,
             workflowManager: this.workflowManager,
+            assetLoaderManager: this.assetLoaderManager,
+            revertManager: this.revertManager
             animationManager: this.animationManager,
             measureManager: this.measureManager,
             idManager: this.idManager,
@@ -422,7 +431,7 @@ export class GameEngine {
         this.gameLoop = new GameLoop(this._update, this._draw);
 
         // ✨ _initAsyncManagers에서 로드할 총 에셋 및 데이터 수를 수동으로 계산
-        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 1; // 9(기존) + 5(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 1(warrior-finish.png)
+        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 1 + 2; // 9(기존) + 5(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 1(warrior-finish.png) + 2(새로운 애니메이션 이미지)
         this.assetLoaderManager.setTotalAssetsToLoad(expectedDataAndAssetCount);
 
         // 초기화 과정의 비동기 처리
@@ -513,6 +522,8 @@ export class GameEngine {
         // ✨ 전투 배경 이미지 로드
         await this.assetLoaderManager.loadImage('sprite_battle_stage_forest', 'assets/images/battle-stage-forest.png');
 
+        await this.assetLoaderManager.loadImage("sprite_warrior_attack", "assets/images/warrior-attack.png");
+        await this.assetLoaderManager.loadImage("sprite_warrior_hitted", "assets/images/warrior-hitted.png");
         console.log(`[GameEngine] Registered unit ID: ${UNITS.WARRIOR.id}`);
         console.log(`[GameEngine] Loaded warrior sprite: ${UNITS.WARRIOR.spriteId}`);
 
@@ -641,6 +652,7 @@ export class GameEngine {
     getMovingManager() { return this.movingManager; } // ✨ MovingManager getter 추가
 
     getButtonEngine() { return this.buttonEngine; }
+    getRevertManager() { return this.revertManager; } // ✨ RevertManager getter 추가
 
     // Dice 관련 엔진/매니저에 대한 getter
     getDiceEngine() { return this.diceEngine; }

--- a/js/managers/BattleCalculationManager.js
+++ b/js/managers/BattleCalculationManager.js
@@ -3,12 +3,13 @@ import { DelayEngine } from './DelayEngine.js'; // ✨ DelayEngine 추가
 import { GAME_EVENTS } from '../constants.js';
 
 export class BattleCalculationManager {
-    constructor(eventManager, battleSimulationManager, diceRollManager, delayEngine) {
+    constructor(eventManager, battleSimulationManager, diceRollManager, delayEngine, revertManager) {
         console.log("\ud83d\udcca BattleCalculationManager initialized. Delegating heavy calculations to worker. \ud83d\udcca");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
         this.diceRollManager = diceRollManager;
         this.delayEngine = delayEngine; // ✨ delayEngine 저장
+        this.revertManager = revertManager; // ✨ revertManager 저장
         this.worker = new Worker('./js/workers/battleCalculationWorker.js');
 
         this.worker.onmessage = this._handleWorkerMessage.bind(this);
@@ -31,6 +32,15 @@ export class BattleCalculationManager {
 
             const unitToUpdate = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
             if (unitToUpdate) {
+                // ✨ 데미지 받았을 때 애니메이션 처리
+                if (hpDamageDealt > 0 || barrierDamageDealt > 0) {
+                    if (unitToUpdate.classId === 'class_warrior') {
+                        this.revertManager.saveState(unitToUpdate.id, unitToUpdate.image);
+                        unitToUpdate.image = this.battleSimulationManager.assetLoaderManager.getImage('sprite_warrior_hitted');
+                        this.revertManager.revertState(unitToUpdate.id, 300); // 300ms 후 복귀
+                    }
+                }
+
                 unitToUpdate.currentHp = newHp;
                 unitToUpdate.currentBarrier = newBarrier;
 

--- a/js/managers/RevertManager.js
+++ b/js/managers/RevertManager.js
@@ -1,0 +1,40 @@
+export class RevertManager {
+    constructor(battleSimulationManager, timingEngine, delayEngine) {
+        console.log("\u21a9\ufe0f RevertManager initialized. Ready to restore previous states. \u21a9\ufe0f");
+        this.battleSimulationManager = battleSimulationManager;
+        this.timingEngine = timingEngine;
+        this.delayEngine = delayEngine;
+        this.originalStates = new Map(); // key: unitId, value: { originalImage: HTMLImageElement }
+    }
+
+    /**
+     * \uc720\ub2c8\ud2b8\uc758 \ud604\uc7ac \uc0c1\ud0dc(\uc608: \uc774\ubbf8\uc9c0)\ub97c \uc800\uc7a5\ud569\ub2c8\ub2e4.
+     * @param {string} unitId - \uc0c1\ud0dc\ub97c \uc800\uc7a5\ud560 \uc720\ub2c8\ud2b8\uc758 ID
+     * @param {HTMLImageElement} originalImage - \uc800\uc7a5\ud560 \uc6d0\ubcf8 \uc774\ubbf8\uc9c0 \uac1d\uccb4
+     */
+    saveState(unitId, originalImage) {
+        this.originalStates.set(unitId, { originalImage });
+        console.log(`[RevertManager] Saved original state for unit '${unitId}'.`);
+    }
+
+    /**
+     * \uc800\uc7a5\ub41c \uc0c1\ud0dc\ub85c \uc720\ub2c8\ud2b8\ub97c \ubc18\ud658\ud569\ub2c8\ub2e4.
+     * @param {string} unitId - \uc0c1\ud0dc\ub97c \ubc18\ud658\ud560 \uc720\ub2c8\ud2b8\uc758 ID
+     * @param {number} delayMs - \uc774\ubbf8\uc9c0\ub97c \ubc18\ud658\ud558\uae30 \uc804 \ub300\uae30\ud560 \uc2dc\uac04 (\ubc00\ub9ac\ucd08)
+     */
+    revertState(unitId, delayMs = 300) {
+        const savedState = this.originalStates.get(unitId);
+        const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+
+        if (savedState && unit) {
+            this.timingEngine.addTimedAction(async () => {
+                await this.delayEngine.waitFor(delayMs);
+                unit.image = savedState.originalImage;
+                this.originalStates.delete(unitId);
+                console.log(`[RevertManager] Reverted unit '${unitId}' to original state.`);
+            }, 500, `Revert ${unitId} Image`);
+        } else {
+            console.warn(`[RevertManager] No saved state or unit found for '${unitId}'. Cannot revert.`);
+        }
+    }
+}

--- a/js/managers/warriorSkillsAI.js
+++ b/js/managers/warriorSkillsAI.js
@@ -37,8 +37,19 @@ export class WarriorSkillsAI {
         }
         if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${userUnit.name} uses ${skillData.name} on ${targetUnit.name}!`);
 
+        // ✨ 공격 애니메이션 시작 (warrior-attack.png)
+        if (userUnit.classId === 'class_warrior') {
+            this.managers.revertManager.saveState(userUnit.id, userUnit.image);
+            userUnit.image = this.managers.assetLoaderManager.getImage('sprite_warrior_attack');
+        }
+
         // 1. ✨ 스킬 아이콘 애니메이션 시작 (즉시 발행)
         this.managers.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, { skillId: skillData.id, userId: userUnit.id, targetId: targetUnit.id });
+
+        // ✨ 애니메이션 끝나면 원상복구
+        if (userUnit.classId === 'class_warrior') {
+            this.managers.revertManager.revertState(userUnit.id, 100); // 100ms 후 복귀
+        }
         await this.managers.delayEngine.waitFor(800);
 
         const userUnitClassData = await this.managers.idManager.get(userUnit.classId);
@@ -87,6 +98,12 @@ export class WarriorSkillsAI {
         }
         if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${userUnit.name} uses ${skillData.name}!`);
 
+        // ✨ 공격 애니메이션 시작 (warrior-attack.png)
+        if (userUnit.classId === 'class_warrior') {
+            this.managers.revertManager.saveState(userUnit.id, userUnit.image);
+            userUnit.image = this.managers.assetLoaderManager.getImage('sprite_warrior_attack');
+        }
+
         // 1. 스탯 버프 적용
         if (skillData.effect.statBuff) {
             this.managers.eventManager.emit(GAME_EVENTS.LOG_MESSAGE, { message: `${userUnit.name}의 공격력이 ${skillData.effect.statBuff.amount} 증가합니다!` });
@@ -100,6 +117,11 @@ export class WarriorSkillsAI {
         }
 
         this.managers.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, { skillId: skillData.id, userId: userUnit.id });
+
+        // ✨ 애니메이션 끝나면 원상복구
+        if (userUnit.classId === 'class_warrior') {
+            this.managers.revertManager.revertState(userUnit.id, 100); // 100ms 후 복귀
+        }
     }
 
     /**
@@ -117,6 +139,12 @@ export class WarriorSkillsAI {
         }
         if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${userUnit.name} attempts ${skillData.name} on ${targetUnit.name}!`);
 
+        // ✨ 공격 애니메이션 시작 (warrior-attack.png)
+        if (userUnit.classId === 'class_warrior') {
+            this.managers.revertManager.saveState(userUnit.id, userUnit.image);
+            userUnit.image = this.managers.assetLoaderManager.getImage('sprite_warrior_attack');
+        }
+
         if (skillData.effect.applyChance && this.managers.diceEngine.getRandomFloat() < skillData.effect.applyChance) {
             this.managers.workflowManager.triggerStatusEffectApplication(targetUnit.id, skillData.effect.statusEffectId);
             await this.managers.delayEngine.waitFor(100);
@@ -126,6 +154,11 @@ export class WarriorSkillsAI {
         }
 
         this.managers.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, { skillId: skillData.id, userId: userUnit.id, targetId: targetUnit.id });
+
+        // ✨ 애니메이션 끝나면 원상복구
+        if (userUnit.classId === 'class_warrior') {
+            this.managers.revertManager.revertState(userUnit.id, 100); // 100ms 후 복귀
+        }
     }
 
     /**
@@ -142,6 +175,12 @@ export class WarriorSkillsAI {
         }
         if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${userUnit.name} uses ${skillData.name} on ${attackerUnit.name}!`);
 
+        // ✨ 공격 애니메이션 시작 (warrior-attack.png)
+        if (userUnit.classId === 'class_warrior') {
+            this.managers.revertManager.saveState(userUnit.id, userUnit.image);
+            userUnit.image = this.managers.assetLoaderManager.getImage('sprite_warrior_attack');
+        }
+
         const counterAttackDamageMultiplier = skillData.effect.counterAttackDamageMultiplier || 1;
         const attackSkillData = {
             type: ATTACK_TYPES.PHYSICAL,
@@ -153,6 +192,11 @@ export class WarriorSkillsAI {
         await this.managers.delayEngine.waitFor(300);
 
         this.managers.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, { skillId: skillData.id, userId: userUnit.id, targetId: attackerUnit.id });
+
+        // ✨ 애니메이션 끝나면 원상복구
+        if (userUnit.classId === 'class_warrior') {
+            this.managers.revertManager.revertState(userUnit.id, 100); // 100ms 후 복귀
+        }
     }
 
     /**

--- a/tests/unit/warriorSkillsAIUnitTests.js
+++ b/tests/unit/warriorSkillsAIUnitTests.js
@@ -42,6 +42,8 @@ export function runWarriorSkillsAIUnitTests() {
                 if (GAME_DEBUG_MODE) console.log(`[MockDelayEngine] Waited ${ms}ms.`);
             }
         },
+        assetLoaderManager: { getImage: () => ({}) },
+        revertManager: { saveState: () => {}, revertState: () => {} },
         statusEffectManager: {
             applyStatusEffectCalled: false,
             applyStatusEffect: (unitId, effectId) => {


### PR DESCRIPTION
## Summary
- add `RevertManager` to handle temporary image swaps
- load new warrior animation sprites
- update `BattleCalculationManager` to show hit animation
- update `WarriorSkillsAI` to animate warrior attacks
- expose new manager in `GameEngine`
- adjust tests for new dependencies

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6877ca1daad88327a6e617c2a0bdb878