### PR TITLE
Fix initialization issues for battle flow

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -64,6 +64,20 @@ export const CLASSES = {
         description: '느릿느릿 움직이는 언데드.',
         skills: ['skill_melee_attack'],
         moveRange: 2,
+        baseStats: {
+            hp: 40,
+            attack: 8,
+            defense: 3,
+            speed: 2,
+            valor: 0,
+            strength: 8,
+            endurance: 6,
+            agility: 4,
+            intelligence: 2,
+            wisdom: 1,
+            luck: 1,
+            weight: 15
+        },
         tags: ['근접', '언데드', '적_클래스']
     },
     // 다른 클래스들이 여기에 추가됩니다.


### PR DESCRIPTION
## Summary
- add base stats for zombie class
- create status effect management in `BattleEngine`
- load unit images before starting a battle

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878008ced1c83278f6b000196147939