### PR TITLE
Add Battle Cry buff system

### DIFF
--- a/data/statusEffects.js
+++ b/data/statusEffects.js
@@ -50,6 +50,17 @@ export const STATUS_EFFECTS = {
         }
     },
 
+    BATTLE_CRY: {
+        id: 'status_battle_cry',
+        name: '전투의 외침',
+        type: STATUS_EFFECT_TYPES.BUFF,
+        description: '공격력이 3턴간 10% 증가합니다.',
+        duration: 3,
+        effect: {
+            attackModifier: 1.1 // 공격력 1.1배 (10% 증가)
+        }
+    },
+
     // ✨ 새롭게 추가된 '무장해제' 상태 이상
     DISARMED: {
         id: 'status_disarmed',

--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -32,8 +32,8 @@ export const WARRIOR_SKILLS = {
         description: '자신의 공격력을 일시적으로 증가시키고 일반 공격을 수행합니다.',
         requiredUserTags: ['전사_클래스'],
         effect: {
-            statBuff: { type: 'attack', amount: 10, duration: 1 }, // 공격력 10 증가, 1턴 지속
-            allowAdditionalAttack: true // 버프 후 추가 공격 가능 (이것이 이 스킬 타입의 핵심)
+            statusEffectId: 'status_battle_cry', // 적용할 상태이상 ID
+            allowAdditionalAttack: true // 버프 후 추가 공격 가능 플래그
         }
     },
     // 디버프 스킬 (일반 공격 시 묻어남 예시)

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -122,7 +122,6 @@ export class GameEngine {
         this.statManager = new StatManager(this.valorEngine, this.weightEngine);
 
         this.diceEngine = new DiceEngine();
-        this.diceRollManager = new DiceRollManager(this.diceEngine, this.valorEngine);
         this.diceBotManager = new DiceBotManager(this.diceEngine);
 
         // ------------------------------------------------------------------
@@ -299,11 +298,11 @@ export class GameEngine {
         // ------------------------------------------------------------------
         // 11. Combat Flow & AI Managers
         // ------------------------------------------------------------------
-        // BattleCalculationManager는 DiceRollManager가 준비된 이후에 초기화합니다.
+        // BattleCalculationManager는 DiceRollManager를 나중에 주입합니다.
         this.battleCalculationManager = new BattleCalculationManager(
             this.eventManager,
             this.battleSimulationManager,
-            this.diceRollManager,
+            null,
             this.delayEngine
         );
 
@@ -315,6 +314,10 @@ export class GameEngine {
             this.turnCountManager,
             this.battleCalculationManager
         );
+
+        // 이제 StatusEffectManager가 준비되었으므로 DiceRollManager를 생성
+        this.diceRollManager = new DiceRollManager(this.diceEngine, this.valorEngine, this.statusEffectManager);
+        this.battleCalculationManager.diceRollManager = this.diceRollManager;
         this.workflowManager = new WorkflowManager(
             this.eventManager,
             this.statusEffectManager,

--- a/js/managers/SkillIconManager.js
+++ b/js/managers/SkillIconManager.js
@@ -47,6 +47,7 @@ export class SkillIconManager {
             'status_stun': 'assets/icons/status_effects/stun.png',
             'status_bleed': 'assets/icons/status_effects/bleed.png',
             'status_berserk': 'assets/icons/status_effects/berserk.png',
+            'status_battle_cry': 'assets/icons/skills/battle_cry.png', // ✨ 버프 아이콘 등록
             'status_disarmed': 'assets/icons/status_effects/disarmed.png'
         };
 


### PR DESCRIPTION
## Summary
- connect Warrior's Battle Cry skill to a new `status_battle_cry` status effect
- register icon for the buff
- apply attack modifiers from active status effects in `DiceRollManager`
- implement Battle Cry behaviour in `warriorSkillsAI`
- inject `StatusEffectManager` into `DiceRollManager` via `GameEngine`
- update unit tests for new DiceRollManager constructor and buff handling

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877e25964bc8327aa895183e6b01b4b