### PR TITLE
Fix initialization race when loading debug build

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -210,7 +210,7 @@
             try {
                 gameEngine = new GameEngine('gameCanvas'); // GameEngine 인스턴스 생성
                 gameEngine.eventManager.setGameRunningState(true); // ✨ 디버그 모드에서도 게임 시작 시 상태 설정
-                gameEngine.start(); // 게임 엔진 시작
+                // GameEngine.initializeGame() 내에서 초기화 완료 후 자동으로 게임이 시작됩니다.
             } catch (error) {
                 console.error("Fatal Error in Debug Mode: Game Engine failed to start.", error);
                 // debug.html에서는 오류가 나도 계속 실행되도록 alert는 생략

--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
         const gameEngine = new GameEngine('gameCanvas');
         gameEngine.eventManager.setGameRunningState(true); // ✨ 게임 시작 시 상태 설정
-        gameEngine.start();
+        // GameEngine.initializeGame() 내부에서 모든 비동기 초기화가 끝난 후
+        // 자동으로 gameEngine.start()가 호출됩니다.
 
         // 영웅 패널 버튼 클릭 이벤트 리스너 추가
         const toggleHeroPanelBtn = document.getElementById(BUTTON_IDS.TOGGLE_HERO_PANEL); // ✨ 상수 사용


### PR DESCRIPTION
## Summary
- only start the game loop after async managers finish loading
- adjust debug.html and main.js to let `GameEngine` handle startup timing

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687818464fe8832793556f940cde7580