### PR TITLE
Add formation manager, monster spawner and skill AI improvements

### DIFF
--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -15,10 +15,12 @@ export const WARRIOR_SKILLS = {
         id: 'skill_warrior_charge',
         name: '돌격',
         type: SKILL_TYPES.ACTIVE,
+        aiFunction: 'charge',
         probability: 40, // 이 확률은 RuleManager에 정의된 슬롯 확률에 따라 재조정될 수 있습니다.
         description: '적에게 돌진하여 물리 피해를 입힙니다. 이동과 공격을 동시에 수행합니다.',
         requiredUserTags: ['근접'], // 근접 태그를 가진 유닛만 사용 가능
         effect: {
+            dice: { num: 1, sides: 8 },
             damageMultiplier: 1.5,
             stunChance: 0.2 // 20% 확률로 기절
         }
@@ -28,10 +30,12 @@ export const WARRIOR_SKILLS = {
         id: 'skill_warrior_battle_cry',
         name: '전투의 외침',
         type: SKILL_TYPES.BUFF,
+        aiFunction: 'battleCry',
         probability: 30,
         description: '자신의 공격력을 일시적으로 증가시키고 일반 공격을 수행합니다.',
         requiredUserTags: ['전사_클래스'],
         effect: {
+            dice: { num: 1, sides: 6 },
             statusEffectId: 'status_battle_cry', // 적용할 상태이상 ID
             allowAdditionalAttack: true // 버프 후 추가 공격 가능 플래그
         }

--- a/js/managers/BattleFormationManager.js
+++ b/js/managers/BattleFormationManager.js
@@ -1,0 +1,30 @@
+// js/managers/BattleFormationManager.js
+
+export class BattleFormationManager {
+    constructor(battleSimulationManager) {
+        console.log("\uD83D\uDCCB BattleFormationManager initialized. Arranging heroes for battle. \uD83D\uDCCB");
+        this.battleSimulationManager = battleSimulationManager;
+    }
+
+    /**
+     * 제공된 아군 유닛들을 지정된 포메이션에 따라 배치합니다.
+     * @param {object[]} allyUnits - 배치할 아군 유닛 데이터 배열
+     */
+    placeAllies(allyUnits) {
+        const formationPositions = [
+            { x: 2, y: 3 }, { x: 2, y: 5 }, { x: 4, y: 4 },
+            { x: 4, y: 2 }, { x: 4, y: 6 }, { x: 0, y: 4 }
+        ];
+
+        allyUnits.forEach((unit, index) => {
+            if (index < formationPositions.length) {
+                const pos = formationPositions[index];
+                unit.gridX = pos.x;
+                unit.gridY = pos.y;
+                const unitImage = this.battleSimulationManager.assetLoaderManager.getImage(unit.spriteId);
+                this.battleSimulationManager.addUnit(unit, unitImage, pos.x, pos.y);
+                console.log(`[BattleFormationManager] Placed ${unit.name} at (${pos.x}, ${pos.y})`);
+            }
+        });
+    }
+}

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -69,19 +69,21 @@ export class ClassAIManager {
     }
 
     async executeSkillAI(userUnit, skillData) {
-        let targetUnit = null;
+        if (!skillData.aiFunction) {
+            if (GAME_DEBUG_MODE) console.warn(`[ClassAIManager] Skill ${skillData.name} has no 'aiFunction' defined.`);
+            return;
+        }
 
-        if (skillData.id === WARRIOR_SKILLS.CHARGE.id) {
-            targetUnit = this.targetingManager.getLowestHpUnit('enemy');
-            if (targetUnit) {
-                await this.warriorSkillsAI.charge(userUnit, targetUnit, skillData);
-            } else if (GAME_DEBUG_MODE) {
-                console.log(`[ClassAIManager] Charge skill for ${userUnit.name} has no target.`);
+        const aiFunction = this.warriorSkillsAI[skillData.aiFunction];
+        if (typeof aiFunction === 'function') {
+            let targetUnit = null;
+            if (skillData.id === WARRIOR_SKILLS.CHARGE.id) {
+                targetUnit = this.targetingManager.getLowestHpUnit('enemy');
             }
-        } else if (skillData.id === WARRIOR_SKILLS.BATTLE_CRY.id) {
-            await this.warriorSkillsAI.battleCry(userUnit, skillData);
-        } else if (GAME_DEBUG_MODE) {
-            console.warn(`[ClassAIManager] No specific AI execution logic found for skill: ${skillData.name}`);
+
+            await aiFunction.call(this.warriorSkillsAI, userUnit, targetUnit, skillData);
+        } else {
+            if (GAME_DEBUG_MODE) console.warn(`[ClassAIManager] AI function '${skillData.aiFunction}' not found in WarriorSkillsAI.`);
         }
     }
 

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -20,19 +20,22 @@ export class HeroManager {
     }
 
     /**
-     * 지정된 수만큼의 전사 클래스 영웅을 생성하여 전투에 배치합니다.
+     * 지정된 수만큼의 전사 클래스 영웅 데이터를 생성하여 반환합니다.
      * @param {number} count - 생성할 영웅의 수
+     * @returns {Promise<object[]>} 생성된 영웅 데이터 배열
      */
-    async createAndPlaceWarriors(count) {
-        console.log(`[HeroManager] Creating ${count} new warriors...`);
+    async createWarriors(count) {
+        console.log(`[HeroManager] Creating data for ${count} new warriors...`);
         const warriorClassData = await this.idManager.get(CLASSES.WARRIOR.id);
         const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
         const warriorSkillKeys = Object.keys(WARRIOR_SKILLS);
 
         if (!warriorClassData || !warriorImage) {
             console.error('[HeroManager] Warrior class data or image not found. Cannot create warriors.');
-            return;
+            return [];
         }
+
+        const createdHeroes = [];
 
         for (let i = 0; i < count; i++) {
             const unitId = `hero_warrior_${Date.now()}_${i}`;
@@ -45,17 +48,14 @@ export class HeroManager {
                 randomSkills.add(randomSkillId);
             }
 
-            const startX = 2 + i * 2;
-            const startY = 4;
-
             const heroUnitData = {
                 id: unitId,
                 name: randomName,
                 classId: CLASSES.WARRIOR.id,
                 type: ATTACK_TYPES.MERCENARY,
                 spriteId: UNITS.WARRIOR.spriteId,
-                gridX: startX,
-                gridY: startY,
+                gridX: 0,
+                gridY: 0,
                 baseStats: { ...UNITS.WARRIOR.baseStats },
                 currentHp: UNITS.WARRIOR.baseStats.hp,
                 skillSlots: [...randomSkills],
@@ -63,8 +63,6 @@ export class HeroManager {
             };
 
             await this.idManager.addOrUpdateId(unitId, heroUnitData);
-            this.battleSimulationManager.addUnit(heroUnitData, warriorImage, startX, startY);
-
             await this.unitSpriteEngine.registerUnitSprites(unitId, {
                 idle: 'assets/images/warrior.png',
                 attack: 'assets/images/warrior-attack.png',
@@ -73,7 +71,9 @@ export class HeroManager {
                 status: 'assets/images/warrior-status-effects.png'
             });
 
-            console.log(`[HeroManager] Created warrior: ${randomName} (ID: ${unitId}) at (${startX}, ${startY}) and registered its sprites.`);
+            createdHeroes.push(heroUnitData);
+            console.log(`[HeroManager] Created data for warrior: ${heroUnitData.name}`);
         }
+        return createdHeroes;
     }
 }

--- a/js/managers/MonsterSpawnManager.js
+++ b/js/managers/MonsterSpawnManager.js
@@ -1,0 +1,56 @@
+// js/managers/MonsterSpawnManager.js
+
+import { ATTACK_TYPES } from '../constants.js';
+
+export class MonsterSpawnManager {
+    constructor(idManager, assetLoaderManager, battleSimulationManager) {
+        console.log("\uD83D\uDC79 MonsterSpawnManager initialized. Spawning creatures of the dark. \uD83D\uDC79");
+        this.idManager = idManager;
+        this.assetLoaderManager = assetLoaderManager;
+        this.battleSimulationManager = battleSimulationManager;
+    }
+
+    /**
+     * 스테이지 ID에 따라 몬스터를 스폰합니다.
+     * @param {string} stageId - 몬스터를 스폰할 스테이지의 ID
+     */
+    async spawnMonstersForStage(stageId) {
+        const stageData = {
+            stage1: {
+                zombie: { count: 5, positions: [{x: 12, y: 2}, {x: 12, y: 4}, {x: 12, y: 6}, {x: 14, y: 3}, {x: 14, y: 5}] }
+            }
+        };
+
+        const currentStage = stageData[stageId];
+        if (!currentStage) {
+            console.error(`[MonsterSpawnManager] Stage data for '${stageId}' not found.`);
+            return;
+        }
+
+        const zombieClassData = await this.idManager.get('class_zombie');
+        const zombieImage = this.assetLoaderManager.getImage('sprite_zombie_default');
+
+        if (currentStage.zombie) {
+            for (let i = 0; i < currentStage.zombie.count; i++) {
+                const pos = currentStage.zombie.positions[i] || { x: 13 + i, y: 4 };
+                const unitId = `unit_zombie_${Date.now()}_${i}`;
+
+                const zombieUnit = {
+                    id: unitId,
+                    name: '좀비',
+                    classId: 'class_zombie',
+                    type: ATTACK_TYPES.ENEMY,
+                    spriteId: 'sprite_zombie_default',
+                    gridX: pos.x,
+                    gridY: pos.y,
+                    baseStats: { ...(zombieClassData.baseStats || {}) },
+                    currentHp: zombieClassData.baseStats.hp,
+                };
+
+                await this.idManager.addOrUpdateId(unitId, zombieUnit);
+                this.battleSimulationManager.addUnit(zombieUnit, zombieImage, pos.x, pos.y);
+            }
+        }
+        console.log(`[MonsterSpawnManager] Spawned monsters for stage: ${stageId}`);
+    }
+}

--- a/js/managers/StatusIconManager.js
+++ b/js/managers/StatusIconManager.js
@@ -8,19 +8,19 @@ export class StatusIconManager {
      * StatusIconManager를 초기화합니다.
      * @param {SkillIconManager} skillIconManager
      * @param {BattleSimulationManager} battleSimulationManager
-     * @param {AnimationManager} animationManager
+     * @param {BindingManager} bindingManager
      * @param {MeasureManager} measureManager
      * @param {TurnCountManager} turnCountManager
      */
-    constructor(skillIconManager, battleSimulationManager, animationManager, measureManager, turnCountManager) {
+    constructor(skillIconManager, battleSimulationManager, bindingManager, measureManager, turnCountManager) {
         if (GAME_DEBUG_MODE) console.log("\u2728 StatusIconManager initialized. Displaying status effects visually. \u2728");
-        if (!skillIconManager || !battleSimulationManager || !animationManager || !measureManager || !turnCountManager) {
+        if (!skillIconManager || !battleSimulationManager || !bindingManager || !measureManager || !turnCountManager) {
             throw new Error("[StatusIconManager] Missing one or more essential dependencies. Cannot initialize.");
         }
 
         this.skillIconManager = skillIconManager;
         this.battleSimulationManager = battleSimulationManager;
-        this.animationManager = animationManager;
+        this.bindingManager = bindingManager;
         this.measureManager = measureManager;
         this.turnCountManager = turnCountManager;
 
@@ -34,7 +34,7 @@ export class StatusIconManager {
      * @param {CanvasRenderingContext2D} ctx
      */
     draw(ctx) {
-        const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
+        const { effectiveTileSize } = this.battleSimulationManager.getGridRenderParameters();
 
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
             if (unit.currentHp <= 0) continue;
@@ -42,14 +42,9 @@ export class StatusIconManager {
             const activeEffects = this.turnCountManager.getEffectsOfUnit(unit.id);
             if (!activeEffects || activeEffects.size === 0) continue;
 
-            const { drawX, drawY } = this.animationManager.getRenderPosition(
-                unit.id,
-                unit.gridX,
-                unit.gridY,
-                effectiveTileSize,
-                gridOffsetX,
-                gridOffsetY
-            );
+            const bindings = this.bindingManager.getBindings(unit.id);
+            if (!bindings) continue;
+            const { renderX: drawX, renderY: drawY } = bindings;
 
             const baseIconSize = effectiveTileSize * this.iconSizeRatio;
             let currentIconDrawX = drawX + (effectiveTileSize - (activeEffects.size * baseIconSize + (activeEffects.size - 1) * this.iconSpacing)) / 2;

--- a/js/managers/warriorSkillsAI.js
+++ b/js/managers/warriorSkillsAI.js
@@ -56,10 +56,10 @@ export class WarriorSkillsAI {
             if (GAME_DEBUG_MODE) console.log("[WarriorSkillsAI] Charge: Failed to move to optimal position, proceeding with attack from current location.");
         }
 
-        // 2. 물리 피해 계산 및 적용
+        // 2. 물리 피해 계산 및 적용 (데이터 참조)
         const attackSkillData = {
             type: ATTACK_TYPES.PHYSICAL,
-            dice: { num: 1, sides: 8 },
+            dice: skillData.effect.dice,
             damageMultiplier: skillData.effect.damageMultiplier || 1
         };
 
@@ -106,7 +106,7 @@ export class WarriorSkillsAI {
                     attackType: ATTACK_TYPES.MELEE
                 });
 
-                const normalAttackData = { type: ATTACK_TYPES.PHYSICAL, dice: { num: 1, sides: 6 } };
+                const normalAttackData = { type: ATTACK_TYPES.PHYSICAL, dice: skillData.effect.dice };
                 this.managers.battleCalculationManager.requestDamageCalculation(userUnit.id, closestEnemy.id, normalAttackData);
                 await this.managers.delayEngine.waitFor(500);
             } else {


### PR DESCRIPTION
## Summary
- enable `WARRIOR_SKILLS` to specify `aiFunction` and dice data
- execute warrior skills dynamically according to the new field
- create `BattleFormationManager` and `MonsterSpawnManager`
- refactor `HeroManager` to only create hero data
- wire new managers into `GameEngine`
- drive `StatusIconManager` from `BindingManager`
- bind unit render positions every frame

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6877f62d4ed88327b9ab52376cec9105