### PR TITLE
Fix stage data injection

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -33,14 +33,23 @@ export class GameEngine {
         this.gameLoop = new GameLoop(this._update.bind(this), this._draw.bind(this));
 
         // 비동기 매니저 초기화 후 게임 시작
-        this._initAsyncManagers().then(() => {
-            this.start();
-        });
+        this._initAsyncManagers()
+            .then(() => {
+                this.start();
+            })
+            .catch((err) => {
+                console.error('Fatal Error: Async manager initialization failed.', err);
+            });
     }
 
     async _initAsyncManagers() {
-        await this.assetEngine.getIdManager().initialize();
-        await this.battleEngine.setupBattle();
+        try {
+            await this.assetEngine.getIdManager().initialize();
+            await this.battleEngine.setupBattle();
+        } catch (error) {
+            console.error('Async manager initialization failed.', error);
+            throw error;
+        }
     }
 
     _update(deltaTime) {

--- a/js/engines/BattleEngine.js
+++ b/js/engines/BattleEngine.js
@@ -9,6 +9,7 @@ import { DiceBotManager } from '../managers/DiceBotManager.js';
 import { HeroManager } from '../managers/HeroManager.js';
 import { BattleFormationManager } from '../managers/BattleFormationManager.js';
 import { MonsterSpawnManager } from '../managers/MonsterSpawnManager.js';
+import { StageDataManager } from '../managers/StageDataManager.js';
 import { DelayEngine } from '../managers/DelayEngine.js';
 import { TimingEngine } from '../managers/TimingEngine.js';
 import { CoordinateManager } from '../managers/CoordinateManager.js';
@@ -29,6 +30,7 @@ export class BattleEngine {
         const idManager = assetEngine.getIdManager();
         const assetLoaderManager = assetEngine.getAssetLoaderManager();
         const animationManager = renderEngine.getAnimationManager();
+        this.stageDataManager = new StageDataManager();
 
         this.valorEngine = new ValorEngine();
         this.weightEngine = new WeightEngine();
@@ -69,7 +71,12 @@ export class BattleEngine {
 
         this.heroManager = new HeroManager(idManager, this.diceEngine, assetLoaderManager, this.battleSimulationManager, assetEngine.getUnitSpriteEngine());
         this.battleFormationManager = new BattleFormationManager(this.battleSimulationManager);
-        this.monsterSpawnManager = new MonsterSpawnManager(idManager, assetLoaderManager, this.battleSimulationManager);
+        this.monsterSpawnManager = new MonsterSpawnManager(
+            idManager,
+            assetLoaderManager,
+            this.battleSimulationManager,
+            this.stageDataManager
+        );
 
         this.conditionalManager = new ConditionalManager(this.battleSimulationManager, idManager);
     }
@@ -89,4 +96,5 @@ export class BattleEngine {
     }
 
     getBattleSimulationManager() { return this.battleSimulationManager; }
+    getStageDataManager() { return this.stageDataManager; }
 }

--- a/js/managers/MonsterSpawnManager.js
+++ b/js/managers/MonsterSpawnManager.js
@@ -18,6 +18,11 @@ export class MonsterSpawnManager {
      * @param {string} stageId - 몬스터를 스폰할 스테이지의 ID
      */
     async spawnMonstersForStage(stageId) {
+        if (!this.stageDataManager) {
+            console.error('[MonsterSpawnManager] StageDataManager not provided.');
+            return;
+        }
+
         const currentStage = this.stageDataManager.getStageData(stageId);
         if (!currentStage) {
             console.error(`[MonsterSpawnManager] Stage data for '${stageId}' not found.`);


### PR DESCRIPTION
## Summary
- inject StageDataManager into BattleEngine to provide monster spawn data
- handle missing stage data manager
- add error handling during async initialization

## Testing
- `node --test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6877fbd9dafc832787798440015abcde