### PR TITLE
Improve hero creation and centralize stat updates

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -24,6 +24,25 @@ export const CLASSES = {
             WARRIOR_SKILLS.BATTLE_CRY.id,
             WARRIOR_SKILLS.IRON_WILL.id
         ],
+        statRanges: {
+            hp: [90, 130],
+            valor: [40, 70],
+            strength: [20, 35],
+            endurance: [15, 30],
+            agility: [5, 15],
+            intelligence: [5, 10],
+            wisdom: [5, 15],
+            luck: [10, 20],
+            weight: [25, 40],
+            speed: [40, 60]
+        },
+        availableSkills: [
+            WARRIOR_SKILLS.CHARGE.id,
+            WARRIOR_SKILLS.BATTLE_CRY.id,
+            WARRIOR_SKILLS.RENDING_STRIKE.id,
+            WARRIOR_SKILLS.RETALIATE.id,
+            WARRIOR_SKILLS.IRON_WILL.id
+        ],
         moveRange: 3, // 전사의 이동 거리
         tags: ['근접', '방어', '용병_클래스'] // ✨ 태그 추가
     },

--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -1,13 +1,7 @@
 // data/warriorSkills.js
 
-// 스킬 타입 상수는 필요에 따라 별도의 constants.js 파일로 이동 가능
-export const SKILL_TYPES = {
-    ACTIVE: 'active',
-    PASSIVE: 'passive',
-    DEBUFF: 'debuff',
-    REACTION: 'reaction',
-    BUFF: 'buff'
-};
+// 스킬 타입 상수는 constants.js에서 가져옵니다
+import { SKILL_TYPES } from '../js/constants.js';
 
 export const WARRIOR_SKILLS = {
     // 액티브 스킬 (첫 번째 슬롯에 있으면 좋은 스킬 예시)

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -9,6 +9,7 @@ import { MeasureManager } from './managers/MeasureManager.js';
 import { RuleManager } from './managers/RuleManager.js';
 import { SceneEngine } from './managers/SceneEngine.js';
 import { LogicManager } from './managers/LogicManager.js';
+import { UnitStatManager } from './managers/UnitStatManager.js';
 
 export class GameEngine {
     constructor(canvasId) {
@@ -23,6 +24,9 @@ export class GameEngine {
         this.assetEngine = new AssetEngine(this.eventManager);
         this.renderEngine = new RenderEngine(canvasId, this.eventManager, this.measureManager);
         this.battleEngine = new BattleEngine(this.eventManager, this.measureManager, this.assetEngine, this.renderEngine);
+
+        // \u2728 UnitStatManager 초기화
+        this.unitStatManager = new UnitStatManager(this.eventManager, this.battleEngine.getBattleSimulationManager());
 
         // 3. 장면 및 로직
         this.sceneEngine = new SceneEngine();
@@ -75,4 +79,5 @@ export class GameEngine {
     getAssetEngine() { return this.assetEngine; }
     getRenderEngine() { return this.renderEngine; }
     getBattleEngine() { return this.battleEngine; }
+    getUnitStatManager() { return this.unitStatManager; }
 }

--- a/js/engines/BattleEngine.js
+++ b/js/engines/BattleEngine.js
@@ -64,6 +64,7 @@ export class BattleEngine {
             this.classAIManager,
             this.delayEngine,
             this.timingEngine,
+            measureManager,
             animationManager,
             null,
             null

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -28,7 +28,8 @@ export class HeroManager {
         console.log(`[HeroManager] Creating data for ${count} new warriors...`);
         const warriorClassData = await this.idManager.get(CLASSES.WARRIOR.id);
         const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
-        const warriorSkillKeys = Object.keys(WARRIOR_SKILLS);
+        const statRanges = warriorClassData.statRanges;
+        const availableSkills = warriorClassData.availableSkills;
 
         if (!warriorClassData || !warriorImage) {
             console.error('[HeroManager] Warrior class data or image not found. Cannot create warriors.');
@@ -41,11 +42,15 @@ export class HeroManager {
             const unitId = `hero_warrior_${Date.now()}_${i}`;
             const randomName = this.heroNameList[this.diceEngine.getRandomInt(0, this.heroNameList.length - 1)];
 
+            const baseStats = {};
+            for (const stat in statRanges) {
+                baseStats[stat] = this.diceEngine.getRandomInt(statRanges[stat][0], statRanges[stat][1]);
+            }
+
             const randomSkills = new Set();
-            while (randomSkills.size < 3) {
-                const randomIndex = this.diceEngine.getRandomInt(0, warriorSkillKeys.length - 1);
-                const randomSkillId = WARRIOR_SKILLS[warriorSkillKeys[randomIndex]].id;
-                randomSkills.add(randomSkillId);
+            while (randomSkills.size < 3 && availableSkills.length > randomSkills.size) {
+                const randomIndex = this.diceEngine.getRandomInt(0, availableSkills.length - 1);
+                randomSkills.add(availableSkills[randomIndex]);
             }
 
             const heroUnitData = {
@@ -56,8 +61,8 @@ export class HeroManager {
                 spriteId: UNITS.WARRIOR.spriteId,
                 gridX: 0,
                 gridY: 0,
-                baseStats: { ...UNITS.WARRIOR.baseStats },
-                currentHp: UNITS.WARRIOR.baseStats.hp,
+                baseStats: baseStats,
+                currentHp: baseStats.hp,
                 skillSlots: [...randomSkills],
                 tags: [...CLASSES.WARRIOR.tags]
             };

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -76,6 +76,12 @@ export class MeasureManager {
                 weaponDropFadeDuration: 500,    // 무기 사라지는 시간 (ms)
                 weaponDropTotalDuration: 1300   // 무기 애니메이션 총 지속 시간 (ms)
             },
+            // ✨ 타이밍 관련 설정 추가
+            timing: {
+                turnEndDelay: 1000,     // 턴 종료 후 다음 턴 시작까지의 딜레이
+                skillExecutionDelay: 800, // 스킬 시전 시 기본 딜레이
+                damageDisplayDelay: 100  // 다중 피해 표시 사이의 딜레이
+            },
             // ✨ 파티클 효과 관련 설정 추가
             particle: {
                 baseSize: 4,      // 파티클 기본 크기 (픽셀)

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -4,7 +4,7 @@
 import { GAME_EVENTS, UI_STATES, ATTACK_TYPES } from '../constants.js';
 
 export class TurnEngine {
-    constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager, statusEffectManager) {
+    constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, measureManager, animationManager, battleCalculationManager, statusEffectManager) {
         console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
@@ -13,6 +13,7 @@ export class TurnEngine {
         this.delayEngine = delayEngine;
         this.timingEngine = timingEngine;
         this.animationManager = animationManager;
+        this.measureManager = measureManager;
         this.battleCalculationManager = battleCalculationManager;
         this.statusEffectManager = statusEffectManager;
 
@@ -172,7 +173,7 @@ export class TurnEngine {
 
         console.log(`--- Turn ${this.currentTurn} Ends ---\n`);
 
-        await this.delayEngine.waitFor(1000);
+        await this.delayEngine.waitFor(this.measureManager.get('timing.turnEndDelay'));
 
         if (this.eventManager.getGameRunningState()) {
             this.nextTurn();


### PR DESCRIPTION
## Summary
- reference skill type constants from a single source
- add timing settings in `MeasureManager`
- use timing settings in `TurnEngine`
- enrich warrior class data with stat ranges and skill pool
- generate warriors using class data
- centralize stat changes with an event-driven `UnitStatManager`
- simplify `BattleCalculationManager` worker handling
- pass `measureManager` to `TurnEngine` and expose `UnitStatManager` from `GameEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6877fe21fb288327b7708eda0bf7b105