### PR TITLE
Prevent residual hero data by clearing IdManager

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -56,12 +56,14 @@ export class GameEngine {
         try {
             console.log("--- Game Initialization Start ---");
 
-            const idManager = this.assetEngine.getIdManager();
+        const idManager = this.assetEngine.getIdManager();
 
-            // 단계 1: 데이터베이스 시스템 초기화
-            console.log("Initialization Step 1: Initializing IdManager (DB)...");
-            await idManager.initialize();
-            console.log("✅ IdManager Initialized.");
+        // 단계 1: 데이터베이스 시스템 초기화
+        console.log("Initialization Step 1: Initializing IdManager (DB)...");
+        await idManager.initialize();
+        // 디버그 환경에서 남아 있을 수 있는 이전 세션 데이터를 정리합니다.
+        await idManager.clearAllData();
+        console.log("✅ IdManager Initialized.");
 
             // 단계 2: 기본 게임 데이터 등록 (클래스, 아이템 등)
             console.log("Initialization Step 2: Registering base game data...");

--- a/js/managers/IdManager.js
+++ b/js/managers/IdManager.js
@@ -176,6 +176,35 @@ export class IdManager {
     }
 
     /**
+     * Remove all ID entries from IndexedDB and memory.
+     * Useful for ensuring a clean state during debugging.
+     * @returns {Promise<void>}
+     */
+    async clearAllData() {
+        if (!this.db) {
+            console.warn('[IdManager] IndexedDB not initialized, cannot clear data.');
+            return;
+        }
+
+        return new Promise((resolve, reject) => {
+            const transaction = this.db.transaction([STORE_NAME], 'readwrite');
+            const store = transaction.objectStore(STORE_NAME);
+            const request = store.clear();
+
+            request.onsuccess = () => {
+                this.idMap.clear();
+                console.log('[IdManager] All ID data cleared from IndexedDB and memory.');
+                resolve();
+            };
+
+            request.onerror = (event) => {
+                console.error('[IdManager] Failed to clear all data:', event.target.error);
+                reject(event.target.error);
+            };
+        });
+    }
+
+    /**
      * Example: cache a resource URL using Cache API.
      * @param {string} url
      * @returns {Promise<void>}


### PR DESCRIPTION
## Summary
- add `clearAllData()` helper to `IdManager`
- clear out any cached ID data during game initialization

## Testing
- `npm test`
- `python3 -m http.server 8001 &`
- `curl http://localhost:8001/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68781ab9db04832794efba1e95545703