### PR TITLE
Fix UnitActionManager with status sprites

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -387,7 +387,12 @@ export class GameEngine {
         // 12. Sprite & Action Managers
         // ------------------------------------------------------------------
         this.unitSpriteEngine = new UnitSpriteEngine(this.assetLoaderManager, this.battleSimulationManager);
-        this.unitActionManager = new UnitActionManager(this.eventManager, this.unitSpriteEngine, this.delayEngine);
+        this.unitActionManager = new UnitActionManager(
+            this.eventManager,
+            this.unitSpriteEngine,
+            this.delayEngine,
+            this.battleSimulationManager
+        );
 
         // ------------------------------------------------------------------
         // 13. Scene Registrations & Layer Engine Setup
@@ -430,7 +435,7 @@ export class GameEngine {
         this.gameLoop = new GameLoop(this._update, this._draw);
 
         // ✨ _initAsyncManagers에서 로드할 총 에셋 및 데이터 수를 수동으로 계산
-        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 3; // 9(기존) + 5(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 3(전사 상태 스프라이트)
+        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 4; // 9(기존) + 5(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 4(전사 상태 스프라이트)
         this.assetLoaderManager.setTotalAssetsToLoad(expectedDataAndAssetCount);
 
         // 초기화 과정의 비동기 처리
@@ -528,6 +533,10 @@ export class GameEngine {
             'sprite_warrior_finish',
             'assets/images/warrior-finish.png'
         );
+        await this.assetLoaderManager.loadImage(
+            'sprite_warrior_status',
+            'assets/images/warrior-status-effects.png'
+        );
         // ✨ 전사 패널 이미지 로드
         await this.assetLoaderManager.loadImage('sprite_warrior_panel', 'assets/images/warrior-panel-1.png');
         // ✨ 전투 배경 이미지 로드
@@ -546,7 +555,8 @@ export class GameEngine {
             idle: 'assets/images/warrior.png',
             attack: 'assets/images/warrior-attack.png',
             hitted: 'assets/images/warrior-hitted.png',
-            finish: 'assets/images/warrior-finish.png'
+            finish: 'assets/images/warrior-finish.png',
+            status: 'assets/images/warrior-status-effects.png'
         });
 
         // ✨ BattleSimulationManager에 유닛 배치 시 currentHp 초기화

--- a/js/managers/UnitActionManager.js
+++ b/js/managers/UnitActionManager.js
@@ -1,6 +1,7 @@
 // js/managers/UnitActionManager.js
 
 import { GAME_EVENTS, GAME_DEBUG_MODE } from '../constants.js';
+import { STATUS_EFFECTS } from '../../data/statusEffects.js';
 
 export class UnitActionManager {
     /**
@@ -9,11 +10,12 @@ export class UnitActionManager {
      * @param {UnitSpriteEngine} unitSpriteEngine - 스프라이트 변경을 요청할 엔진 인스턴스
      * @param {DelayEngine} delayEngine - 행동 후 기본 상태로 돌아오기 위한 지연 처리 인스턴스
      */
-    constructor(eventManager, unitSpriteEngine, delayEngine) {
+    constructor(eventManager, unitSpriteEngine, delayEngine, battleSimulationManager) {
         if (GAME_DEBUG_MODE) console.log("\uD83D\uDD75\uFE0F UnitActionManager initialized. Detecting unit actions. \uD83D\uDD75\uFE0F");
         this.eventManager = eventManager;
         this.unitSpriteEngine = unitSpriteEngine;
         this.delayEngine = delayEngine;
+        this.battleSimulationManager = battleSimulationManager; // 유닛 상태 확인용
 
         this._setupEventListeners();
     }
@@ -25,21 +27,34 @@ export class UnitActionManager {
         this.eventManager.subscribe(GAME_EVENTS.DISPLAY_DAMAGE, this._onUnitHitted.bind(this));
         // 유닛 사망 이벤트 구독
         this.eventManager.subscribe(GAME_EVENTS.UNIT_DEATH, this._onUnitDeath.bind(this));
+        // ✨ 상태이상 적용 이벤트 구독
+        this.eventManager.subscribe(GAME_EVENTS.STATUS_EFFECT_APPLIED, this._onStatusEffectApplied.bind(this));
 
-        if (GAME_DEBUG_MODE) console.log("[UnitActionManager] Subscribed to unit action events.");
+        if (GAME_DEBUG_MODE) console.log("[UnitActionManager] Subscribed to unit action and status effect events.");
     }
 
     _onUnitAttack({ attackerId }) {
+        const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === attackerId);
+        if (!unit || unit.currentHp <= 0) return;
+
         if (GAME_DEBUG_MODE) console.log(`[UnitActionManager] Attack detected from ${attackerId}.`);
         this.unitSpriteEngine.setUnitSprite(attackerId, 'attack');
 
         // 공격 애니메이션 시간만큼 기다린 후 기본 상태로 복귀
         this.delayEngine.waitFor(800).then(() => {
             this.unitSpriteEngine.setUnitSprite(attackerId, 'idle');
+            const currentUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === attackerId);
+            // ✨ 유닛이 살아있을 때만 기본 상태로 복귀
+            if (currentUnit && currentUnit.currentHp > 0) {
+                this.unitSpriteEngine.setUnitSprite(attackerId, 'idle');
+            }
         });
     }
 
     _onUnitHitted({ unitId, damage }) {
+        const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+        if (!unit || unit.currentHp <= 0) return;
+
         if (damage > 0) {
             if (GAME_DEBUG_MODE) console.log(`[UnitActionManager] Unit ${unitId} was hitted.`);
             this.unitSpriteEngine.setUnitSprite(unitId, 'hitted');
@@ -47,6 +62,11 @@ export class UnitActionManager {
             // 피격 애니메이션 시간만큼 기다린 후 기본 상태로 복귀
             this.delayEngine.waitFor(800).then(() => {
                 this.unitSpriteEngine.setUnitSprite(unitId, 'idle');
+                const currentUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+                 // ✨ 유닛이 살아있을 때만 기본 상태로 복귀
+                if (currentUnit && currentUnit.currentHp > 0) {
+                    this.unitSpriteEngine.setUnitSprite(unitId, 'idle');
+                }
             });
         }
     }
@@ -55,6 +75,33 @@ export class UnitActionManager {
         if (GAME_DEBUG_MODE) console.log(`[UnitActionManager] Death detected for ${unitId}.`);
         this.unitSpriteEngine.setUnitSprite(unitId, 'finish');
         // 죽은 후에는 기본 상태로 돌아가지 않습니다.
+    }
+
+    /**
+     * 상태이상이 적용되었을 때 호출됩니다.
+     * @param {{ unitId: string, statusEffectId: string }} data 
+     */
+    _onStatusEffectApplied({ unitId, statusEffectId }) {
+        // ✨ '광폭화' 상태이상은 제외
+        if (statusEffectId === STATUS_EFFECTS.BERSERK.id) {
+            if (GAME_DEBUG_MODE) console.log(`[UnitActionManager] Berserk status applied to ${unitId}, skipping sprite change.`);
+            return;
+        }
+
+        const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+        if (!unit || unit.currentHp <= 0) return;
+
+        if (GAME_DEBUG_MODE) console.log(`[UnitActionManager] Status effect ${statusEffectId} detected on ${unitId}.`);
+        this.unitSpriteEngine.setUnitSprite(unitId, 'status'); // 'status' 상태 스프라이트로 변경
+
+        // 상태이상 효과는 일정 시간 지속될 수 있으므로, 여기서는 1초 후 기본 상태로 되돌립니다.
+        // 실제 게임에서는 상태이상이 끝나는 시점에 맞춰 복귀시키는 것이 더 좋습니다.
+        this.delayEngine.waitFor(1000).then(() => {
+            const currentUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
+            if (currentUnit && currentUnit.currentHp > 0) {
+                this.unitSpriteEngine.setUnitSprite(unitId, 'idle');
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- hook battleSimulationManager into UnitActionManager
- load warrior status sprite and include in sprite registration
- account for unit death/state when switching sprites
- react to status effect events and ignore berserk
- adjust asset counts for new sprite

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877dd90f244832784bdb794dee470ef