### PR TITLE
Implement reaction skill system

### DIFF
--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -54,11 +54,12 @@ export const WARRIOR_SKILLS = {
         id: 'skill_warrior_retaliate',
         name: '반격',
         type: SKILL_TYPES.REACTION,
-        probability: 30, // 이 확률은 공격받을 때마다 다시 계산됩니다.
-        description: '공격을 받을 시 일정 확률로 즉시 반격합니다.',
+        description: '공격을 받을 시 일정 확률로 즉시 80%의 피해로 반격합니다.',
         requiredUserTags: ['방어'],
         effect: {
-            counterAttackDamageMultiplier: 0.8 // 80% 공격력으로 반격
+            probability: 0.4, // 기본 발동 확률 40% (슬롯에 따라 조정될 수 있음)
+            damageModifier: 0.8, // 반격 시 피해량 80%
+            tags: ['일반공격'] // 이 공격이 평타 판정임을 명시
         }
     },
     // 패시브 스킬 (상시 발동 예시)

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -62,6 +62,7 @@ import { WarriorSkillsAI } from './managers/warriorSkillsAI.js'; // ✨ WarriorS
 import { UnitSpriteEngine } from './managers/UnitSpriteEngine.js';
 import { UnitActionManager } from './managers/UnitActionManager.js';
 import { PassiveSkillManager } from './managers/PassiveSkillManager.js';
+import { ReactionSkillManager } from './managers/ReactionSkillManager.js'; // ✨ ReactionSkillManager import
 
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
@@ -405,6 +406,14 @@ export class GameEngine {
             this.battleSimulationManager,
             this.workflowManager
         );
+        this.reactionSkillManager = new ReactionSkillManager(
+            this.eventManager,
+            this.idManager,
+            this.diceEngine,
+            this.battleSimulationManager,
+            this.battleCalculationManager,
+            this.delayEngine
+        );
 
         // ------------------------------------------------------------------
         // 13. Scene Registrations & Layer Engine Setup
@@ -716,4 +725,5 @@ export class GameEngine {
     getUnitSpriteEngine() { return this.unitSpriteEngine; }
     getUnitActionManager() { return this.unitActionManager; }
     getPassiveSkillManager() { return this.passiveSkillManager; }
+    getReactionSkillManager() { return this.reactionSkillManager; }
 }

--- a/js/constants.js
+++ b/js/constants.js
@@ -51,4 +51,12 @@ export const ATTACK_TYPES = {
     ENEMY: 'enemy'
 };
 
+export const SKILL_TYPES = {
+    ACTIVE: 'active',
+    PASSIVE: 'passive',
+    DEBUFF: 'debuff',
+    REACTION: 'reaction',
+    BUFF: 'buff'
+};
+
 export const GAME_DEBUG_MODE = true; // ✨ 디버그 모드 플래그 (배포 시 false로 설정)

--- a/js/managers/BattleCalculationManager.js
+++ b/js/managers/BattleCalculationManager.js
@@ -54,6 +54,12 @@ export class BattleCalculationManager {
         }
     }
 
+    /**
+     * 데미지 계산을 요청하고 결과를 이벤트로 전달합니다.
+     * @param {string} attackerUnitId
+     * @param {string} targetUnitId
+     * @param {object} skillData - 스킬 정보 또는 일반 공격 정보
+     */
     requestDamageCalculation(attackerUnitId, targetUnitId, skillData = null) {
         const attackerUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === attackerUnitId);
         const targetUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === targetUnitId);

--- a/js/managers/DiceRollManager.js
+++ b/js/managers/DiceRollManager.js
@@ -96,7 +96,14 @@ export class DiceRollManager {
             }
         }
 
-        const finalDamage = (damageRoll + attackBonus) * finalAttackModifier;
+        let finalDamage = (damageRoll + attackBonus) * finalAttackModifier;
+
+        // ✨ 반격 등 스킬 자체의 피해량 조절자 적용
+        if (skillData.damageModifier) {
+            finalDamage *= skillData.damageModifier;
+            console.log(`[DiceRollManager] Applying skill damage modifier: ${skillData.damageModifier}`);
+        }
+
         console.log(`[DiceRollManager] Performed damage roll (${skillData.dice.num}d${skillData.dice.sides} + ${attackBonus}) * ${finalAttackModifier.toFixed(2)} (Modifiers) = ${finalDamage.toFixed(0)}`);
         return Math.max(0, Math.floor(finalDamage));
     }

--- a/js/managers/ReactionSkillManager.js
+++ b/js/managers/ReactionSkillManager.js
@@ -1,0 +1,70 @@
+// js/managers/ReactionSkillManager.js
+
+import { GAME_EVENTS, GAME_DEBUG_MODE, ATTACK_TYPES } from '../constants.js';
+import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
+
+export class ReactionSkillManager {
+    /**
+     * @param {EventManager} eventManager
+     * @param {IdManager} idManager
+     * @param {DiceEngine} diceEngine
+     * @param {BattleSimulationManager} battleSimulationManager
+     * @param {BattleCalculationManager} battleCalculationManager
+     * @param {DelayEngine} delayEngine
+     */
+    constructor(eventManager, idManager, diceEngine, battleSimulationManager, battleCalculationManager, delayEngine) {
+        if (GAME_DEBUG_MODE) console.log("\uD83D\uDCA5 ReactionSkillManager initialized. Ready to retaliate! \uD83D\uDCA5");
+        this.eventManager = eventManager;
+        this.idManager = idManager;
+        this.diceEngine = diceEngine;
+        this.battleSimulationManager = battleSimulationManager;
+        this.battleCalculationManager = battleCalculationManager;
+        this.delayEngine = delayEngine;
+
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        this.eventManager.subscribe(GAME_EVENTS.DISPLAY_DAMAGE, this._onUnitDamaged.bind(this));
+    }
+
+    /**
+     * 유닛이 피해를 입었을 때 반격 스킬 발동을 체크합니다.
+     * @param {{ unitId: string, damage: number, attackerId: string }} param0
+     */
+    async _onUnitDamaged({ unitId: defenderId, damage, attackerId }) {
+        if (damage <= 0 || !attackerId) return;
+
+        const defender = this.battleSimulationManager.unitsOnGrid.find(u => u.id === defenderId);
+        if (!defender || defender.currentHp <= 0) return;
+
+        const classData = await this.idManager.get(defender.classId);
+        if (!classData || !classData.skills || !classData.skills.includes(WARRIOR_SKILLS.RETALIATE.id)) {
+            return;
+        }
+
+        const skillData = WARRIOR_SKILLS.RETALIATE;
+
+        if (this.diceEngine.getRandomFloat() < skillData.effect.probability) {
+            if (GAME_DEBUG_MODE) console.log(`[ReactionSkillManager] ${defender.name}'s Retaliate triggered against ${attackerId}!`);
+
+            await this.delayEngine.waitFor(250);
+
+            this.eventManager.emit(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, {
+                attackerId: defenderId,
+                targetId: attackerId,
+                attackType: ATTACK_TYPES.MELEE,
+                isReaction: true
+            });
+
+            const retaliateAttackData = {
+                type: ATTACK_TYPES.PHYSICAL,
+                dice: { num: 1, sides: 6 },
+                damageModifier: skillData.effect.damageModifier
+            };
+            this.battleCalculationManager.requestDamageCalculation(defenderId, attackerId, retaliateAttackData);
+
+            await this.delayEngine.waitFor(800);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a global `SKILL_TYPES` constant with `REACTION` type
- extend warrior skill data for new `Retaliate` reaction skill
- implement `ReactionSkillManager` to handle reaction attacks
- allow damage modifiers in `DiceRollManager`
- expose `ReactionSkillManager` from `GameEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877e61026d08327996ec17b4e5b4dcb