### PR TITLE
Fix hero skill selection

### DIFF
--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -59,9 +59,11 @@ export class HeroManager {
             }
 
             const randomSkills = new Set();
-            while (randomSkills.size < 3 && availableSkills.length > randomSkills.size) {
-                const randomIndex = this.diceEngine.getRandomInt(0, availableSkills.length - 1);
-                randomSkills.add(availableSkills[randomIndex]);
+            if (availableSkills.length > 0) {
+                while (randomSkills.size < 3 && availableSkills.length > randomSkills.size) {
+                    const randomIndex = this.diceEngine.getRandomInt(0, availableSkills.length - 1);
+                    randomSkills.add(availableSkills[randomIndex]);
+                }
             }
 
             const heroUnitData = {


### PR DESCRIPTION
## Summary
- avoid infinite loops when warrior skills are missing

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68780bc17f1483278a7455b68e2728a5