### PR TITLE
Add hire warrior feature

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -31,9 +31,15 @@ export class GameEngine {
         this.unitStatManager = new UnitStatManager(this.eventManager, this.battleEngine.getBattleSimulationManager());
         this.sceneEngine = new SceneEngine();
         this.logicManager = new LogicManager(this.measureManager, this.sceneEngine);
+
+        // ✨ UIEngine이 HeroManager 기능을 활용할 수 있도록 연결
+        this.renderEngine.uiEngine.heroManager = this.battleEngine.heroManager;
         
         // RenderEngine에 필요한 후반 종속성 주입
         this.renderEngine.injectDependencies(this.battleEngine.getBattleSimulationManager(), this.logicManager, this.sceneEngine);
+
+        // 순환 참조 문제를 방지하기 위해 UIEngine 인스턴스를 ButtonEngine에도 전달
+        this.renderEngine.inputManager.buttonEngine.uiEngine = this.renderEngine.uiEngine;
 
         // 4. 게임 루프 설정
         this.gameLoop = new GameLoop(this._update.bind(this), this._draw.bind(this));

--- a/js/constants.js
+++ b/js/constants.js
@@ -35,8 +35,8 @@ export const UI_STATES = {
 };
 
 export const BUTTON_IDS = {
-    // 캔버스에 그려지는 버튼 ID (현재는 사용하지 않음)
-    // BATTLE_START: 'battleStartButton',
+    // 캔버스에 그려지는 버튼 ID
+    HIRE_WARRIOR: 'hireWarriorBtn',
 
     // HTML 버튼 ID
     TOGGLE_HERO_PANEL: 'toggleHeroPanelBtn',

--- a/js/engines/BattleEngine.js
+++ b/js/engines/BattleEngine.js
@@ -111,8 +111,8 @@ export class BattleEngine {
 
         // IdManager를 거치지 않고, 미리 import 해둔 정적 데이터를 직접 HeroManager에 전달합니다.
         // 이것이 레이스 컨디션을 막는 가장 확실한 방법입니다.
-        const heroes = await this.heroManager.createWarriors(3, CLASSES.WARRIOR);
-        this.battleFormationManager.placeAllies(heroes);
+        // const heroes = await this.heroManager.createWarriors(3, CLASSES.WARRIOR);
+        // this.battleFormationManager.placeAllies(heroes);
         await this.monsterSpawnManager.spawnMonstersForStage('stage1');
     }
 

--- a/js/engines/RenderEngine.js
+++ b/js/engines/RenderEngine.js
@@ -23,7 +23,7 @@ export class RenderEngine {
         this.animationManager = new AnimationManager(measureManager, null, this.particleEngine);
 
         this.buttonEngine = new ButtonEngine();
-        this.uiEngine = new UIEngine(this.renderer, measureManager, eventManager, null, this.buttonEngine);
+        this.uiEngine = new UIEngine(this.renderer, measureManager, eventManager, null, this.buttonEngine, null);
         this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine, this.buttonEngine, eventManager);
     }
 

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -20,6 +20,47 @@ export class HeroManager {
     }
 
     /**
+     * ✨ [신규] 새로운 전사 한 명을 고용하여 빈 슬롯에 배치합니다.
+     */
+    async hireNewWarrior() {
+        console.log("[HeroManager] Attempting to hire a new warrior...");
+        const warriorClassData = await this.idManager.get(CLASSES.WARRIOR.id);
+        if (!warriorClassData) {
+            console.error("[HeroManager] Warrior class data not loaded. Cannot hire warrior.");
+            return;
+        }
+
+        const newWarriors = await this.createWarriors(1, warriorClassData);
+        if (newWarriors.length === 0) {
+            console.error("[HeroManager] Failed to create new warrior data.");
+            return;
+        }
+
+        const newWarrior = newWarriors[0];
+        const formationPositions = [
+            { x: 2, y: 3 }, { x: 2, y: 5 }, { x: 4, y: 4 },
+            { x: 4, y: 2 }, { x: 4, y: 6 }, { x: 0, y: 4 }
+            // 필요에 따라 더 많은 포지션 추가
+        ];
+
+        let placed = false;
+        for (const pos of formationPositions) {
+            if (!this.battleSimulationManager.isTileOccupied(pos.x, pos.y)) {
+                const warriorImage = this.assetLoaderManager.getImage(newWarrior.spriteId);
+                this.battleSimulationManager.addUnit(newWarrior, warriorImage, pos.x, pos.y);
+                console.log(`[HeroManager] New warrior ${newWarrior.name} hired and placed at (${pos.x}, ${pos.y}).`);
+                placed = true;
+                break;
+            }
+        }
+
+        if (!placed) {
+            console.warn("[HeroManager] No empty slot found to place the new warrior.");
+            // 여기에 사용자에게 알림을 주는 로직을 추가할 수 있습니다.
+        }
+    }
+
+    /**
      * 지정된 수만큼의 전사 클래스 영웅 데이터를 생성하여 반환합니다.
      * @param {number} count - 생성할 영웅의 수
      * @param {object} warriorClassData - IdManager를 거치지 않고 직접 받은 전사 클래스 데이터

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -5,13 +5,14 @@
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS } from '../constants.js';
 
 export class UIEngine {
-    constructor(renderer, measureManager, eventManager, mercenaryPanelManager, buttonEngine) {
+    constructor(renderer, measureManager, eventManager, mercenaryPanelManager, buttonEngine, heroManager) {
         console.log("\ud83c\udf9b UIEngine initialized. Ready to draw interfaces. \ud83c\udf9b");
         this.renderer = renderer;
         this.measureManager = measureManager;
         this.eventManager = eventManager;
         this.mercenaryPanelManager = mercenaryPanelManager;
         this.buttonEngine = buttonEngine;
+        this.heroManager = heroManager;
 
         this.canvas = renderer.canvas;
         this.ctx = renderer.ctx;
@@ -20,6 +21,23 @@ export class UIEngine {
         this.heroPanelVisible = false;
 
         this.recalculateUIDimensions();
+
+        // ✨ '전사 고용' 버튼 등록
+        const hireButtonWidth = 150;
+        const hireButtonHeight = 50;
+        this.buttonEngine.registerButton(
+            BUTTON_IDS.HIRE_WARRIOR,
+            this.measureManager.get('gameResolution.width') - hireButtonWidth - 20,
+            20,
+            hireButtonWidth,
+            hireButtonHeight,
+            () => {
+                console.log("'전사 고용' 버튼 클릭됨!");
+                if (this.heroManager) {
+                    this.heroManager.hireNewWarrior();
+                }
+            }
+        );
 
         // ✨ '전투 시작' 버튼은 이제 HTML에서 관리하므로 ButtonEngine에 등록하지 않습니다.
 
@@ -68,7 +86,18 @@ export class UIEngine {
     draw(ctx) {
         // ✨ '전투 시작' 버튼은 이제 HTML 요소이므로 캔버스에 그리지 않습니다.
         if (this._currentUIState === UI_STATES.MAP_SCREEN) {
-            // 다른 UI 요소가 있다면 여기에 그립니다.
+            const buttonRect = this.buttonEngine.getButtonRect(BUTTON_IDS.HIRE_WARRIOR);
+            if (buttonRect) {
+                ctx.fillStyle = 'darkblue';
+                ctx.fillRect(buttonRect.x, buttonRect.y, buttonRect.width, buttonRect.height);
+                ctx.strokeStyle = 'white';
+                ctx.strokeRect(buttonRect.x, buttonRect.y, buttonRect.width, buttonRect.height);
+                ctx.fillStyle = 'white';
+                ctx.font = `${this.uiFontSize}px Arial`;
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillText('전사 고용', buttonRect.x + buttonRect.width / 2, buttonRect.y + buttonRect.height / 2);
+            }
         } else if (this._currentUIState === UI_STATES.COMBAT_SCREEN) {
             // 전투 화면에서는 현재 별도의 상단 텍스트를 표시하지 않습니다.
         }


### PR DESCRIPTION
## Summary
- remove auto hero generation in `BattleEngine` setup
- add hero hiring helper to `HeroManager`
- register a new "hire warrior" canvas button in `UIEngine`
- pass `heroManager` from `GameEngine` to `UIEngine`
- define button id constant and update render engine

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68781429bc1c832793fb2799f7af5ce6