### PR TITLE
Fix undefined hero name list handling

### DIFF
--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -42,6 +42,11 @@ export class HeroManager {
         const availableSkills = warriorClassData.availableSkills || [];
         const tags = warriorClassData.tags || [];
 
+        // 이름 목록이 없으면 기본 이름을 사용하여 오류를 방지합니다.
+        const heroNames = Array.isArray(this.heroNameList) && this.heroNameList.length > 0
+            ? this.heroNameList
+            : ['Warrior'];
+
         if (!warriorImage) {
             console.error('[HeroManager] Warrior image not found. Cannot create warriors.');
             return [];
@@ -51,7 +56,7 @@ export class HeroManager {
 
         for (let i = 0; i < count; i++) {
             const unitId = `hero_warrior_${Date.now()}_${i}`;
-            const randomName = this.heroNameList[this.diceEngine.getRandomInt(0, this.heroNameList.length - 1)];
+            const randomName = heroNames[this.diceEngine.getRandomInt(0, heroNames.length - 1)];
 
             const baseStats = {};
             for (const stat in statRanges) {


### PR DESCRIPTION
## Summary
- prevent `HeroManager.createWarriors` from crashing when `heroNameList` is missing
- use fallback name list if none provided

## Testing
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878125efe508327974666760486e5be