### PR TITLE
Use static warrior class data

### DIFF
--- a/js/engines/BattleEngine.js
+++ b/js/engines/BattleEngine.js
@@ -23,6 +23,7 @@ import { DiceRollManager } from '../managers/DiceRollManager.js';
 import { BattleCalculationManager } from '../managers/BattleCalculationManager.js';
 import { TurnCountManager } from '../managers/TurnCountManager.js';
 import { StatusEffectManager } from '../managers/StatusEffectManager.js';
+import { CLASSES } from '../../data/class.js'; // ◀◀◀ **이 부분을 추가해주세요!**
 
 /**
  * 전투 시뮬레이션과 턴 진행을 담당하는 엔진입니다.
@@ -108,7 +109,8 @@ export class BattleEngine {
         await this.assetLoaderManager.loadImage('sprite_warrior_default', 'assets/images/warrior.png');
         await this.assetLoaderManager.loadImage('sprite_zombie_default', 'assets/images/zombie.png');
 
-        const heroes = await this.heroManager.createWarriors(3);
+        // static 데이터를 직접 HeroManager에 전달하여 IdManager 의존성을 제거합니다.
+        const heroes = await this.heroManager.createWarriors(3, CLASSES.WARRIOR);
         this.battleFormationManager.placeAllies(heroes);
         await this.monsterSpawnManager.spawnMonstersForStage('stage1');
     }

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -22,25 +22,22 @@ export class HeroManager {
     /**
      * 지정된 수만큼의 전사 클래스 영웅 데이터를 생성하여 반환합니다.
      * @param {number} count - 생성할 영웅의 수
+     * @param {object} warriorClassData - IdManager를 거치지 않고 직접 받은 전사 클래스 데이터
      * @returns {Promise<object[]>} 생성된 영웅 데이터 배열
      */
-    async createWarriors(count) {
+    async createWarriors(count, warriorClassData) {
         console.log(`[HeroManager] Creating data for ${count} new warriors...`);
-        let warriorClassData = await this.idManager.get(CLASSES.WARRIOR.id);
-        const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
 
+        // idManager에서 데이터를 가져오는 대신, 매개변수로 받은 데이터를 직접 사용합니다.
         if (!warriorClassData) {
-            console.warn('[HeroManager] Warrior class not registered in IdManager, falling back to static data.');
-            warriorClassData = CLASSES.WARRIOR;
-            try {
-                await this.idManager.addOrUpdateId(CLASSES.WARRIOR.id, warriorClassData);
-            } catch (e) {
-                console.error('[HeroManager] Failed to register warrior class to IdManager:', e);
-            }
+            console.error('[HeroManager] warriorClassData was not provided to createWarriors. Aborting.');
+            return [];
         }
 
-        const statRanges = (warriorClassData && warriorClassData.statRanges) || {};
-        const availableSkills = (warriorClassData && warriorClassData.availableSkills) || [];
+        const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
+
+        const statRanges = warriorClassData.statRanges || {};
+        const availableSkills = warriorClassData.availableSkills || [];
 
         if (!warriorImage) {
             console.error('[HeroManager] Warrior image not found. Cannot create warriors.');
@@ -69,7 +66,7 @@ export class HeroManager {
             const heroUnitData = {
                 id: unitId,
                 name: randomName,
-                classId: CLASSES.WARRIOR.id,
+                classId: warriorClassData.id,
                 type: ATTACK_TYPES.MERCENARY,
                 spriteId: UNITS.WARRIOR.spriteId,
                 gridX: 0,
@@ -77,7 +74,7 @@ export class HeroManager {
                 baseStats: baseStats,
                 currentHp: baseStats.hp,
                 skillSlots: [...randomSkills],
-                tags: [...CLASSES.WARRIOR.tags]
+                tags: [...warriorClassData.tags]
             };
 
             await this.idManager.addOrUpdateId(unitId, heroUnitData);


### PR DESCRIPTION
## Summary
- pass CLASSES.WARRIOR directly when creating heroes
- update `HeroManager.createWarriors` to accept class data via parameter

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68780ec453dc83278d9101ce390d2c76