### PR TITLE
Add skill use logic and sprite registration

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -293,7 +293,7 @@
                 runRuleManagerUnitTests();
                 runTurnOrderManagerUnitTests(eventManager, battleSimulationManager);
                 runBasicAIManagerUnitTests(battleSimulationManager);
-                runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager);
+                runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager);
                 runBattleSimulationManagerUnitTests(measureManager, gameEngine.getAssetLoaderManager(), idManager, logicManager);
                 runAnimationManagerUnitTests();
                 runValorEngineUnitTests();
@@ -615,7 +615,7 @@
             runRuleManagerUnitTests();
             runTurnOrderManagerUnitTests(eventManager, battleSimulationManager);
             runBasicAIManagerUnitTests(battleSimulationManager);
-            runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager);
+            runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager);
             runBattleSimulationManagerUnitTests(measureManager, gameEngine.getAssetLoaderManager(), idManager, logicManager);
             runAnimationManagerUnitTests();
             runValorEngineUnitTests();

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -282,14 +282,6 @@ export class GameEngine {
             this.diceBotManager
         );
 
-        // ✨ HeroManager 초기화 - 실제 전사 영웅 생성을 담당
-        this.heroManager = new HeroManager(
-            this.idManager,
-            this.diceEngine,
-            this.assetLoaderManager,
-            this.battleSimulationManager
-        );
-
         // ✨ SynergyEngine 초기화
         this.synergyEngine = new SynergyEngine(this.idManager, this.eventManager);
 
@@ -371,9 +363,18 @@ export class GameEngine {
             this.battleSimulationManager,
             this.weightEngine // ✨ weightEngine 추가
         );
-        this.classAIManager = new ClassAIManager(this.idManager, this.battleSimulationManager, this.measureManager, this.basicAIManager);
-        // ✨ TargetingManager 초기화
-        this.targetingManager = new TargetingManager(this.battleSimulationManager); // BattleSimulationManager를 의존성으로 전달
+        // 먼저 TargetingManager를 초기화
+        this.targetingManager = new TargetingManager(this.battleSimulationManager);
+        // ClassAIManager에 추가 매니저 전달
+        this.classAIManager = new ClassAIManager(
+            this.idManager,
+            this.battleSimulationManager,
+            this.measureManager,
+            this.basicAIManager,
+            this.warriorSkillsAI,
+            this.diceEngine,
+            this.targetingManager
+        );
 
         // ✨ TurnEngine에 새로운 의존성 전달
         this.turnEngine = new TurnEngine(
@@ -431,6 +432,15 @@ export class GameEngine {
             this.battleSimulationManager,
             this.battleCalculationManager,
             this.delayEngine
+        );
+
+        // HeroManager는 UnitSpriteEngine이 준비된 이후 생성한다
+        this.heroManager = new HeroManager(
+            this.idManager,
+            this.diceEngine,
+            this.assetLoaderManager,
+            this.battleSimulationManager,
+            this.unitSpriteEngine
         );
 
         // ------------------------------------------------------------------
@@ -594,14 +604,6 @@ export class GameEngine {
 
         console.log(`[GameEngine] Registered unit ID: ${UNITS.WARRIOR.id}`);
         console.log(`[GameEngine] Loaded warrior sprite: ${UNITS.WARRIOR.spriteId}`);
-
-        await this.unitSpriteEngine.registerUnitSprites('unit_warrior_001', {
-            idle: 'assets/images/warrior.png',
-            attack: 'assets/images/warrior-attack.png',
-            hitted: 'assets/images/warrior-hitted.png',
-            finish: 'assets/images/warrior-finish.png',
-            status: 'assets/images/warrior-status-effects.png'
-        });
 
         const mockEnemyUnitData = {
             id: 'unit_zombie_001', // ID 변경

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -6,12 +6,13 @@ import { CLASSES } from '../../data/class.js';
 import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export class HeroManager {
-    constructor(idManager, diceEngine, assetLoaderManager, battleSimulationManager) {
+    constructor(idManager, diceEngine, assetLoaderManager, battleSimulationManager, unitSpriteEngine) {
         console.log("\u2728 HeroManager initialized. Ready to create legendary heroes. \u2728");
         this.idManager = idManager;
         this.diceEngine = diceEngine;
         this.assetLoaderManager = assetLoaderManager;
         this.battleSimulationManager = battleSimulationManager;
+        this.unitSpriteEngine = unitSpriteEngine;
         this.heroNameList = [
             '레오닉', '아서스', '가로쉬', '스랄', '제이나', '안두인',
             '바리안', '실바나스', '그롬마쉬', '렉사르', '알렉스트라자', '이렐리아'
@@ -64,7 +65,15 @@ export class HeroManager {
             await this.idManager.addOrUpdateId(unitId, heroUnitData);
             this.battleSimulationManager.addUnit(heroUnitData, warriorImage, startX, startY);
 
-            console.log(`[HeroManager] Created warrior: ${randomName} (ID: ${unitId}) at (${startX}, ${startY})`);
+            await this.unitSpriteEngine.registerUnitSprites(unitId, {
+                idle: 'assets/images/warrior.png',
+                attack: 'assets/images/warrior-attack.png',
+                hitted: 'assets/images/warrior-hitted.png',
+                finish: 'assets/images/warrior-finish.png',
+                status: 'assets/images/warrior-status-effects.png'
+            });
+
+            console.log(`[HeroManager] Created warrior: ${randomName} (ID: ${unitId}) at (${startX}, ${startY}) and registered its sprites.`);
         }
     }
 }

--- a/tests/unit/classAIManagerUnitTests.js
+++ b/tests/unit/classAIManagerUnitTests.js
@@ -2,7 +2,7 @@
 
 import { ClassAIManager } from '../../js/managers/ClassAIManager.js';
 
-export function runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager) {
+export function runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager) {
     console.log("--- ClassAIManager Unit Test Start ---");
 
     let testCount = 0;
@@ -45,7 +45,7 @@ export function runClassAIManagerUnitTests(idManager, battleSimulationManager, m
     // 테스트 1: 초기화 확인
     testCount++;
     try {
-        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager);
+        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager);
         if (classAIManager.basicAIManager === basicAIManager) {
             console.log("ClassAIManager: Initialized correctly with BasicAIManager. [PASS]");
             passCount++;
@@ -60,7 +60,7 @@ export function runClassAIManagerUnitTests(idManager, battleSimulationManager, m
     testCount++;
     basicAIManagerCalled = false;
     try {
-        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager);
+        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager);
         battleSimulationManager.unitsOnGrid = [mockWarriorUnit, mockEnemyUnit];
         const action = await classAIManager.getBasicClassAction(mockWarriorUnit, battleSimulationManager.unitsOnGrid);
 
@@ -78,7 +78,7 @@ export function runClassAIManagerUnitTests(idManager, battleSimulationManager, m
     testCount++;
     basicAIManagerCalled = false;
     try {
-        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager);
+        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager);
         battleSimulationManager.unitsOnGrid = [mockUnknownClassUnit, mockEnemyUnit];
         const action = await classAIManager.getBasicClassAction(mockUnknownClassUnit, battleSimulationManager.unitsOnGrid);
 
@@ -110,7 +110,7 @@ export function runClassAIManagerUnitTests(idManager, battleSimulationManager, m
     };
 
     try {
-        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager);
+        const classAIManager = new ClassAIManager(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager);
         const mockUnitNoClass = { ...mockWarriorUnit, classId: 'class_nonexistent' };
         const action = await classAIManager.getBasicClassAction(mockUnitNoClass, battleSimulationManager.unitsOnGrid);
 


### PR DESCRIPTION
## Summary
- enhance `ClassAIManager` with skill decision logic
- inject dependencies for `ClassAIManager` and `HeroManager`
- register sprites for generated heroes
- clean up hardcoded sprite registration
- update debug page and unit tests for new parameters

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6877f3f0d72883278ebea03bbe9edbd4