### PR TITLE
Implement random skills and skill icons

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -36,6 +36,33 @@ export const CLASSES = {
         skills: ['skill_melee_attack'],
         moveRange: 2, // 해골의 이동 거리(예시)
         tags: ['근접', '언데드', '적_클래스'] // ✨ 태그 추가
+    },
+    // ✨ 좀비 클래스 추가
+    ZOMBIE: {
+        id: 'class_zombie',
+        name: '좀비',
+        role: CLASS_ROLES.MELEE_DPS,
+        description: '느릿느릿 움직이는 언데드.',
+        skills: ['skill_melee_attack'],
+        moveRange: 2,
+        tags: ['근접', '언데드', '적_클래스']
+    },
+    // ✨ 용맹한 전사 클래스 추가
+    WARRIOR_VALIANT: {
+        id: 'class_warrior_valiant',
+        name: '용맹한 전사',
+        role: CLASS_ROLES.MELEE_DPS,
+        tags: ['근접', '방어', '전사_클래스'],
+        moveRange: 4,
+        attackRange: 1,
+        baseStats: {
+            hp: 120,
+            attack: 25,
+            defense: 15,
+            speed: 60,
+            intelligence: 10
+        },
+        skills: [] // GameEngine에서 랜덤 스킬로 채워짐
     }
     // 다른 클래스들이 여기에 추가됩니다.
     // MAGE: { id: 'class_mage', ... }

--- a/js/managers/DetailInfoManager.js
+++ b/js/managers/DetailInfoManager.js
@@ -1,6 +1,7 @@
 // js/managers/DetailInfoManager.js
 
 import { GAME_EVENTS } from '../constants.js'; // 이벤트 상수를 사용
+import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export class DetailInfoManager {
     /**
@@ -12,7 +13,7 @@ export class DetailInfoManager {
      * @param {IdManager} idManager - 클래스, 스킬, 시너지 이름 조회를 위한 IdManager 인스턴스
      * @param {CameraEngine} cameraEngine - 카메라 위치/줌 정보를 조회하기 위한 CameraEngine 인스턴스
      */
-    constructor(eventManager, measureManager, battleSimulationManager, heroEngine, idManager, cameraEngine) {
+    constructor(eventManager, measureManager, battleSimulationManager, heroEngine, idManager, cameraEngine, skillIconManager) {
         console.log("🔍 DetailInfoManager initialized. Ready to show unit details on hover. 🔍");
         this.eventManager = eventManager;
         this.measureManager = measureManager;
@@ -20,6 +21,7 @@ export class DetailInfoManager {
         this.heroEngine = heroEngine;
         this.idManager = idManager;
         this.cameraEngine = cameraEngine;
+        this.skillIconManager = skillIconManager;
 
         this.hoveredUnit = null;       // 현재 마우스가 올라간 유닛
         this.lastMouseX = 0;           // 마우스의 마지막 X 좌표 (논리적 캔버스 좌표)
@@ -247,11 +249,20 @@ export class DetailInfoManager {
             ctx.font = 'bold 16px Arial';
             ctx.fillText('스킬:', tooltipX + padding, tooltipY + currentYOffset);
             currentYOffset += lineHeight;
-            ctx.font = '14px Arial';
             for (const skillId of skillsToList) {
-                // 스킬 ID에서 "skill_" 프리픽스 제거하여 표시 (예: "skill_1" -> "1")
-                ctx.fillText(`- ${skillId.replace('skill_', '').replace('passive_', '패시브-')}`, tooltipX + padding, tooltipY + currentYOffset);
-                currentYOffset += lineHeight;
+                const skillData = Object.values(WARRIOR_SKILLS).find(s => s.id === skillId);
+                const icon = this.skillIconManager ? this.skillIconManager.getSkillIcon(skillId) : null;
+                const iconSize = 20;
+                const iconX = tooltipX + padding;
+                const iconY = tooltipY + currentYOffset;
+                if (icon) {
+                    ctx.drawImage(icon, iconX, iconY, iconSize, iconSize);
+                }
+                ctx.font = '14px Arial';
+                const textX = iconX + iconSize + 5;
+                const textY = iconY + 2;
+                ctx.fillText(skillData ? skillData.name : skillId, textX, textY);
+                currentYOffset += iconSize + 5;
             }
             currentYOffset += 5; // 다음 섹션과의 간격
         }


### PR DESCRIPTION
## Summary
- extend class data with valiant warrior and zombie entries
- load new class data in `GameEngine` and create `_initBattleGrid`
- spawn 3 valiant warriors with random skills and 5 zombies
- pass `SkillIconManager` into `DetailInfoManager` and render icons in the tooltip

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877ea9fa6f88327bd76f38c96320c06