### PR TITLE
Implement Unit sprite management

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -59,6 +59,8 @@ import { ButtonEngine } from './managers/ButtonEngine.js'; // ✨ ButtonEngine �
 import { DetailInfoManager } from './managers/DetailInfoManager.js'; // ✨ DetailInfoManager 추가
 import { TagManager } from './managers/TagManager.js'; // ✨ TagManager 추가
 import { WarriorSkillsAI } from './managers/warriorSkillsAI.js'; // ✨ WarriorSkillsAI 추가
+import { UnitSpriteEngine } from './managers/UnitSpriteEngine.js';
+import { UnitActionManager } from './managers/UnitActionManager.js';
 
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
@@ -382,7 +384,13 @@ export class GameEngine {
         this.warriorSkillsAI = new WarriorSkillsAI(commonManagersForSkills);
 
         // ------------------------------------------------------------------
-        // 12. Scene Registrations & Layer Engine Setup
+        // 12. Sprite & Action Managers
+        // ------------------------------------------------------------------
+        this.unitSpriteEngine = new UnitSpriteEngine(this.assetLoaderManager, this.battleSimulationManager);
+        this.unitActionManager = new UnitActionManager(this.eventManager, this.unitSpriteEngine, this.delayEngine);
+
+        // ------------------------------------------------------------------
+        // 13. Scene Registrations & Layer Engine Setup
         // ------------------------------------------------------------------
         // ✨ sceneEngine에 UI_STATES 상수 사용
         this.sceneEngine.registerScene(UI_STATES.MAP_SCREEN, [this.territoryManager]);
@@ -422,7 +430,7 @@ export class GameEngine {
         this.gameLoop = new GameLoop(this._update, this._draw);
 
         // ✨ _initAsyncManagers에서 로드할 총 에셋 및 데이터 수를 수동으로 계산
-        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 1; // 9(기존) + 5(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 1(warrior-finish.png)
+        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 3; // 9(기존) + 5(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 3(전사 상태 스프라이트)
         this.assetLoaderManager.setTotalAssetsToLoad(expectedDataAndAssetCount);
 
         // 초기화 과정의 비동기 처리
@@ -508,6 +516,18 @@ export class GameEngine {
             UNITS.WARRIOR.spriteId,
             'assets/images/warrior.png'
         );
+        await this.assetLoaderManager.loadImage(
+            'sprite_warrior_attack',
+            'assets/images/warrior-attack.png'
+        );
+        await this.assetLoaderManager.loadImage(
+            'sprite_warrior_hitted',
+            'assets/images/warrior-hitted.png'
+        );
+        await this.assetLoaderManager.loadImage(
+            'sprite_warrior_finish',
+            'assets/images/warrior-finish.png'
+        );
         // ✨ 전사 패널 이미지 로드
         await this.assetLoaderManager.loadImage('sprite_warrior_panel', 'assets/images/warrior-panel-1.png');
         // ✨ 전투 배경 이미지 로드
@@ -521,6 +541,13 @@ export class GameEngine {
         const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
         // ✨ 전사 패널 이미지 로드 후 참조
         const warriorPanelImage = this.assetLoaderManager.getImage('sprite_warrior_panel');
+
+        await this.unitSpriteEngine.registerUnitSprites('unit_warrior_001', {
+            idle: 'assets/images/warrior.png',
+            attack: 'assets/images/warrior-attack.png',
+            hitted: 'assets/images/warrior-hitted.png',
+            finish: 'assets/images/warrior-finish.png'
+        });
 
         // ✨ BattleSimulationManager에 유닛 배치 시 currentHp 초기화
         // 전사를 그리드의 더 왼쪽에 배치 (gridX: 3)
@@ -664,4 +691,6 @@ export class GameEngine {
     // ✨ StatusIconManager getter 추가
     getStatusIconManager() { return this.statusIconManager; }
     getShadowEngine() { return this.shadowEngine; } // ✨ ShadowEngine getter 추가
+    getUnitSpriteEngine() { return this.unitSpriteEngine; }
+    getUnitActionManager() { return this.unitActionManager; }
 }

--- a/js/managers/UnitActionManager.js
+++ b/js/managers/UnitActionManager.js
@@ -1,0 +1,60 @@
+// js/managers/UnitActionManager.js
+
+import { GAME_EVENTS, GAME_DEBUG_MODE } from '../constants.js';
+
+export class UnitActionManager {
+    /**
+     * UnitActionManager를 초기화합니다.
+     * @param {EventManager} eventManager - 게임 이벤트를 구독하기 위한 인스턴스
+     * @param {UnitSpriteEngine} unitSpriteEngine - 스프라이트 변경을 요청할 엔진 인스턴스
+     * @param {DelayEngine} delayEngine - 행동 후 기본 상태로 돌아오기 위한 지연 처리 인스턴스
+     */
+    constructor(eventManager, unitSpriteEngine, delayEngine) {
+        if (GAME_DEBUG_MODE) console.log("\uD83D\uDD75\uFE0F UnitActionManager initialized. Detecting unit actions. \uD83D\uDD75\uFE0F");
+        this.eventManager = eventManager;
+        this.unitSpriteEngine = unitSpriteEngine;
+        this.delayEngine = delayEngine;
+
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        // 유닛 공격 시도 이벤트 구독
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, this._onUnitAttack.bind(this));
+        // 유닛 피해 표시 이벤트 구독
+        this.eventManager.subscribe(GAME_EVENTS.DISPLAY_DAMAGE, this._onUnitHitted.bind(this));
+        // 유닛 사망 이벤트 구독
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_DEATH, this._onUnitDeath.bind(this));
+
+        if (GAME_DEBUG_MODE) console.log("[UnitActionManager] Subscribed to unit action events.");
+    }
+
+    _onUnitAttack({ attackerId }) {
+        if (GAME_DEBUG_MODE) console.log(`[UnitActionManager] Attack detected from ${attackerId}.`);
+        this.unitSpriteEngine.setUnitSprite(attackerId, 'attack');
+
+        // 공격 애니메이션 시간만큼 기다린 후 기본 상태로 복귀
+        this.delayEngine.waitFor(800).then(() => {
+            this.unitSpriteEngine.setUnitSprite(attackerId, 'idle');
+        });
+    }
+
+    _onUnitHitted({ unitId, damage }) {
+        if (damage > 0) {
+            if (GAME_DEBUG_MODE) console.log(`[UnitActionManager] Unit ${unitId} was hitted.`);
+            this.unitSpriteEngine.setUnitSprite(unitId, 'hitted');
+
+            // 피격 애니메이션 시간만큼 기다린 후 기본 상태로 복귀
+            this.delayEngine.waitFor(800).then(() => {
+                this.unitSpriteEngine.setUnitSprite(unitId, 'idle');
+            });
+        }
+    }
+
+    _onUnitDeath({ unitId }) {
+        if (GAME_DEBUG_MODE) console.log(`[UnitActionManager] Death detected for ${unitId}.`);
+        this.unitSpriteEngine.setUnitSprite(unitId, 'finish');
+        // 죽은 후에는 기본 상태로 돌아가지 않습니다.
+    }
+}
+

--- a/js/managers/UnitSpriteEngine.js
+++ b/js/managers/UnitSpriteEngine.js
@@ -1,0 +1,68 @@
+// js/managers/UnitSpriteEngine.js
+
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+export class UnitSpriteEngine {
+    /**
+     * UnitSpriteEngine을 초기화합니다.
+     * @param {AssetLoaderManager} assetLoaderManager - 스프라이트 이미지 로드를 위한 인스턴스
+     * @param {BattleSimulationManager} battleSimulationManager - 유닛 정보 접근 및 업데이트를 위한 인스턴스
+     */
+    constructor(assetLoaderManager, battleSimulationManager) {
+        if (GAME_DEBUG_MODE) console.log("\uD83C\uDFA8 UnitSpriteEngine initialized. Ready to switch unit sprites. \uD83C\uDFA8");
+        this.assetLoaderManager = assetLoaderManager;
+        this.battleSimulationManager = battleSimulationManager;
+        // 유닛의 상태별 스프라이트를 저장합니다. 구조: Map<unitId, Map<spriteState, HTMLImageElement>>
+        this.unitSpriteMap = new Map();
+    }
+
+    /**
+     * 유닛의 상태별 스프라이트 이미지를 미리 로드하고 등록합니다.
+     * @param {string} unitId - 유닛의 고유 ID
+     * @param {object} spriteStates - { state: 'url' } 형태의 객체. 예: { idle: 'path/to/idle.png', attack: '...' }
+     * @returns {Promise<void>}
+     */
+    async registerUnitSprites(unitId, spriteStates) {
+        if (!this.unitSpriteMap.has(unitId)) {
+            this.unitSpriteMap.set(unitId, new Map());
+        }
+
+        const unitSprites = this.unitSpriteMap.get(unitId);
+        const promises = [];
+
+        for (const state in spriteStates) {
+            const url = spriteStates[state];
+            const assetId = `sprite_${unitId}_${state}`;
+
+            const promise = this.assetLoaderManager.loadImage(assetId, url)
+                .then(image => {
+                    unitSprites.set(state, image);
+                    if (GAME_DEBUG_MODE) console.log(`[UnitSpriteEngine] Registered sprite for ${unitId}, state: ${state}`);
+                })
+                .catch(error => {
+                    console.error(`[UnitSpriteEngine] Failed to load sprite for ${unitId}, state: ${state}`, error);
+                });
+            promises.push(promise);
+        }
+        await Promise.all(promises);
+    }
+
+    /**
+     * 유닛의 스프라이트를 지정된 상태로 변경합니다.
+     * @param {string} unitId - 변경할 유닛의 ID
+     * @param {string} spriteState - 변경할 스프라이트 상태 (예: 'idle', 'attack', 'hitted', 'finish')
+     */
+    setUnitSprite(unitId, spriteState) {
+        const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+        const unitSprites = this.unitSpriteMap.get(unitId);
+
+        if (unit && unitSprites && unitSprites.has(spriteState)) {
+            const newSprite = unitSprites.get(spriteState);
+            unit.image = newSprite; // 현재 유닛 이미지 교체
+            if (GAME_DEBUG_MODE) console.log(`[UnitSpriteEngine] Unit ${unitId}'s sprite changed to '${spriteState}'.`);
+        } else {
+            if (GAME_DEBUG_MODE) console.warn(`[UnitSpriteEngine] Sprite for state '${spriteState}' not found for unit ${unitId}.`);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add UnitSpriteEngine for handling state-based unit images
- add UnitActionManager to react to battle events and update sprites
- integrate new managers into GameEngine
- preload warrior state sprites and register with UnitSpriteEngine

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877d8bb651483279dbf37c41fed24f3