### PR TITLE
Refactor turn engine with state and command patterns

### DIFF
--- a/js/commands/AttackCommand.js
+++ b/js/commands/AttackCommand.js
@@ -1,0 +1,24 @@
+import { GAME_EVENTS, ATTACK_TYPES } from '../constants.js';
+
+export class AttackCommand {
+    constructor(attackerId, targetId) {
+        this.attackerId = attackerId;
+        this.targetId = targetId;
+    }
+
+    async execute({ battleCalculationManager, eventManager, delayEngine }) {
+        console.log(`[Command] Executing Attack: ${this.attackerId} -> ${this.targetId}`);
+        if (eventManager) {
+            eventManager.emit(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, {
+                attackerId: this.attackerId,
+                targetId: this.targetId,
+                attackType: ATTACK_TYPES.MELEE
+            });
+        }
+        const attackSkillData = { type: ATTACK_TYPES.PHYSICAL, dice: { num: 1, sides: 6 } };
+        battleCalculationManager.requestDamageCalculation(this.attackerId, this.targetId, attackSkillData);
+        if (delayEngine) {
+            await delayEngine.waitFor(500);
+        }
+    }
+}

--- a/js/commands/MoveCommand.js
+++ b/js/commands/MoveCommand.js
@@ -1,0 +1,18 @@
+export class MoveCommand {
+    constructor(unitId, destX, destY) {
+        this.unitId = unitId;
+        this.destX = destX;
+        this.destY = destY;
+    }
+
+    async execute({ battleSimulationManager, animationManager }) {
+        const unit = battleSimulationManager.unitsOnGrid.find(u => u.id === this.unitId);
+        if (!unit) return;
+        const startX = unit.gridX;
+        const startY = unit.gridY;
+        const moved = battleSimulationManager.moveUnit(this.unitId, this.destX, this.destY);
+        if (moved && animationManager) {
+            await animationManager.queueMoveAnimation(this.unitId, startX, startY, this.destX, this.destY);
+        }
+    }
+}

--- a/js/components/PositionComponent.js
+++ b/js/components/PositionComponent.js
@@ -1,0 +1,3 @@
+export function PositionComponent(x = 0, y = 0) {
+    return { x, y };
+}

--- a/js/components/StatsComponent.js
+++ b/js/components/StatsComponent.js
@@ -1,0 +1,8 @@
+export function StatsComponent(stats) {
+    return {
+        ...stats,
+        currentHp: stats.hp,
+        currentBarrier: 0,
+        maxBarrier: 0,
+    };
+}

--- a/js/engines/BattleEngine.js
+++ b/js/engines/BattleEngine.js
@@ -119,6 +119,7 @@ export class BattleEngine {
 
     update(deltaTime) {
         this.conditionalManager.update();
+        this.turnEngine.update();
     }
 
     getBattleSimulationManager() { return this.battleSimulationManager; }

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -2,6 +2,8 @@
 
 import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 import { GAME_DEBUG_MODE } from '../constants.js';
+import { AttackCommand } from '../commands/AttackCommand.js';
+import { MoveCommand } from '../commands/MoveCommand.js';
 
 export class ClassAIManager {
     constructor(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager) {
@@ -100,6 +102,23 @@ export class ClassAIManager {
 
         const action = this.basicAIManager.determineMoveAndTarget(warriorUnit, allUnits, moveRange, attackRange);
 
-        return action;
+        if (!action) return null;
+
+        if (action.actionType === 'attack' && action.targetId) {
+            return new AttackCommand(warriorUnit.id, action.targetId);
+        }
+
+        if (action.actionType === 'move') {
+            return new MoveCommand(warriorUnit.id, action.moveTargetX, action.moveTargetY);
+        }
+
+        if (action.actionType === 'moveAndAttack' && action.targetId) {
+            return [
+                new MoveCommand(warriorUnit.id, action.moveTargetX, action.moveTargetY),
+                new AttackCommand(warriorUnit.id, action.targetId)
+            ];
+        }
+
+        return null;
     }
 }

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -2,6 +2,7 @@
 
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, ATTACK_TYPES } from '../constants.js';
+import { StartTurnState } from '../states/StartTurnState.js';
 
 export class TurnEngine {
     constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, measureManager, animationManager, battleCalculationManager, statusEffectManager) {
@@ -21,6 +22,8 @@ export class TurnEngine {
         this.activeUnitIndex = -1;
         this.turnOrder = [];
 
+        this.currentState = null;
+
         this.turnPhaseCallbacks = {
             startOfTurn: [],
             unitActions: [],
@@ -30,6 +33,23 @@ export class TurnEngine {
         this.eventManager.subscribe(GAME_EVENTS.UNIT_DEATH, (data) => { // ✨ 상수 사용
             this.turnOrderManager.removeUnitFromOrder(data.unitId);
         });
+    }
+
+    setState(newState) {
+        if (this.currentState && this.currentState.exit) {
+            this.currentState.exit();
+        }
+        this.currentState = newState;
+        console.log(`[TurnEngine] State changed to: ${this.currentState.constructor.name}`);
+        if (this.currentState.enter) {
+            this.currentState.enter();
+        }
+    }
+
+    update() {
+        if (this.currentState && this.currentState.update) {
+            this.currentState.update();
+        }
     }
 
     /**
@@ -49,138 +69,9 @@ export class TurnEngine {
         this.initializeTurnOrder();
         // 전투 시작 시 모든 상태 효과 초기화
         this.statusEffectManager.turnCountManager.clearAllEffects();
-        this.nextTurn();
+        this.setState(new StartTurnState(this));
     }
 
-    async nextTurn() {
-        const livingMercenaries = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === ATTACK_TYPES.MERCENARY && u.currentHp > 0); // ✨ 상수 사용
-        const livingEnemies = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === ATTACK_TYPES.ENEMY && u.currentHp > 0); // ✨ 상수 사용
-
-        if (livingMercenaries.length === 0) {
-            console.log("[TurnEngine] All mercenaries defeated! Battle Over.");
-            this.eventManager.emit(GAME_EVENTS.BATTLE_END, { reason: 'allMercenariesDefeated' }); // ✨ 상수 사용
-            this.eventManager.setGameRunningState(false);
-            return;
-        }
-        if (livingEnemies.length === 0) {
-            console.log("[TurnEngine] All enemies defeated! Battle Over.");
-            this.eventManager.emit(GAME_EVENTS.BATTLE_END, { reason: 'allEnemiesDefeated' }); // ✨ 상수 사용
-            this.eventManager.setGameRunningState(false);
-            return;
-        }
-
-        this.currentTurn++;
-        console.log(`\n--- Turn ${this.currentTurn} Starts ---`);
-        this.eventManager.emit(GAME_EVENTS.TURN_START, { turn: this.currentTurn }); // ✨ 상수 사용
-        this.timingEngine.clearActions();
-
-        this.eventManager.emit(GAME_EVENTS.TURN_PHASE, { phase: 'startOfTurn', turn: this.currentTurn });
-        for (const callback of this.turnPhaseCallbacks.startOfTurn) {
-            await callback();
-        }
-
-        const currentTurnUnits = this.turnOrderManager.getTurnOrder();
-        for (let i = 0; i < currentTurnUnits.length; i++) {
-            const unit = currentTurnUnits[i];
-            if (unit.currentHp <= 0) {
-                console.log(`[TurnEngine] Unit ${unit.name} is already dead. Skipping turn.`);
-                continue;
-            }
-
-            this.activeUnitIndex = i;
-            console.log(`[TurnEngine] Processing turn for unit: ${unit.name} (ID: ${unit.id})`);
-            this.eventManager.emit(GAME_EVENTS.UNIT_TURN_START, { unitId: unit.id, unitName: unit.name }); // ✨ 상수 사용
-            // ✨ 상태 효과 확인: 유닛의 행동 가능 여부 검사
-            const activeEffects = this.statusEffectManager.getUnitActiveEffects(unit.id);
-            let canUnitAct = true;
-
-            if (activeEffects) {
-                for (const [effectId, effect] of activeEffects.entries()) {
-                    if (effect.effectData.effect.canAct === false) {
-                        canUnitAct = false;
-                        console.log(`[TurnEngine] Unit ${unit.name} is ${effect.effectData.name} (${effectId}) and cannot act this turn.`);
-                        break;
-                    }
-                }
-            }
-
-            let action = null;
-            if (!canUnitAct) {
-                await this.delayEngine.waitFor(500);
-            } else {
-                action = await this.classAIManager.getBasicClassAction(unit, this.battleSimulationManager.unitsOnGrid);
-            }
-
-            if (action) {
-                this.timingEngine.addTimedAction(async () => {
-                    if (action.actionType === 'move' || action.actionType === 'moveAndAttack') {
-                        const startGridX = unit.gridX;
-                        const startGridY = unit.gridY;
-                        console.log(`[TurnEngine] Unit ${unit.name} attempts to move from (${startGridX},${startGridY}) to (${action.moveTargetX}, ${action.moveTargetY}).`);
-
-                        const moved = this.battleSimulationManager.moveUnit(unit.id, action.moveTargetX, action.moveTargetY);
-                        if (moved) {
-                            await this.animationManager.queueMoveAnimation(
-                                unit.id,
-                                startGridX,
-                                startGridY,
-                                action.moveTargetX,
-                                action.moveTargetY
-                            );
-                        }
-                    }
-
-                    if (action.actionType === 'attack' || action.actionType === 'moveAndAttack') {
-                        if (action.targetId) {
-                            const targetUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === action.targetId);
-                            if (targetUnit && targetUnit.currentHp > 0) {
-                                console.log(`[TurnEngine] Unit ${unit.name} attacks ${targetUnit.name}!`);
-                                this.eventManager.emit(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, { // ✨ 상수 사용
-                                    attackerId: unit.id,
-                                    targetId: targetUnit.id,
-                                    attackType: ATTACK_TYPES.MELEE // ✨ 상수 사용
-                                });
-                                const defaultAttackSkillData = { type: ATTACK_TYPES.PHYSICAL, dice: { num: 1, sides: 6 } }; // ✨ 상수 사용
-                                this.battleCalculationManager.requestDamageCalculation(unit.id, targetUnit.id, defaultAttackSkillData);
-                                await this.delayEngine.waitFor(500);
-                            } else {
-                                console.log(`[TurnEngine] Target ${action.targetId} is no longer valid for attack.`);
-                            }
-                        }
-                    } else if (action.actionType === 'skill') {
-                        console.log(`[TurnEngine] Unit ${unit.name} attempts to use skill.`);
-                        await this.delayEngine.waitFor(800);
-                    }
-                }, 10, `${unit.name}'s Primary Action`);
-            } else {
-                console.log(`[TurnEngine] Unit ${unit.name} has no determined action for this turn.`);
-            }
-
-            this.eventManager.emit(GAME_EVENTS.TURN_PHASE, { phase: 'unitActions', unitId: unit.id, turn: this.currentTurn });
-            for (const callback of this.turnPhaseCallbacks.unitActions) {
-                await callback(unit);
-            }
-            this.eventManager.emit(GAME_EVENTS.UNIT_TURN_END, { unitId: unit.id, unitName: unit.name }); // ✨ 상수 사용
-
-            await this.timingEngine.processActions();
-            this.timingEngine.clearActions();
-        }
-
-        this.eventManager.emit(GAME_EVENTS.TURN_PHASE, { phase: 'endOfTurn', turn: this.currentTurn });
-        for (const callback of this.turnPhaseCallbacks.endOfTurn) {
-            await callback();
-        }
-
-        console.log(`--- Turn ${this.currentTurn} Ends ---\n`);
-
-        await this.delayEngine.waitFor(this.measureManager.get('timing.turnEndDelay'));
-
-        if (this.eventManager.getGameRunningState()) {
-            this.nextTurn();
-        } else {
-            console.log("[TurnEngine] Game is paused or ended, not proceeding to next turn.");
-        }
-    }
 
     addTurnPhaseCallback(phase, callback) {
         if (this.turnPhaseCallbacks[phase]) {

--- a/js/states/EndTurnState.js
+++ b/js/states/EndTurnState.js
@@ -1,0 +1,19 @@
+import { TurnState } from './TurnState.js';
+import { StartTurnState } from './StartTurnState.js';
+import { GAME_EVENTS } from '../constants.js';
+
+export class EndTurnState extends TurnState {
+    async enter() {
+        this.turnEngine.eventManager.emit(GAME_EVENTS.TURN_PHASE, { phase: 'endOfTurn', turn: this.turnEngine.currentTurn });
+        for (const cb of this.turnEngine.turnPhaseCallbacks.endOfTurn) {
+            await cb();
+        }
+        console.log(`--- Turn ${this.turnEngine.currentTurn} Ends ---\n`);
+        await this.turnEngine.delayEngine.waitFor(this.turnEngine.measureManager.get('timing.turnEndDelay'));
+        if (this.turnEngine.eventManager.getGameRunningState()) {
+            this.turnEngine.setState(new StartTurnState(this.turnEngine));
+        } else {
+            console.log('[TurnEngine] Game is paused or ended, not proceeding to next turn.');
+        }
+    }
+}

--- a/js/states/ProcessUnitTurnState.js
+++ b/js/states/ProcessUnitTurnState.js
@@ -1,0 +1,61 @@
+import { TurnState } from './TurnState.js';
+import { EndTurnState } from './EndTurnState.js';
+
+export class ProcessUnitTurnState extends TurnState {
+    async enter() {
+        const bsm = this.turnEngine.battleSimulationManager;
+        const currentTurnUnits = this.turnEngine.turnOrderManager.getTurnOrder();
+        for (let i = 0; i < currentTurnUnits.length; i++) {
+            const unit = currentTurnUnits[i];
+            if (unit.currentHp <= 0) continue;
+
+            this.turnEngine.activeUnitIndex = i;
+            this.turnEngine.eventManager.emit('unitTurnStart', { unitId: unit.id, unitName: unit.name });
+
+            const activeEffects = this.turnEngine.statusEffectManager.getUnitActiveEffects(unit.id);
+            let canUnitAct = true;
+            if (activeEffects) {
+                for (const [, effect] of activeEffects.entries()) {
+                    if (effect.effectData.effect.canAct === false) {
+                        canUnitAct = false;
+                        break;
+                    }
+                }
+            }
+
+            let aiResult = null;
+            if (!canUnitAct) {
+                await this.turnEngine.delayEngine.waitFor(500);
+            } else {
+                aiResult = await this.turnEngine.classAIManager.getBasicClassAction(unit, bsm.unitsOnGrid);
+            }
+
+            const commands = [];
+            if (Array.isArray(aiResult)) {
+                commands.push(...aiResult);
+            } else if (aiResult && typeof aiResult.execute === 'function') {
+                commands.push(aiResult);
+            }
+
+            for (const cmd of commands) {
+                await cmd.execute({
+                    battleSimulationManager: bsm,
+                    animationManager: this.turnEngine.animationManager,
+                    battleCalculationManager: this.turnEngine.battleCalculationManager,
+                    eventManager: this.turnEngine.eventManager,
+                    delayEngine: this.turnEngine.delayEngine
+                });
+            }
+
+            this.turnEngine.eventManager.emit('turnPhase', { phase: 'unitActions', unitId: unit.id, turn: this.turnEngine.currentTurn });
+            for (const cb of this.turnEngine.turnPhaseCallbacks.unitActions) {
+                await cb(unit);
+            }
+            this.turnEngine.eventManager.emit('unitTurnEnd', { unitId: unit.id, unitName: unit.name });
+
+            await this.turnEngine.timingEngine.processActions();
+            this.turnEngine.timingEngine.clearActions();
+        }
+        this.turnEngine.setState(new EndTurnState(this.turnEngine));
+    }
+}

--- a/js/states/StartTurnState.js
+++ b/js/states/StartTurnState.js
@@ -1,0 +1,25 @@
+import { TurnState } from './TurnState.js';
+import { ProcessUnitTurnState } from './ProcessUnitTurnState.js';
+import { GAME_EVENTS, ATTACK_TYPES } from '../constants.js';
+
+export class StartTurnState extends TurnState {
+    async enter() {
+        const livingMercenaries = this.turnEngine.battleSimulationManager.unitsOnGrid.filter(u => u.type === ATTACK_TYPES.MERCENARY && u.currentHp > 0);
+        const livingEnemies = this.turnEngine.battleSimulationManager.unitsOnGrid.filter(u => u.type === ATTACK_TYPES.ENEMY && u.currentHp > 0);
+        if (livingMercenaries.length === 0 || livingEnemies.length === 0) {
+            const reason = livingMercenaries.length === 0 ? 'allMercenariesDefeated' : 'allEnemiesDefeated';
+            this.turnEngine.eventManager.emit(GAME_EVENTS.BATTLE_END, { reason });
+            this.turnEngine.eventManager.setGameRunningState(false);
+            return;
+        }
+        this.turnEngine.currentTurn++;
+        console.log(`\n--- Turn ${this.turnEngine.currentTurn} Starts ---`);
+        this.turnEngine.eventManager.emit(GAME_EVENTS.TURN_START, { turn: this.turnEngine.currentTurn });
+        this.turnEngine.timingEngine.clearActions();
+        this.turnEngine.eventManager.emit(GAME_EVENTS.TURN_PHASE, { phase: 'startOfTurn', turn: this.turnEngine.currentTurn });
+        for (const cb of this.turnEngine.turnPhaseCallbacks.startOfTurn) {
+            await cb();
+        }
+        this.turnEngine.setState(new ProcessUnitTurnState(this.turnEngine));
+    }
+}

--- a/js/states/TurnState.js
+++ b/js/states/TurnState.js
@@ -1,0 +1,8 @@
+export class TurnState {
+    constructor(turnEngine) {
+        this.turnEngine = turnEngine;
+    }
+    async enter() {}
+    async update() {}
+    async exit() {}
+}


### PR DESCRIPTION
## Summary
- implement simple component store for `BattleSimulationManager`
- add `AttackCommand` to decouple action execution
- create new turn state classes and refactor `TurnEngine` to use them
- hook state-driven update in `BattleEngine`
- expand command pattern with `MoveCommand`
- execute AI decisions with new commands inside `ProcessUnitTurnState`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6878029f2c84832796f1c1e3ea22568c