### PR TITLE
Fix missing class data for hero creation

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -10,6 +10,7 @@ import { RuleManager } from './managers/RuleManager.js';
 import { SceneEngine } from './managers/SceneEngine.js';
 import { LogicManager } from './managers/LogicManager.js';
 import { UnitStatManager } from './managers/UnitStatManager.js';
+import { GameDataManager } from './managers/GameDataManager.js';
 
 export class GameEngine {
     constructor(canvasId) {
@@ -48,7 +49,9 @@ export class GameEngine {
 
     async _initAsyncManagers() {
         try {
-            await this.assetEngine.getIdManager().initialize();
+            const idManager = this.assetEngine.getIdManager();
+            await idManager.initialize();
+            await GameDataManager.registerBaseClasses(idManager);
             await this.battleEngine.setupBattle();
         } catch (error) {
             console.error('Async manager initialization failed.', error);

--- a/js/managers/GameDataManager.js
+++ b/js/managers/GameDataManager.js
@@ -1,0 +1,29 @@
+// js/managers/GameDataManager.js
+
+import { CLASSES } from '../../data/class.js';
+
+/**
+ * GameDataManager seeds the IdManager with static game data
+ * such as class definitions. This ensures other managers
+ * can safely access class information during initialization.
+ */
+export class GameDataManager {
+    /**
+     * Register all base class data into IdManager.
+     * @param {IdManager} idManager - IdManager instance
+     */
+    static async registerBaseClasses(idManager) {
+        if (!idManager) {
+            console.error('[GameDataManager] IdManager not provided.');
+            return;
+        }
+        for (const key of Object.keys(CLASSES)) {
+            const classData = CLASSES[key];
+            try {
+                await idManager.addOrUpdateId(classData.id, classData);
+            } catch (e) {
+                console.error(`[GameDataManager] Failed to register class ${classData.id}:`, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed default class definitions via new `GameDataManager`
- initialize `GameDataManager` before battle setup so IdManager has warrior data

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68780696aa248327ba07bbf7e2b8434e