### PR TITLE
Add HeroManager to spawn hero units

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -48,6 +48,7 @@ import { TurnCountManager } from './managers/TurnCountManager.js';
 import { StatusEffectManager } from './managers/StatusEffectManager.js';
 import { WorkflowManager } from './managers/WorkflowManager.js';
 import { HeroEngine } from "./managers/HeroEngine.js"; // HeroEngine 추가
+import { HeroManager } from './managers/HeroManager.js'; // ✨ HeroManager import
 import { SynergyEngine } from './managers/SynergyEngine.js'; // ✨ SynergyEngine 추가
 import { STATUS_EFFECTS } from '../data/statusEffects.js';
 
@@ -279,6 +280,14 @@ export class GameEngine {
             this.assetLoaderManager,
             this.diceEngine,
             this.diceBotManager
+        );
+
+        // ✨ HeroManager 초기화 - 실제 전사 영웅 생성을 담당
+        this.heroManager = new HeroManager(
+            this.idManager,
+            this.diceEngine,
+            this.assetLoaderManager,
+            this.battleSimulationManager
         );
 
         // ✨ SynergyEngine 초기화
@@ -627,41 +636,10 @@ export class GameEngine {
     }
 
     async _initBattleGrid() {
-        const valiantWarriorClassData = await this.idManager.get('class_warrior_valiant');
-        const warriorSkillKeys = Object.keys(WARRIOR_SKILLS);
+        // ✨ 기존 테스트용 전사 유닛 생성 코드를 제거하고 HeroManager를 사용합니다.
+        await this.heroManager.createAndPlaceWarriors(3);
 
-        const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
         const zombieImage = this.assetLoaderManager.getImage('sprite_zombie_default');
-
-        for (let i = 0; i < 3; i++) {
-            const unitId = `unit_warrior_valiant_${i + 1}`;
-            const startX = 2 + i * 2;
-            const startY = 2;
-
-            const randomSkills = new Set();
-            while (randomSkills.size < 3) {
-                const randomIndex = Math.floor(this.diceEngine.getRandomFloat() * warriorSkillKeys.length);
-                const randomSkillId = WARRIOR_SKILLS[warriorSkillKeys[randomIndex]].id;
-                randomSkills.add(randomSkillId);
-            }
-
-            const warriorClassDataWithSkills = { ...valiantWarriorClassData, skills: [...randomSkills] };
-            await this.idManager.addOrUpdateId(warriorClassDataWithSkills.id, warriorClassDataWithSkills);
-
-            const warriorUnit = {
-                id: unitId,
-                name: '용맹한 전사',
-                classId: 'class_warrior_valiant',
-                type: ATTACK_TYPES.MERCENARY,
-                spriteId: UNITS.WARRIOR.spriteId,
-                gridX: startX,
-                gridY: startY,
-                baseStats: { ...valiantWarriorClassData.baseStats },
-                currentHp: valiantWarriorClassData.baseStats.hp,
-                skillSlots: [...randomSkills]
-            };
-            this.battleSimulationManager.addUnit(warriorUnit, warriorImage, startX, startY);
-        }
 
         const zombieClassData = await this.idManager.get('class_zombie');
         for (let i = 0; i < 5; i++) {
@@ -766,6 +744,8 @@ export class GameEngine {
     getDiceEngine() { return this.diceEngine; }
     getDiceRollManager() { return this.diceRollManager; }
     getHeroEngine() { return this.heroEngine; }
+    // ✨ HeroManager getter 추가
+    getHeroManager() { return this.heroManager; }
     // ✨ SynergyEngine getter 추가
     getSynergyEngine() { return this.synergyEngine; }
     // ✨ DetailInfoManager getter 추가

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -1,0 +1,70 @@
+// js/managers/HeroManager.js
+
+import { ATTACK_TYPES } from '../constants.js';
+import { UNITS } from '../../data/unit.js';
+import { CLASSES } from '../../data/class.js';
+import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
+
+export class HeroManager {
+    constructor(idManager, diceEngine, assetLoaderManager, battleSimulationManager) {
+        console.log("\u2728 HeroManager initialized. Ready to create legendary heroes. \u2728");
+        this.idManager = idManager;
+        this.diceEngine = diceEngine;
+        this.assetLoaderManager = assetLoaderManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.heroNameList = [
+            '레오닉', '아서스', '가로쉬', '스랄', '제이나', '안두인',
+            '바리안', '실바나스', '그롬마쉬', '렉사르', '알렉스트라자', '이렐리아'
+        ];
+    }
+
+    /**
+     * 지정된 수만큼의 전사 클래스 영웅을 생성하여 전투에 배치합니다.
+     * @param {number} count - 생성할 영웅의 수
+     */
+    async createAndPlaceWarriors(count) {
+        console.log(`[HeroManager] Creating ${count} new warriors...`);
+        const warriorClassData = await this.idManager.get(CLASSES.WARRIOR.id);
+        const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
+        const warriorSkillKeys = Object.keys(WARRIOR_SKILLS);
+
+        if (!warriorClassData || !warriorImage) {
+            console.error('[HeroManager] Warrior class data or image not found. Cannot create warriors.');
+            return;
+        }
+
+        for (let i = 0; i < count; i++) {
+            const unitId = `hero_warrior_${Date.now()}_${i}`;
+            const randomName = this.heroNameList[this.diceEngine.getRandomInt(0, this.heroNameList.length - 1)];
+
+            const randomSkills = new Set();
+            while (randomSkills.size < 3) {
+                const randomIndex = this.diceEngine.getRandomInt(0, warriorSkillKeys.length - 1);
+                const randomSkillId = WARRIOR_SKILLS[warriorSkillKeys[randomIndex]].id;
+                randomSkills.add(randomSkillId);
+            }
+
+            const startX = 2 + i * 2;
+            const startY = 4;
+
+            const heroUnitData = {
+                id: unitId,
+                name: randomName,
+                classId: CLASSES.WARRIOR.id,
+                type: ATTACK_TYPES.MERCENARY,
+                spriteId: UNITS.WARRIOR.spriteId,
+                gridX: startX,
+                gridY: startY,
+                baseStats: { ...UNITS.WARRIOR.baseStats },
+                currentHp: UNITS.WARRIOR.baseStats.hp,
+                skillSlots: [...randomSkills],
+                tags: [...CLASSES.WARRIOR.tags]
+            };
+
+            await this.idManager.addOrUpdateId(unitId, heroUnitData);
+            this.battleSimulationManager.addUnit(heroUnitData, warriorImage, startX, startY);
+
+            console.log(`[HeroManager] Created warrior: ${randomName} (ID: ${unitId}) at (${startX}, ${startY})`);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove temporary valiant warrior spawning code
- introduce `HeroManager` to create random warrior heroes
- hook HeroManager into GameEngine and spawn 3 warriors when battle grid initializes

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877f10caab08327a221b004b844e34b